### PR TITLE
fix(scan): LoadSkillsHandler catalog resolution + summary on zero fin…

### DIFF
--- a/src/AgentSmith.Application/Services/Handlers/LoadSkillsHandler.cs
+++ b/src/AgentSmith.Application/Services/Handlers/LoadSkillsHandler.cs
@@ -8,11 +8,15 @@ using Microsoft.Extensions.Logging;
 namespace AgentSmith.Application.Services.Handlers;
 
 /// <summary>
-/// Loads skill role definitions from the configured skills path.
-/// Resolves paths relative to the config file directory.
+/// Loads skill role definitions from the configured skills path. Tries the
+/// external skill catalog (post-p0103) first since that's where skills now
+/// live; falls back to config-dir / repo-root / CWD for dev-from-source
+/// setups. The pre-p0103 catalog-blind resolution missed the cache entirely
+/// and silently soft-failed with zero skills loaded.
 /// </summary>
 public sealed class LoadSkillsHandler(
     ISkillLoader skillLoader,
+    ISkillsCatalogPath catalogPath,
     ILogger<LoadSkillsHandler> logger)
     : ICommandHandler<LoadSkillsContext>
 {
@@ -40,14 +44,29 @@ public sealed class LoadSkillsHandler(
     {
         var skillsPath = context.SkillsPath;
 
-        // 1. If the path exists as-is (absolute or already correct relative), use it
+        // 1. Absolute path or correct CWD-relative
         if (Directory.Exists(skillsPath))
         {
             logger.LogDebug("Skills path exists as-is: {Dir}", skillsPath);
             return skillsPath;
         }
 
-        // 2. Resolve relative to config file directory
+        // 2. External skill catalog (post-p0103) — typical production path
+        try
+        {
+            var catalogRelative = Path.Combine(catalogPath.Root, skillsPath);
+            if (Directory.Exists(catalogRelative))
+            {
+                logger.LogDebug("Skills path resolved via skill catalog: {Dir}", catalogRelative);
+                return catalogRelative;
+            }
+        }
+        catch (InvalidOperationException)
+        {
+            // Catalog not yet bootstrapped (CLI tooling running before bootstrap).
+        }
+
+        // 3. Resolve relative to config file directory
         if (context.Pipeline.TryGet<string>(ContextKeys.ConfigDir, out var configDir)
             && !string.IsNullOrEmpty(configDir))
         {
@@ -59,7 +78,7 @@ public sealed class LoadSkillsHandler(
             }
         }
 
-        // 3. Try relative to repo root
+        // 4. Try relative to repo root
         if (context.Pipeline.TryGet<Domain.Entities.Repository>(ContextKeys.Repository, out var repo)
             && repo is not null)
         {
@@ -71,7 +90,7 @@ public sealed class LoadSkillsHandler(
             }
         }
 
-        // 4. Fallback: CWD/config/
+        // 5. Fallback: CWD/config/
         var cwdRelative = Path.Combine("config", skillsPath);
         logger.LogDebug("Skills path fallback to CWD: {Dir}", cwdRelative);
         return cwdRelative;

--- a/src/AgentSmith.Infrastructure/Services/Output/SummaryOutputStrategy.cs
+++ b/src/AgentSmith.Infrastructure/Services/Output/SummaryOutputStrategy.cs
@@ -18,14 +18,9 @@ public sealed partial class SummaryOutputStrategy(
     public Task DeliverAsync(OutputContext context, CancellationToken cancellationToken = default)
     {
         var consolidated = GetConsolidatedOutput(context);
-
-        if (string.IsNullOrWhiteSpace(consolidated))
-        {
-            Console.WriteLine("No findings to summarize.");
-            return Task.CompletedTask;
-        }
-
-        var findings = ParseFindings(consolidated);
+        var findings = string.IsNullOrWhiteSpace(consolidated)
+            ? new List<SummaryFinding>()
+            : ParseFindings(consolidated);
 
         var sb = new StringBuilder();
         sb.AppendLine();
@@ -34,16 +29,24 @@ public sealed partial class SummaryOutputStrategy(
         sb.AppendLine("═══════════════════════════════════════");
         sb.AppendLine();
 
-        var grouped = findings
-            .GroupBy(f => f.Severity)
-            .OrderBy(g => SeverityOrder(g.Key));
-
-        foreach (var group in grouped)
+        if (findings.Count == 0)
         {
-            sb.AppendLine($"{group.Key.ToUpperInvariant()} ({group.Count()})");
-            foreach (var f in group)
-                sb.AppendLine($"  {f.Title}{(f.Confidence > 0 ? $" — confidence {f.Confidence}" : "")}");
+            sb.AppendLine("No findings.");
             sb.AppendLine();
+        }
+        else
+        {
+            var grouped = findings
+                .GroupBy(f => f.Severity)
+                .OrderBy(g => SeverityOrder(g.Key));
+
+            foreach (var group in grouped)
+            {
+                sb.AppendLine($"{group.Key.ToUpperInvariant()} ({group.Count()})");
+                foreach (var f in group)
+                    sb.AppendLine($"  {f.Title}{(f.Confidence > 0 ? $" — confidence {f.Confidence}" : "")}");
+                sb.AppendLine();
+            }
         }
 
         sb.AppendLine($"Total: {findings.Count} findings");

--- a/tests/AgentSmith.Tests/Services/LoadSkillsHandlerTests.cs
+++ b/tests/AgentSmith.Tests/Services/LoadSkillsHandlerTests.cs
@@ -1,0 +1,99 @@
+using AgentSmith.Application.Models;
+using AgentSmith.Application.Services.Handlers;
+using AgentSmith.Contracts.Commands;
+using AgentSmith.Contracts.Models.Configuration;
+using AgentSmith.Contracts.Services;
+using AgentSmith.Domain.Models;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace AgentSmith.Tests.Services;
+
+public sealed class LoadSkillsHandlerTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public LoadSkillsHandlerTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "as-skills-" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir)) Directory.Delete(_tempDir, recursive: true);
+    }
+
+    [Fact]
+    public async Task ResolvesSkillsPath_ViaSkillCatalog_WhenPostP0103Layout()
+    {
+        // Catalog under tempDir/.cache/skills, with skills/api-security/ inside it
+        var catalogRoot = Path.Combine(_tempDir, "cache");
+        var catalogSkills = Path.Combine(catalogRoot, "skills", "api-security");
+        Directory.CreateDirectory(catalogSkills);
+
+        var catalogPath = new Mock<ISkillsCatalogPath>();
+        catalogPath.Setup(c => c.Root).Returns(catalogRoot);
+
+        var skillLoader = new Mock<ISkillLoader>();
+        skillLoader
+            .Setup(l => l.LoadRoleDefinitions(catalogSkills))
+            .Returns(new List<RoleSkillDefinition> { new() { Name = "test", DisplayName = "Test", Emoji = "x", Rules = "" } });
+
+        var handler = new LoadSkillsHandler(
+            skillLoader.Object,
+            catalogPath.Object,
+            NullLogger<LoadSkillsHandler>.Instance);
+
+        var pipeline = new PipelineContext();
+        var ctx = new LoadSkillsContext("skills/api-security", pipeline);
+
+        var result = await handler.ExecuteAsync(ctx, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Message.Should().Contain("Loaded 1 skills");
+        skillLoader.Verify(l => l.LoadRoleDefinitions(catalogSkills), Times.Once);
+    }
+
+    [Fact]
+    public async Task ResolvesSkillsPath_AsIs_WhenAbsolutePathExists()
+    {
+        var absSkillsDir = Path.Combine(_tempDir, "abs-skills");
+        Directory.CreateDirectory(absSkillsDir);
+
+        var catalogPath = new Mock<ISkillsCatalogPath>();
+        catalogPath.Setup(c => c.Root).Throws(new InvalidOperationException("not bootstrapped"));
+
+        var skillLoader = new Mock<ISkillLoader>();
+        skillLoader.Setup(l => l.LoadRoleDefinitions(absSkillsDir)).Returns(new List<RoleSkillDefinition>());
+
+        var handler = new LoadSkillsHandler(skillLoader.Object, catalogPath.Object, NullLogger<LoadSkillsHandler>.Instance);
+        var pipeline = new PipelineContext();
+        var ctx = new LoadSkillsContext(absSkillsDir, pipeline);
+
+        var result = await handler.ExecuteAsync(ctx, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        skillLoader.Verify(l => l.LoadRoleDefinitions(absSkillsDir), Times.Once);
+    }
+
+    [Fact]
+    public async Task SoftFails_WhenNoPathResolves()
+    {
+        var catalogPath = new Mock<ISkillsCatalogPath>();
+        catalogPath.Setup(c => c.Root).Returns(Path.Combine(_tempDir, "empty-cache"));
+
+        var skillLoader = new Mock<ISkillLoader>();
+
+        var handler = new LoadSkillsHandler(skillLoader.Object, catalogPath.Object, NullLogger<LoadSkillsHandler>.Instance);
+        var pipeline = new PipelineContext();
+        var ctx = new LoadSkillsContext("skills/nonexistent", pipeline);
+
+        var result = await handler.ExecuteAsync(ctx, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Message.Should().Contain("Skills directory not found");
+        skillLoader.Verify(l => l.LoadRoleDefinitions(It.IsAny<string>()), Times.Never);
+    }
+}


### PR DESCRIPTION
…dings

LoadSkillsHandler now tries the external skill catalog (post-p0103) before falling back to config-dir / repo-root / CWD. Previously the handler was catalog-blind: it looked at four local-fs locations, none of which match the new ~/.cache/agentsmith/skills layout. CI runs were silently soft-failing with "Skills directory not found" and zero skills loaded — pipeline continued, but no LLM analysis produced findings.

SummaryOutputStrategy now always renders the header + total + cost line. Previously an empty consolidated output bailed early with just "No findings to summarize." — no banner, no cost number, hiding the fact that the run actually completed (and what it cost). Empty case now reads "No findings." inside the same banner, with cost line below.

3 new LoadSkillsHandler tests; 1187/1187 green.