### PR TITLE
fix: CommandExecutor scope lifetime + bump skills catalog to v1.1.0

### DIFF
--- a/config/agentsmith.example.yml
+++ b/config/agentsmith.example.yml
@@ -283,7 +283,7 @@ tool_runner:
 # based on this section. See docs/skills/source-modes.md.
 skills:
   source: default                         # default | path | url
-  version: v1.0.0                         # required when source: default
+  version: v1.1.0                         # required when source: default
   # cache_dir defaults to $XDG_CACHE_HOME/agentsmith/skills, then $HOME/.cache/agentsmith/skills,
   # then {tmp}/agentsmith/skills — set explicitly only for system-managed paths (e.g. K8s mount).
   # cache_dir: /var/lib/agentsmith/skills

--- a/docs/skills/airgap.md
+++ b/docs/skills/airgap.md
@@ -12,7 +12,7 @@ it via env var:
 # agentsmith.yml — production config
 skills:
   source: default
-  version: v1.0.0
+  version: v1.1.0
   sha256: 3f1a8b…    # pin against tampering
   cache_dir: /var/lib/agentsmith/skills
 ```

--- a/docs/skills/source-modes.md
+++ b/docs/skills/source-modes.md
@@ -14,7 +14,7 @@ sources, configured under `skills:` in `agentsmith.yml`:
 ```yaml
 skills:
   source: default
-  version: v1.0.0
+  version: v1.1.0
   # cache_dir defaults to $XDG_CACHE_HOME/agentsmith/skills (or $HOME/.cache/...,
   # then {tmp}/agentsmith/skills) — set explicitly only when the OS path is
   # operator-managed (e.g. /var/lib/agentsmith/skills with a K8s volume mount).

--- a/src/AgentSmith.Application/Extensions/ServiceCollectionExtensions.cs
+++ b/src/AgentSmith.Application/Extensions/ServiceCollectionExtensions.cs
@@ -20,7 +20,15 @@ public static class ServiceCollectionExtensions
 {
     public static IServiceCollection AddAgentSmithCommands(this IServiceCollection services)
     {
-        services.AddSingleton<ICommandExecutor, CommandExecutor>();
+        // Transient (not Singleton): a Singleton CommandExecutor would receive the
+        // ROOT IServiceProvider regardless of where it's resolved from, so its
+        // GetService<ICommandHandler<T>>() calls would resolve handlers from the
+        // root scope. Handlers like GeneratePlanHandler depend on Scoped services
+        // (IAgentProviderFactory), so this trips ValidateScopes at runtime. Transient
+        // means CommandExecutor injects the same provider its caller was resolved
+        // from — Server flows resolve through a request scope, CLI flows resolve
+        // from root and have no Scoped deps that matter (no DialogueTrail).
+        services.AddTransient<ICommandExecutor, CommandExecutor>();
         services.AddSingleton<IPromptOverrideSource, EnvDirectoryPromptOverrideSource>();
         services.AddSingleton<IPromptCatalog, EmbeddedPromptCatalog>();
         RegisterHandlers(services);


### PR DESCRIPTION
## Summary

Two follow-ups that landed on `p0111d-provider-overrides` after PR #55 was merged.

- **CommandExecutor lifetime Singleton → Transient.** Pre-existing latent bug since p0021 — Singleton CommandExecutor receives the ROOT IServiceProvider regardless of where it's resolved from, so handler lookups (e.g. `ICommandHandler<GeneratePlanContext>`) hit the root scope. `GeneratePlanHandler` depends on Scoped `IAgentProviderFactory`, which trips ValidateScopes at runtime under Server Development env: *"Cannot resolve … from root provider because it requires scoped service IAgentProviderFactory"*. Transient lets CommandExecutor inherit its caller's provider — Server flows resolve through a per-request scope, CLI flows have no Scoped deps that matter.
- **Skills catalog version v1.0.0 → v1.1.0.** agent-smith-skills v1.1.0 ships the p0111-migrated SKILL.md frontmatter (`roles_supported`, `activation`, `role_assignment`, `output_contract`). The new strict-mode loader (p0111a) and phase-based triage (p0111c) require this. Updates `config/agentsmith.example.yml` + two docs; `config/agentsmith.yml` has no `skills:` block today, so production config is unaffected.

## Test plan

- [x] `dotnet build AgentSmith.sln` clean
- [x] `dotnet test` — 1305/1305 pass
- [ ] Server boot under Development env no longer throws on first pipeline run with `GeneratePlanCommand`

🤖 Generated with [Claude Code](https://claude.com/claude-code)