### PR TITLE
feat(p0113a): spawn pipeline jobs from queue via ephemeral CLI containers

### DIFF
--- a/docs/concepts/spawned-jobs.md
+++ b/docs/concepts/spawned-jobs.md
@@ -1,0 +1,95 @@
+# Spawned Jobs
+
+Queue-driven pipeline runs (webhook + poll) execute in **ephemeral CLI containers** spawned per run, not in-process inside the Server pod. The Server is orchestration: it polls, claims, queues, dispatches, and tracks lifecycle. The actual pipeline — git operations, agentic LLM rounds, test execution — runs in a per-run container that has the project's toolchain (dotnet SDK, git, etc.).
+
+This page documents the cross-process flow, the recovery story, and the contracts between the two halves.
+
+## Why ephemeral containers
+
+The Server pod is fundamentally a dispatcher. Running pipelines in-process means its container needs every language's toolchain (dotnet SDK, npm, python, …) for steps like `TestCommand`. That doesn't scale across a multi-language platform — and the architectural intent has always been ephemeral job containers per run. The chat-intent path (Slack/Teams) already uses `IJobSpawner` for this; **p0113** closes the gap on the queue path.
+
+## The two halves
+
+```
+┌──────────────────────────── Server pod ──────────────────────────┐
+│                                                                  │
+│   webhook / poll                                                 │
+│        │                                                         │
+│        ▼                                                         │
+│   TicketClaimService ──── Pending → Enqueued ───────► Redis      │
+│        │                                              queue      │
+│        │                                              │          │
+│        ▼                                              ▼          │
+│   PipelineQueueConsumer ◄──────────────── dequeues ──┘          │
+│        │                                                         │
+│        ▼                                                         │
+│   IPipelineJobDispatcher                                         │
+│   (JobSpawnerPipelineDispatcher)                                 │
+│        │                                                         │
+│        ├── 1. SaveAsync(jobId, request) ──► Redis (1h TTL)       │
+│        │                                                         │
+│        └── 2. SpawnQueueJobAsync(jobId, redisUrl, configPath)    │
+│                                       │                          │
+└───────────────────────────────────────┼──────────────────────────┘
+                                        │ (Docker run / K8s Job)
+                                        ▼
+┌──────────────────────────── CLI container ──────────────────────┐
+│                                                                  │
+│   agent-smith run-claimed-job                                    │
+│       --job-id <id>                                              │
+│       --redis-url <url>                                          │
+│       --config /app/config/agentsmith.yml                        │
+│                                                                  │
+│   1. Connect to Redis                                            │
+│   2. IPipelineRequestStore.LoadAsync(jobId) ──► PipelineRequest  │
+│   3. ExecutePipelineUseCase.ExecuteAsync(request, configPath)    │
+│   4. Lifecycle: Enqueued → InProgress → Done | Failed            │
+│                                                                  │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+## Why Redis-handoff (not CLI args)
+
+`PipelineRequest` carries structured fields: `ProjectName`, `PipelineName`, `TicketId`, `IsInit`, `Headless`, plus a `Context` dictionary that some flows populate (e.g. `ScanBranch`). Stuffing this through CLI args is fragile — escaping issues, shell quoting on different platforms, length limits, and the `Context` dictionary doesn't have a clean argv encoding.
+
+The Server stores the request as JSON under `agentsmith:pipeline-request:{jobId}` with a 1h TTL. The container's CLI args stay short — just the jobId, the Redis URL, and the config path. The container loads the structured request and calls the **structured** `ExecutePipelineUseCase.ExecuteAsync(PipelineRequest, ...)` overload directly — bypassing the intent parser that the Slack-flow uses.
+
+The 1h TTL is a soft contract: spawn must complete and the container must load the request within the hour. Long-running pipelines are unaffected — they've already moved past the load-and-discard phase by then.
+
+## Lifecycle across the boundary
+
+| Transition | Side | Detail |
+|------------|------|--------|
+| Pending → Enqueued | Server (`TicketClaimService`) | SETNX claim-lock; atomic per ticket |
+| Enqueued → InProgress | **Container** (via `PipelineExecutor` inside `ExecutePipelineUseCase`) | First lifecycle write inside the spawned container |
+| InProgress → Done / Failed | **Container** (via `LifecycleScope.Dispose`) | At pipeline end |
+
+Between the Server's `Enqueued` write and the container's `InProgress` write sits the **spawn window** — if `SpawnQueueJobAsync` succeeds but the container fails to start (image pull error, K8s quota, Docker daemon down), or starts but never reaches the lifecycle code (config load throws, DI build fails), the ticket would stay `Enqueued` forever without intervention.
+
+`EnqueuedReconciler` (existing, p0095c) is the load-bearing recovery: it sweeps `Enqueued` tickets without active heartbeat back to `Pending` after the configured stale-window (default 10 min). That window is short enough for actionable recovery, long enough that slow-starting containers don't get reset mid-spawn.
+
+## What this MVP ships (p0113a)
+
+- **`IPipelineJobDispatcher`** (Application/Contracts) — the abstraction PipelineQueueConsumer depends on
+- **`JobSpawnerPipelineDispatcher`** (Server) — generates jobId, persists request via `IPipelineRequestStore`, calls `IJobSpawner.SpawnQueueJobAsync`
+- **`IPipelineRequestStore` + `RedisPipelineRequestStore`** — the Redis-backed handoff
+- **`IJobSpawner.SpawnQueueJobAsync`** — added to both `DockerJobSpawner` and `KubernetesJobSpawner`
+- **`run-claimed-job`** — hidden CLI subcommand the spawned container runs
+- **`PipelineQueueConsumer`** — switched from in-process `ExecutePipelineUseCase` invocation to `IPipelineJobDispatcher.DispatchAsync`
+
+## What is deferred to p0113b
+
+- **`SecretsForwardingPolicy`** whitelist — explicit env-var allow-list crossing the spawn boundary. Today: hard-coded list inside each spawner.
+- **`JobRequest.ImageOverride` resolution chain** (`request → pipeline → default`) for projects needing per-language toolchain images.
+- **Heartbeat-gap mitigation**: write the first heartbeat **before** the DI build inside `run-claimed-job` so a DI-build crash doesn't ghost the ticket. Today: relies on `EnqueuedReconciler` to revert.
+- **`AGENTSMITH_TEST_FAIL_AFTER` env-var fail-injection** for reproducible CI of the persist+recovery paths.
+- **Server Dockerfile**: drop SDK if any remains (already aspnet:8.0); CLI Dockerfile remove `p4x` TODO comment.
+
+## Backpressure
+
+`PipelineQueueConsumer` keeps its `SemaphoreSlim` bounded by `QueueConfig.MaxParallel` (default 4). Post-refactor, this gates **concurrent dispatch calls** (each fast: one SETEX + one spawn API call), not in-flight pipeline count. The real binding constraint downstream is LLM-deployment quota, which scales with operator-side configuration (Azure OpenAI deployment, provider rate limits) — agent-smith does not enforce that bound centrally.
+
+## Related
+
+- [Ticket Lifecycle](ticket-lifecycle.md) — the full state machine and what survives what
+- [Pipeline System](pipeline-system.md) — command/handler model

--- a/docs/concepts/ticket-lifecycle.md
+++ b/docs/concepts/ticket-lifecycle.md
@@ -47,12 +47,12 @@ The `agent-smith:` prefix marks lifecycle labels owned by the framework. Other l
 
 | Transition | Owner | When |
 |------------|-------|------|
-| Pending → Enqueued | `TicketClaimService` | Webhook or poll fires; pre-checks pass; SETNX claim-lock acquired |
-| Enqueued → InProgress | `PipelineExecutor` | Consumer dequeues a `PipelineRequest`, before the first command runs |
-| InProgress → Done | `PipelineExecutor` (via `LifecycleScope.Dispose`) | All pipeline commands succeeded |
-| InProgress → Failed | `PipelineExecutor` (via `LifecycleScope.MarkFailed` + Dispose) | Any command failed; error comment posted to ticket |
-| InProgress → Pending | `StaleJobDetector` | No Redis heartbeat for the ticket and the consumer pod is gone — pipeline is presumed crashed |
-| Enqueued → Enqueued (re-push) | `EnqueuedReconciler` | Ticket is Enqueued but the queue has no entry and no in-flight pipeline owns it |
+| Pending → Enqueued | `TicketClaimService` (Server) | Webhook or poll fires; pre-checks pass; SETNX claim-lock acquired |
+| Enqueued → InProgress | `PipelineExecutor` (**inside the spawned CLI container**, p0113) | Container loads `PipelineRequest` from `IPipelineRequestStore` and starts the pipeline |
+| InProgress → Done | `PipelineExecutor` (container, via `LifecycleScope.Dispose`) | All pipeline commands succeeded |
+| InProgress → Failed | `PipelineExecutor` (container, via `LifecycleScope.MarkFailed` + Dispose) | Any command failed; error comment posted to ticket |
+| InProgress → Pending | `StaleJobDetector` | No Redis heartbeat for the ticket and the container is gone — pipeline is presumed crashed |
+| Enqueued → Pending | `EnqueuedReconciler` | Ticket is Enqueued but no container ever wrote a heartbeat — spawn failed or container crashed before lifecycle init (see [Spawned Jobs](spawned-jobs.md)) |
 
 ## Concurrency primitives
 
@@ -109,6 +109,7 @@ To inspect lifecycle state for a project at a glance, list issues by label in th
 
 ## Related
 
+- [Spawned Jobs](spawned-jobs.md) — how the cross-process boundary is wired
 - [Polling Setup](../setup/polling.md) — opt-in per project
 - [Webhook Configuration](../configuration/webhooks.md) — claim flow and HTTP responses
 - [Polling vs Webhooks](../setup/polling-vs-webhooks.md) — when to choose which

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -93,6 +93,7 @@ nav:
     - concepts/index.md
     - Pipeline System: concepts/pipeline-system.md
     - Ticket Lifecycle: concepts/ticket-lifecycle.md
+    - Spawned Jobs: concepts/spawned-jobs.md
     - Phases & Runs: concepts/phases-and-runs.md
     - Self-Documentation: concepts/self-documentation.md
     - Multi-Agent Orchestration: concepts/multi-agent-orchestration.md

--- a/src/AgentSmith.Application/Services/PipelineQueueConsumer.cs
+++ b/src/AgentSmith.Application/Services/PipelineQueueConsumer.cs
@@ -6,10 +6,14 @@ using Microsoft.Extensions.Logging;
 namespace AgentSmith.Application.Services;
 
 /// <summary>
-/// Pulls PipelineRequests off IRedisJobQueue and runs them with bounded concurrency
-/// (SemaphoreSlim = backpressure knob). On shutdown, stops pulling and waits up to
-/// shutdownGraceSeconds for in-flight pipelines to finish (so they can transition to Failed
-/// and release their heartbeat once p95c lands).
+/// p0113: Pulls PipelineRequests off IRedisJobQueue and dispatches them to
+/// ephemeral CLI containers via IPipelineJobDispatcher. The Server pod is
+/// orchestration-only — language toolchains live in the per-run job container.
+///
+/// SemaphoreSlim bounds concurrent dispatch calls (fast — SETEX + spawn API).
+/// In-flight pipeline count downstream is governed by the cluster (K8s/Docker
+/// capacity), not this knob. On shutdown, waits up to shutdownGraceSeconds
+/// for in-flight dispatch calls to settle.
 /// </summary>
 public sealed class PipelineQueueConsumer(
     IServiceProvider services,
@@ -19,12 +23,17 @@ public sealed class PipelineQueueConsumer(
     int shutdownGraceSeconds,
     ILogger<PipelineQueueConsumer> logger)
 {
+    // configPath is unused post-p0113 (dispatch carries the path through the
+    // Server's ServerContext). Retained on the constructor so the hosted-service
+    // wiring stays stable; can be dropped in a follow-up.
+    private readonly string _configPath = configPath;
+
     public async Task RunAsync(CancellationToken cancellationToken)
     {
         using var semaphore = new SemaphoreSlim(maxParallelJobs);
         var inFlight = new List<Task>();
         logger.LogInformation(
-            "PipelineQueueConsumer started (max parallel: {Max}, grace: {Grace}s)",
+            "PipelineQueueConsumer started (max parallel dispatches: {Max}, grace: {Grace}s)",
             maxParallelJobs, shutdownGraceSeconds);
 
         try
@@ -33,7 +42,7 @@ public sealed class PipelineQueueConsumer(
             {
                 await semaphore.WaitAsync(cancellationToken);
                 logger.LogInformation(
-                    "Dequeued: {Project}/#{Ticket} pipeline={Pipeline} (in-flight: {InFlight}/{Max})",
+                    "Dequeued: {Project}/#{Ticket} pipeline={Pipeline} (in-flight dispatch: {InFlight}/{Max})",
                     request.ProjectName, request.TicketId?.Value ?? "—",
                     request.PipelineName, inFlight.Count(t => !t.IsCompleted) + 1, maxParallelJobs);
                 var task = Task.Run(
@@ -55,19 +64,17 @@ public sealed class PipelineQueueConsumer(
         try
         {
             using var scope = services.CreateScope();
-            var useCase = scope.ServiceProvider.GetRequiredService<ExecutePipelineUseCase>();
-            var result = await useCase.ExecuteAsync(request, configPath, ct);
-            logger.Log(
-                result.IsSuccess ? LogLevel.Information : LogLevel.Warning,
-                "Pipeline {Outcome}: {Project}/{Ticket} — {Msg}",
-                result.IsSuccess ? "succeeded" : "failed",
-                request.ProjectName, request.TicketId?.Value, result.Message);
+            var dispatcher = scope.ServiceProvider.GetRequiredService<IPipelineJobDispatcher>();
+            var jobId = await dispatcher.DispatchAsync(request, ct);
+            logger.LogInformation(
+                "Dispatched: {Project}/{Ticket} job={JobId}",
+                request.ProjectName, request.TicketId?.Value ?? "—", jobId);
         }
         catch (Exception ex)
         {
             logger.LogError(ex,
-                "Pipeline execution error for {Project}/{Ticket}",
-                request.ProjectName, request.TicketId?.Value);
+                "Dispatch failed for {Project}/{Ticket} — request remains claimed; reconciler will recover",
+                request.ProjectName, request.TicketId?.Value ?? "—");
         }
         finally
         {

--- a/src/AgentSmith.Cli/Commands/RunClaimedJobCommand.cs
+++ b/src/AgentSmith.Cli/Commands/RunClaimedJobCommand.cs
@@ -1,0 +1,84 @@
+using System.CommandLine;
+using System.CommandLine.Invocation;
+using AgentSmith.Application.Services;
+using AgentSmith.Contracts.Services;
+using AgentSmith.Domain.Models;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace AgentSmith.Cli.Commands;
+
+/// <summary>
+/// p0113: Hidden CLI subcommand used by Server-spawned containers to pick up a
+/// queue-claimed PipelineRequest. Server saves the structured request under a
+/// jobId via IPipelineRequestStore; this command loads it and drives the
+/// pipeline via the structured ExecutePipelineUseCase overload — no string
+/// round-tripping through the intent parser.
+///
+/// Reachable for debugging via:
+///   agent-smith run-claimed-job --job-id &lt;id&gt; --redis-url &lt;url&gt; --config &lt;path&gt;
+/// (hidden from --help).
+/// </summary>
+internal static class RunClaimedJobCommand
+{
+    public static Command Create(Option<string> configOption, Option<bool> verboseOption)
+    {
+        var jobIdOption = new Option<string>("--job-id", "Job id assigned by the dispatcher") { IsRequired = true };
+        var redisUrlOption = new Option<string>("--redis-url", "Redis connection URL") { IsRequired = true };
+
+        var cmd = new Command("run-claimed-job", "Internal: pick up a queue-claimed pipeline job (hidden)")
+        {
+            jobIdOption, redisUrlOption, configOption, verboseOption,
+        };
+        cmd.IsHidden = true;
+
+        cmd.SetHandler(async (InvocationContext ctx) =>
+        {
+            var jobId = ctx.ParseResult.GetValueForOption(jobIdOption)!;
+            var redisUrl = ctx.ParseResult.GetValueForOption(redisUrlOption)!;
+            var configPath = ctx.ParseResult.GetValueForOption(configOption)!;
+            var verbose = ctx.ParseResult.GetValueForOption(verboseOption);
+
+            var provider = ServiceProviderFactory.Build(
+                verbose, headless: true, jobId: jobId, redisUrl: redisUrl, configPath: configPath);
+            var logger = provider.GetRequiredService<ILogger<Program>>();
+
+            var store = provider.GetRequiredService<IPipelineRequestStore>();
+            var request = await store.LoadAsync(jobId, CancellationToken.None);
+            if (request is null)
+            {
+                logger.LogError(
+                    "PipelineRequest for job {JobId} not found in Redis (key missing or expired). " +
+                    "Exiting non-zero so the orchestrator marks the job failed.",
+                    jobId);
+                ctx.ExitCode = 2;
+                return;
+            }
+
+            logger.LogInformation(
+                "Picked up job {JobId}: {Project}/#{Ticket} pipeline={Pipeline}",
+                jobId, request.ProjectName, request.TicketId?.Value ?? "—", request.PipelineName);
+
+            CommandResult result;
+            try
+            {
+                var useCase = provider.GetRequiredService<ExecutePipelineUseCase>();
+                result = await useCase.ExecuteAsync(request, configPath, CancellationToken.None);
+            }
+            catch (Exception ex)
+            {
+                result = CommandResult.Fail($"Unhandled exception: {ex.Message}");
+                logger.LogError(ex, "Pipeline execution threw for job {JobId}", jobId);
+            }
+
+            if (result.IsSuccess)
+                logger.LogInformation("Job {JobId} succeeded: {Message}", jobId, result.Message);
+            else
+                logger.LogWarning("Job {JobId} failed: {Message}", jobId, result.Message);
+
+            ctx.ExitCode = result.IsSuccess ? 0 : 1;
+        });
+
+        return cmd;
+    }
+}

--- a/src/AgentSmith.Cli/Program.cs
+++ b/src/AgentSmith.Cli/Program.cs
@@ -24,6 +24,7 @@ var rootCommand = new RootCommand("Agent Smith — self-hosted AI orchestration"
     AutonomousCommand.Create(configOption, verboseOption),
     SkillsCommand.Create(configOption, verboseOption),
     runCommand,
+    RunClaimedJobCommand.Create(configOption, verboseOption),
 };
 
 return await rootCommand.InvokeAsync(args);

--- a/src/AgentSmith.Cli/ServiceProviderFactory.cs
+++ b/src/AgentSmith.Cli/ServiceProviderFactory.cs
@@ -8,6 +8,7 @@ using AgentSmith.Infrastructure;
 using AgentSmith.Infrastructure.Models;
 using AgentSmith.Infrastructure.Services.Bus;
 using AgentSmith.Infrastructure.Services.Dialogue;
+using AgentSmith.Infrastructure.Services.Queue;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using StackExchange.Redis;
@@ -53,6 +54,7 @@ internal static class ServiceProviderFactory
             services.AddSingleton<IConnectionMultiplexer>(multiplexer);
             services.AddSingleton<IMessageBus, RedisMessageBus>();
             services.AddSingleton<IDialogueTransport, RedisDialogueTransport>();
+            services.AddSingleton<IPipelineRequestStore, RedisPipelineRequestStore>();
             services.AddSingleton<IProgressReporter>(sp =>
                 new RedisProgressReporter(
                     sp.GetRequiredService<IMessageBus>(), jobId,

--- a/src/AgentSmith.Contracts/Services/IPipelineJobDispatcher.cs
+++ b/src/AgentSmith.Contracts/Services/IPipelineJobDispatcher.cs
@@ -1,0 +1,21 @@
+using AgentSmith.Contracts.Models;
+
+namespace AgentSmith.Contracts.Services;
+
+/// <summary>
+/// Application-level abstraction over how a PipelineRequest is handed off
+/// for execution. Lets PipelineQueueConsumer (Application layer) stay
+/// independent of the spawn mechanism (Server layer).
+///
+/// Production binding: Server's JobSpawnerPipelineDispatcher generates a
+/// jobId, persists the request via IPipelineRequestStore, and spawns an
+/// ephemeral CLI container that loads the request by jobId.
+/// </summary>
+public interface IPipelineJobDispatcher
+{
+    /// <summary>
+    /// Hand off the request for execution. Returns the assigned jobId so the
+    /// caller can correlate logs / heartbeats with the spawned job.
+    /// </summary>
+    Task<string> DispatchAsync(PipelineRequest request, CancellationToken cancellationToken);
+}

--- a/src/AgentSmith.Contracts/Services/IPipelineRequestStore.cs
+++ b/src/AgentSmith.Contracts/Services/IPipelineRequestStore.cs
@@ -1,0 +1,18 @@
+using AgentSmith.Contracts.Models;
+
+namespace AgentSmith.Contracts.Services;
+
+/// <summary>
+/// p0113: cross-process handoff for queue-spawned jobs. Server saves the
+/// PipelineRequest under a jobId; the spawned CLI container loads it and
+/// runs the structured pipeline. CLI args stay short (jobId + redisUrl +
+/// configPath) — full request payload travels via Redis with a TTL guard.
+/// </summary>
+public interface IPipelineRequestStore
+{
+    /// <summary>Save the request under the given jobId. Existing key is overwritten.</summary>
+    Task SaveAsync(string jobId, PipelineRequest request, TimeSpan ttl, CancellationToken cancellationToken);
+
+    /// <summary>Returns null when the key is missing or expired.</summary>
+    Task<PipelineRequest?> LoadAsync(string jobId, CancellationToken cancellationToken);
+}

--- a/src/AgentSmith.Infrastructure/Services/Queue/RedisPipelineRequestStore.cs
+++ b/src/AgentSmith.Infrastructure/Services/Queue/RedisPipelineRequestStore.cs
@@ -1,0 +1,51 @@
+using System.Text.Json;
+using AgentSmith.Contracts.Models;
+using AgentSmith.Contracts.Services;
+using Microsoft.Extensions.Logging;
+using StackExchange.Redis;
+
+namespace AgentSmith.Infrastructure.Services.Queue;
+
+/// <summary>
+/// Redis-backed handoff for queue-spawned jobs (p0113). One key per jobId,
+/// SETEX with TTL — survives short dispatcher↔container races without
+/// growing unbounded. RedisJobQueue already uses the same JsonSerializer
+/// shape for PipelineRequest, so this reuses that round-trip contract.
+/// </summary>
+public sealed class RedisPipelineRequestStore(
+    IConnectionMultiplexer redis,
+    ILogger<RedisPipelineRequestStore> logger) : IPipelineRequestStore
+{
+    private const string KeyPrefix = "agentsmith:pipeline-request:";
+
+    public async Task SaveAsync(
+        string jobId, PipelineRequest request, TimeSpan ttl, CancellationToken cancellationToken)
+    {
+        var db = redis.GetDatabase();
+        var json = JsonSerializer.Serialize(request);
+        await db.StringSetAsync($"{KeyPrefix}{jobId}", json, ttl);
+        logger.LogDebug(
+            "Saved PipelineRequest for job {JobId} (project {Project}, pipeline {Pipeline}, ttl {Ttl}s)",
+            jobId, request.ProjectName, request.PipelineName, (int)ttl.TotalSeconds);
+    }
+
+    public async Task<PipelineRequest?> LoadAsync(string jobId, CancellationToken cancellationToken)
+    {
+        var db = redis.GetDatabase();
+        var json = await db.StringGetAsync($"{KeyPrefix}{jobId}");
+        if (json.IsNullOrEmpty)
+        {
+            logger.LogWarning("PipelineRequest not found for job {JobId} — key missing or expired", jobId);
+            return null;
+        }
+        try
+        {
+            return JsonSerializer.Deserialize<PipelineRequest>(json!);
+        }
+        catch (JsonException ex)
+        {
+            logger.LogError(ex, "Failed to deserialize PipelineRequest for job {JobId}", jobId);
+            return null;
+        }
+    }
+}

--- a/src/AgentSmith.Server/Contracts/IJobSpawner.cs
+++ b/src/AgentSmith.Server/Contracts/IJobSpawner.cs
@@ -10,10 +10,20 @@ namespace AgentSmith.Server.Contracts;
 public interface IJobSpawner
 {
     /// <summary>
-    /// Spawns an ephemeral agent job for the given request.
-    /// Returns the jobId that can be used to track progress via Redis Streams.
+    /// Spawns an ephemeral agent job for the given request (chat-intent flow:
+    /// Slack/Teams "fix #123 in my-project"). Returns the jobId so progress
+    /// can be tracked via Redis Streams.
     /// </summary>
     Task<string> SpawnAsync(JobRequest request, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// p0113: spawns an ephemeral agent job for a queue-claimed PipelineRequest.
+    /// The container picks up its work by reading from the IPipelineRequestStore
+    /// using the supplied jobId — CLI args stay short and structured request
+    /// data round-trips losslessly through Redis.
+    /// </summary>
+    Task SpawnQueueJobAsync(
+        string jobId, string redisUrl, string configPath, CancellationToken cancellationToken);
 
     /// <summary>
     /// Checks whether the container/pod for the given job is still running.

--- a/src/AgentSmith.Server/Extensions/ServiceCollectionExtensions.cs
+++ b/src/AgentSmith.Server/Extensions/ServiceCollectionExtensions.cs
@@ -30,6 +30,7 @@ internal static class ServiceCollectionExtensions
         var multiplexer = ConnectionMultiplexer.Connect(redisUrl);
         services.AddSingleton<IConnectionMultiplexer>(multiplexer);
         services.AddSingleton<IRedisJobQueue, RedisJobQueue>();
+        services.AddSingleton<IPipelineRequestStore, RedisPipelineRequestStore>();
         services.AddSingleton<IRedisClaimLock, RedisClaimLock>();
         services.AddSingleton<IRedisLeaderLease, RedisLeaderLease>();
         services.AddSingleton<IJobHeartbeatService, JobHeartbeatService>();
@@ -78,6 +79,9 @@ internal static class ServiceCollectionExtensions
         services.AddAgentSmithInfrastructure();
         services.AddAgentSmithCommands();
         services.AddIntentEngine();
+        // p0113: queue-driven dispatch goes through ephemeral CLI containers,
+        // not in-process pipeline execution.
+        services.AddSingleton<IPipelineJobDispatcher, JobSpawnerPipelineDispatcher>();
         return services;
     }
 

--- a/src/AgentSmith.Server/Services/DockerJobSpawner.cs
+++ b/src/AgentSmith.Server/Services/DockerJobSpawner.cs
@@ -76,6 +76,71 @@ public sealed class DockerJobSpawner(
         catch (DockerContainerNotFoundException) { return false; }
     }
 
+    public async Task SpawnQueueJobAsync(
+        string jobId, string redisUrl, string configPath, CancellationToken cancellationToken)
+    {
+        var containerName = $"agentsmith-{jobId}";
+        using var client = CreateDockerClient();
+
+        var networkResolver = new DockerNetworkResolver(options, logger);
+        var network = await networkResolver.ResolveAsync(client, cancellationToken);
+
+        var createParams = new CreateContainerParameters
+        {
+            Name = containerName, Image = options.Image,
+            Cmd =
+            [
+                "run-claimed-job",
+                "--job-id", jobId,
+                "--redis-url", redisUrl,
+                "--config", configPath,
+            ],
+            Env = BuildQueueEnv(jobId, redisUrl),
+            Labels = new Dictionary<string, string>
+            {
+                ["app"] = "agentsmith", ["job-id"] = jobId,
+                ["spawned-from"] = "queue",
+                ["managed-by"] = "agentsmith-dispatcher"
+            },
+            HostConfig = new HostConfig
+            {
+                AutoRemove = true, NetworkMode = network,
+                Memory = 1 * 1024 * 1024 * 1024L, MemoryReservation = 512 * 1024 * 1024L,
+                NanoCPUs = 1_000_000_000L,
+            }
+        };
+
+        logger.LogInformation(
+            "Creating Docker queue container {Name} (id={JobId})", containerName, jobId);
+
+        CreateContainerResponse response;
+        try { response = await client.Containers.CreateContainerAsync(createParams, cancellationToken); }
+        catch (DockerImageNotFoundException)
+        {
+            throw new InvalidOperationException(
+                $"Agent image '{options.Image}' not found. Run: docker build -t {options.Image} .");
+        }
+
+        await client.Containers.StartContainerAsync(response.ID, new ContainerStartParameters(), cancellationToken);
+        logger.LogInformation("Started queue container {Name} (jobId={JobId})", containerName, jobId);
+    }
+
+    private static List<string> BuildQueueEnv(string jobId, string redisUrl)
+    {
+        var env = new List<string>
+        {
+            $"JOB_ID={jobId}",
+            $"REDIS_URL={redisUrl}",
+        };
+        foreach (var varName in ForwardedEnvVars)
+        {
+            if (varName == "REDIS_URL") continue;
+            var value = Environment.GetEnvironmentVariable(varName);
+            if (!string.IsNullOrEmpty(value)) env.Add($"{varName}={value}");
+        }
+        return env;
+    }
+
     private static DockerClient CreateDockerClient()
     {
         var dockerHost = Environment.GetEnvironmentVariable("DOCKER_HOST");

--- a/src/AgentSmith.Server/Services/JobSpawnerPipelineDispatcher.cs
+++ b/src/AgentSmith.Server/Services/JobSpawnerPipelineDispatcher.cs
@@ -1,0 +1,36 @@
+using AgentSmith.Contracts.Models;
+using AgentSmith.Contracts.Models.Configuration;
+using AgentSmith.Contracts.Services;
+using AgentSmith.Server.Contracts;
+using Microsoft.Extensions.Logging;
+
+namespace AgentSmith.Server.Services;
+
+/// <summary>
+/// p0113: Server-side adapter from Application's IPipelineJobDispatcher to
+/// IJobSpawner. Generates jobId, persists the request via IPipelineRequestStore,
+/// then spawns an ephemeral CLI container that loads the request by jobId.
+/// </summary>
+public sealed class JobSpawnerPipelineDispatcher(
+    IJobSpawner jobSpawner,
+    IPipelineRequestStore requestStore,
+    ServerContext serverContext,
+    ILogger<JobSpawnerPipelineDispatcher> logger) : IPipelineJobDispatcher
+{
+    private static readonly TimeSpan RequestTtl = TimeSpan.FromHours(1);
+
+    public async Task<string> DispatchAsync(PipelineRequest request, CancellationToken cancellationToken)
+    {
+        var jobId = Guid.NewGuid().ToString("N")[..12];
+        var redisUrl = Environment.GetEnvironmentVariable("REDIS_URL") ?? "redis:6379";
+
+        await requestStore.SaveAsync(jobId, request, RequestTtl, cancellationToken);
+        await jobSpawner.SpawnQueueJobAsync(jobId, redisUrl, serverContext.ConfigPath, cancellationToken);
+
+        logger.LogInformation(
+            "Dispatched queue job {JobId}: {Project}/#{Ticket} pipeline={Pipeline}",
+            jobId, request.ProjectName, request.TicketId?.Value ?? "—", request.PipelineName);
+
+        return jobId;
+    }
+}

--- a/src/AgentSmith.Server/Services/KubernetesJobSpawner.cs
+++ b/src/AgentSmith.Server/Services/KubernetesJobSpawner.cs
@@ -58,6 +58,100 @@ public sealed class KubernetesJobSpawner(
         }
     }
 
+    public async Task SpawnQueueJobAsync(
+        string jobId, string redisUrl, string configPath, CancellationToken cancellationToken)
+    {
+        var jobName = $"agentsmith-{jobId}";
+        var job = BuildQueueJob(jobName, jobId, redisUrl, configPath);
+
+        await k8sClient.BatchV1.CreateNamespacedJobAsync(
+            job, options.Namespace, cancellationToken: cancellationToken);
+
+        logger.LogInformation(
+            "Spawned K8s queue Job {JobName} (id={JobId})", jobName, jobId);
+    }
+
+    private V1Job BuildQueueJob(string jobName, string jobId, string redisUrl, string configPath) => new()
+    {
+        Metadata = new V1ObjectMeta
+        {
+            Name = jobName,
+            NamespaceProperty = options.Namespace,
+            Labels = new Dictionary<string, string>
+            {
+                ["app"] = "agentsmith",
+                ["job-id"] = jobId,
+                ["spawned-from"] = "queue"
+            }
+        },
+        Spec = new V1JobSpec
+        {
+            TtlSecondsAfterFinished = options.TtlSecondsAfterFinished,
+            BackoffLimit = 0,
+            Template = new V1PodTemplateSpec
+            {
+                Metadata = new V1ObjectMeta
+                {
+                    Labels = new Dictionary<string, string>
+                    {
+                        ["app"] = "agentsmith",
+                        ["job-id"] = jobId,
+                        ["spawned-from"] = "queue"
+                    }
+                },
+                Spec = new V1PodSpec
+                {
+                    RestartPolicy = "Never",
+                    Containers =
+                    [
+                        new V1Container
+                        {
+                            Name = "agentsmith",
+                            Image = options.Image,
+                            ImagePullPolicy = options.ImagePullPolicy,
+                            Args =
+                            [
+                                "run-claimed-job",
+                                "--job-id", jobId,
+                                "--redis-url", redisUrl,
+                                "--config", configPath,
+                            ],
+                            Env = BuildQueueEnv(jobId, redisUrl),
+                            Resources = new V1ResourceRequirements
+                            {
+                                Requests = new Dictionary<string, ResourceQuantity>
+                                {
+                                    ["cpu"] = new("250m"),
+                                    ["memory"] = new("512Mi")
+                                },
+                                Limits = new Dictionary<string, ResourceQuantity>
+                                {
+                                    ["cpu"] = new("1000m"),
+                                    ["memory"] = new("1Gi")
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    };
+
+    private List<V1EnvVar> BuildQueueEnv(string jobId, string redisUrl) =>
+    [
+        EnvFromSecret("ANTHROPIC_API_KEY", options.SecretName, "anthropic-api-key"),
+        EnvFromSecret("AZURE_DEVOPS_TOKEN", options.SecretName, "azure-devops-token"),
+        EnvFromSecret("GITHUB_TOKEN", options.SecretName, "github-token"),
+        EnvFromSecret("OPENAI_API_KEY", options.SecretName, "openai-api-key"),
+        EnvFromSecret("AZURE_OPENAI_API_KEY", options.SecretName, "azure-openai-api-key"),
+        EnvFromSecret("GEMINI_API_KEY", options.SecretName, "gemini-api-key"),
+        EnvFromSecret("GITLAB_TOKEN", options.SecretName, "gitlab-token"),
+        EnvFromSecret("JIRA_TOKEN", options.SecretName, "jira-token"),
+        EnvFromSecret("JIRA_EMAIL", options.SecretName, "jira-email"),
+        new V1EnvVar { Name = "REDIS_URL", Value = redisUrl },
+        new V1EnvVar { Name = "JOB_ID", Value = jobId },
+    ];
+
     private V1Job BuildJob(string jobName, string jobId, JobRequest request, string redisUrl) => new()
     {
         Metadata = new V1ObjectMeta

--- a/tests/AgentSmith.Tests/Server/ServerDiLifetimeTests.cs
+++ b/tests/AgentSmith.Tests/Server/ServerDiLifetimeTests.cs
@@ -180,6 +180,7 @@ public sealed class ServerDiLifetimeTests
     {
         services.AddSingleton(Mock.Of<IConnectionMultiplexer>());
         services.AddSingleton<IRedisJobQueue, NullRedisJobQueue>();
+        services.AddSingleton(Mock.Of<IPipelineRequestStore>());
         services.AddSingleton(Mock.Of<IRedisClaimLock>());
         services.AddSingleton<IRedisLeaderLease, NullRedisLeaderLease>();
         services.AddSingleton<IJobHeartbeatService, NullJobHeartbeatService>();

--- a/tests/AgentSmith.Tests/Services/PipelineQueueConsumerTests.cs
+++ b/tests/AgentSmith.Tests/Services/PipelineQueueConsumerTests.cs
@@ -1,0 +1,100 @@
+using AgentSmith.Application.Services;
+using AgentSmith.Contracts.Models;
+using AgentSmith.Contracts.Services;
+using AgentSmith.Domain.Models;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace AgentSmith.Tests.Services;
+
+public sealed class PipelineQueueConsumerTests
+{
+    [Fact]
+    public async Task RunAsync_ConsumesRequest_DispatchesViaJobDispatcher()
+    {
+        var dispatched = new List<PipelineRequest>();
+        var dispatcher = new Mock<IPipelineJobDispatcher>();
+        dispatcher.Setup(d => d.DispatchAsync(It.IsAny<PipelineRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<PipelineRequest, CancellationToken>((req, _) => dispatched.Add(req))
+            .ReturnsAsync("job-12345678");
+
+        var queue = new StubQueue([
+            new PipelineRequest("proj-a", "fix-bug", new TicketId("11"), Headless: true),
+            new PipelineRequest("proj-b", "fix-bug", new TicketId("12"), Headless: true),
+        ]);
+
+        var services = new ServiceCollection();
+        services.AddSingleton(dispatcher.Object);
+        var provider = services.BuildServiceProvider();
+
+        var consumer = new PipelineQueueConsumer(
+            provider, queue, configPath: "/tmp/config.yml",
+            maxParallelJobs: 2, shutdownGraceSeconds: 1,
+            NullLogger<PipelineQueueConsumer>.Instance);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        await consumer.RunAsync(cts.Token);
+
+        dispatched.Should().HaveCount(2);
+        dispatched.Select(r => r.ProjectName).Should().BeEquivalentTo(["proj-a", "proj-b"]);
+        dispatcher.Verify(d => d.DispatchAsync(It.IsAny<PipelineRequest>(), It.IsAny<CancellationToken>()),
+            Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task RunAsync_DispatcherThrows_LogsAndContinues()
+    {
+        var dispatcher = new Mock<IPipelineJobDispatcher>();
+        var calls = 0;
+        dispatcher.Setup(d => d.DispatchAsync(It.IsAny<PipelineRequest>(), It.IsAny<CancellationToken>()))
+            .Returns<PipelineRequest, CancellationToken>((_, _) =>
+            {
+                calls++;
+                if (calls == 1) throw new InvalidOperationException("spawn failed");
+                return Task.FromResult("job-second");
+            });
+
+        var queue = new StubQueue([
+            new PipelineRequest("proj-a", "fix-bug", new TicketId("1"), Headless: true),
+            new PipelineRequest("proj-b", "fix-bug", new TicketId("2"), Headless: true),
+        ]);
+
+        var services = new ServiceCollection();
+        services.AddSingleton(dispatcher.Object);
+        var provider = services.BuildServiceProvider();
+
+        var consumer = new PipelineQueueConsumer(
+            provider, queue, configPath: "/tmp/config.yml",
+            maxParallelJobs: 1, shutdownGraceSeconds: 1,
+            NullLogger<PipelineQueueConsumer>.Instance);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        await consumer.RunAsync(cts.Token);
+
+        calls.Should().Be(2);
+    }
+
+    private sealed class StubQueue(IReadOnlyList<PipelineRequest> items) : IRedisJobQueue
+    {
+        public Task EnqueueAsync(PipelineRequest request, CancellationToken cancellationToken) =>
+            Task.CompletedTask;
+
+        public Task<long> LenAsync(CancellationToken cancellationToken) =>
+            Task.FromResult((long)items.Count);
+
+        public async IAsyncEnumerable<PipelineRequest> ConsumeAsync(
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            foreach (var item in items)
+            {
+                if (cancellationToken.IsCancellationRequested) yield break;
+                yield return item;
+                await Task.Yield();
+            }
+            // Stay open until cancellation so the consumer's await foreach awaits.
+            await Task.Delay(Timeout.Infinite, cancellationToken).ContinueWith(_ => { }, TaskScheduler.Default);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Initial MVP slice of [p0113 spawn-pipeline-jobs spec](https://github.com/holgerleichsenring/agent-smith/blob/spec/p0112-and-followups/.agentsmith/phases/planned/p0113-spawn-pipeline-jobs.yaml). Today \`PipelineQueueConsumer\` runs pipelines in-process inside the Server pod, which means Server's container needs every language's toolchain (dotnet SDK, npm, python, …) for steps like \`TestCommand\`. The Slack-intent path already uses \`IJobSpawner\`; the queue path is the architectural gap.

This PR closes the gap on the queue path: \`PipelineQueueConsumer\` becomes a dispatcher that hands off structured \`PipelineRequest\`s to ephemeral CLI containers via \`IJobSpawner.SpawnQueueJobAsync\`. The container loads the request from Redis and runs the structured pipeline — no string round-tripping through the intent parser.

## What ships

**Application/Contracts (independent of the spawn mechanism)**
- \`IPipelineJobDispatcher\` — abstraction \`PipelineQueueConsumer\` depends on
- \`IPipelineRequestStore\` — JSON handoff for structured \`PipelineRequest\`s under \`agentsmith:pipeline-request:{jobId}\` (1h TTL)
- \`PipelineQueueConsumer\` — switched from in-process \`ExecutePipelineUseCase\` to \`IPipelineJobDispatcher.DispatchAsync\`

**Infrastructure**
- \`RedisPipelineRequestStore\` — reuses the same JSON shape as \`RedisJobQueue\`

**Server**
- \`JobSpawnerPipelineDispatcher\` — generates jobId, persists request, calls \`SpawnQueueJobAsync\`
- \`IJobSpawner.SpawnQueueJobAsync\` — added to both \`DockerJobSpawner\` and \`KubernetesJobSpawner\` with full provider-token env forwarding (Anthropic / OpenAI / Azure-OpenAI / Gemini / GitHub / GitLab / AzureDevOps / Jira / Redis URL)
- DI wiring in \`AddRedis\` (Server) and \`AddCoreDispatcherServices\`

**CLI**
- \`run-claimed-job\` hidden subcommand (\`--job-id\`, \`--redis-url\`, \`--config\`). Loads PipelineRequest by jobId, calls the **structured** \`ExecutePipelineUseCase.ExecuteAsync(request, configPath, ct)\` overload. Fails fast (exit code 2) when the request is missing/expired so the orchestrator marks the job failed.
- DI: \`IPipelineRequestStore\` wired in \`ServiceProviderFactory\` spawned-job mode

**Docs**
- \`concepts/spawned-jobs.md\` (new) — full cross-boundary flow diagram, lifecycle table, recovery story, why Redis-handoff vs CLI args
- \`concepts/ticket-lifecycle.md\` — Enqueued→InProgress fires inside the spawned container; Enqueued→Pending recovery via \`EnqueuedReconciler\`
- \`mkdocs.yml\` nav

## Lifecycle across the boundary

| Transition | Side |
|------------|------|
| Pending → Enqueued | Server (\`TicketClaimService\`) |
| Enqueued → InProgress | **Container** (\`PipelineExecutor\`) |
| InProgress → Done / Failed | **Container** (\`LifecycleScope.Dispose\`) |

Spawn-window gap (Server enqueues → container starts running): \`EnqueuedReconciler\` (existing, p0095c) sweeps stuck \`Enqueued\` tickets back to \`Pending\` after the configured stale-window (default 10 min).

## What is deferred to p0113b

Documented in the original spec; intentionally out of this MVP:

- **\`SecretsForwardingPolicy\` whitelist** — explicit env-var allow-list crossing the spawn boundary. Today: hard-coded list inside each spawner.
- **\`JobRequest.ImageOverride\` resolution chain** (\`request → pipeline → default\`) for projects needing per-language toolchain images.
- **Heartbeat-gap mitigation**: write the first heartbeat **before** the DI build inside \`run-claimed-job\` so a DI-build crash doesn't ghost the ticket. Today: relies on \`EnqueuedReconciler\`.
- **\`AGENTSMITH_TEST_FAIL_AFTER\`** env-var fail-injection for reproducible CI.
- **Server Dockerfile** cleanup (already runtime-only) + remove \`p4x\` TODO in CLI Dockerfile.

## Risk + rollout note

This PR materially changes the runtime behavior of the queue path — Server pods stop executing pipelines and start dispatching them. The Slack-intent flow is **untouched**. Rollout should: (1) ensure the CLI image is reachable from the Server's spawn target (Docker socket / K8s API), (2) confirm \`agentsmith-secrets\` (K8s) holds all provider tokens the running pipeline needs, (3) watch \`EnqueuedReconciler\` logs after deploy — any \"reverted N orphan tickets\" entries indicate spawn issues.

## Test plan

- [x] \`dotnet build\` — 0 warnings, 0 errors.
- [x] \`dotnet test\` — 1309/1309 green.
- [ ] Smoke verify in AAD-DEV with Docker spawner: trigger a ticket, confirm Server logs end at \"Dispatched: ... job=...\", confirm container logs show \"Picked up job ...\" and pipeline execution.
- [ ] Smoke verify EnqueuedReconciler recovery: point spawner at a non-pullable image, confirm ticket reverts to Pending after the stale-window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)