### PR TITLE
feat: combined p0112a + p0113a + p0114 — branch persistence + queue spawn + OpenAI compactor

### DIFF
--- a/docs/concepts/branch-persistence.md
+++ b/docs/concepts/branch-persistence.md
@@ -1,0 +1,68 @@
+# Branch Persistence
+
+Pipeline runs do real work — generated plans, agentic edits, test runs. When a pod restarts mid-pipeline, that work is on a `/tmp` working tree that the next pod cannot see. Without intervention, the next attempt would re-run every analyzer call from scratch, which is both expensive (tokens) and non-idempotent for any LLM round.
+
+Branch persistence is the framework's mitigation: every ticket gets a deterministic work-branch on the source remote, and the failure path of every pipeline pushes the working tree to that branch as a `[wip]` commit before the lifecycle is marked Failed.
+
+## Branch naming
+
+The work-branch name is derived from the ticket id. It is **stable** — the same ticket on the same source produces the same branch every time, so a re-run can find the previous attempt's state.
+
+| Form | When it applies | Example |
+|------|-----------------|---------|
+| `agent-smith/{ticketId}` | One-repo-per-ticket-system deployments (the AAD-DEV pattern, no project disambiguation needed) | `agent-smith/18693` |
+| `agent-smith/{platform}/{projectSlug}/{ticketId}` | Multi-platform / multi-project deployments where ticket ids may collide across systems | `agent-smith/azurerepos/cloud-development/18693` |
+
+Slug rules for the hierarchical form:
+
+- Lower-cased, non-alphanumeric runs collapsed to `-`, leading/trailing `-` trimmed
+- Slugs longer than 64 characters are truncated and suffixed with a 7-char SHA-1 hash of the original slug to keep the result deterministic
+- A `projectName` that slugifies to empty (e.g. `"!!!---???"`) is rejected at compose time as a configuration error
+
+Composition lives in `TicketBranchNamer` (`AgentSmith.Application.Services`) — a static helper. There is no DI registration; builders call it directly.
+
+## The resume path
+
+When `CheckoutSourceCommand` runs, it composes the work-branch name from the ticket and asks the source provider to check out that branch. The provider's `CheckoutBranch` does:
+
+1. Look for a local branch with that name. If found, check it out — done.
+2. Fetch from `origin`.
+3. Look for `refs/remotes/origin/{branch}`. If found, create a local tracking branch from it and check it out — **resume**.
+4. Otherwise, create a fresh branch from the current `HEAD` (legacy behavior — first attempt for this ticket).
+
+This means: if a previous pipeline run pushed a `[wip]` commit, the next run picks up exactly where the prior run stopped. No replays of expensive analyzer calls; the agentic loop sees the prior tool output as committed file state.
+
+## The persist path
+
+`PipelineExecutor` wraps every pipeline run. When any step returns a failed `CommandResult`, the executor invokes `PersistWorkBranchHandler` **before** calling `lifecycle.MarkFailed()`. The handler runs in its own try/catch — a persist failure must never mask the original pipeline failure.
+
+The handler:
+
+1. Reads the `Repository` from the pipeline context. If absent (the pipeline failed before checkout), records `Unknown` and returns Fail.
+2. Builds a `[wip] agent-smith run {runId}` commit message with three trailers (`Run-Id`, `Pipeline`, `Failed-Step`) so the commit is searchable from a log line.
+3. Calls `ISourceProvider.CommitAndPushAsync`.
+4. Classifies any thrown exception into a `PersistFailureKind` and stamps it onto `ContextKeys.PersistFailureKind` for the executor's logging wrapper to route on.
+
+### Failure kinds
+
+| Kind | Trigger | Operator action |
+|------|---------|-----------------|
+| `NoChanges` | Working tree was clean (provider returned an empty-commit signal) | Informational — the pipeline failed before producing any file changes; nothing to persist |
+| `AuthDenied` | Push rejected with HTTP 401/403 or "unauthorized" | Check the source-provider PAT/credentials; the pipeline run still has output in logs |
+| `RemoteDivergent` | Push rejected as `non-fast-forward` | Two pipeline runs raced on the same ticket; investigate the older branch on the remote and decide which to keep — the framework refuses to force-push |
+| `NetworkBlip` | `HttpRequestException` during push | Transient — operator can re-trigger the ticket and the resume path will pick up the local state if the next run lands on the same pod, otherwise the work is lost |
+| `Unknown` | Anything else | Inspect the log for the underlying exception |
+
+Persist failures are logged at `Error` (or `Warning` for `NetworkBlip`) — they show up in the run telemetry next to the original pipeline failure, not in place of it.
+
+## What this does not protect
+
+- **Pipeline failure between commands within a single transactional step**: persistence happens at command boundaries. A handler that produces partial in-memory state without writing to disk is unaffected.
+- **A successful run**: persistence runs only on the failure path. Successful runs commit and push as part of `CommitAndPRCommand` and do not need the WIP fallback.
+- **First-attempt failures with no checkout**: if the pipeline fails before `CheckoutSourceCommand`, there is no working tree to persist (`Unknown` kind, no commit pushed).
+
+## Related
+
+- [Ticket Lifecycle](ticket-lifecycle.md) — where persist sits in the InProgress → Failed transition
+- [Pipeline System](pipeline-system.md) — command/handler model and failure path
+- [Cost Tracking](cost-tracking.md) — why preserving partial work matters for token budgets

--- a/docs/concepts/context-compaction.md
+++ b/docs/concepts/context-compaction.md
@@ -1,0 +1,103 @@
+# Context Compaction
+
+Long agentic runs (ProjectAnalyzer, AgenticExecute) accumulate the full conversation history each turn — every tool result, every assistant response. Without intervention this is **quadratic** in token cost: by iteration 20 the model re-processes 20× the prior tool output. Real numbers from a production trace: ProjectAnalyzer hit ~864k input tokens for a single .NET solution analysis (~$1.73 at gpt-4.1 input pricing).
+
+Compaction summarizes the older prefix of the conversation when a threshold is crossed, keeping the recent tail verbatim. Same conceptual algorithm as p0008's Claude compactor, ported to OpenAI / Azure-OpenAI in p0114.
+
+## Trigger
+
+Compaction fires between rounds when **either**:
+
+```
+currentIterations >= CompactionConfig.ThresholdIterations
+  OR
+estimatedAccumulatedTokens >= CompactionConfig.MaxContextTokens
+```
+
+Boolean OR (no max(), no AND). Defaults: `ThresholdIterations=8`, `MaxContextTokens=80000`.
+
+The estimate uses a `chars / 4` heuristic — accurate to ±5% for English text. It only feeds the trigger decision; the **post-compaction savings number** is the authoritative `usage.prompt_tokens` from the next API response.
+
+## What's preserved, what's summarized
+
+```
+[ system prompt          ]   ← preserved verbatim (cache-stable)
+[ initial user prompt    ]   ↘
+[ assistant + tool_calls ]    │
+[ tool result            ]    │  ← summarized into a single
+[ assistant + tool_calls ]    │  [Context Summary] user message
+[ tool result            ]    │
+[ assistant text         ]   ↗
+[ assistant + tool_calls ]   ↘
+[ tool result            ]    │  ← TAIL: kept verbatim
+[ assistant + tool_calls ]    │  (last 2 complete tool-call rounds)
+[ tool result            ]   ↗
+```
+
+A "round" is one of:
+- `AssistantChatMessage` with tool_calls + all `ToolChatMessage` responses to those `tool_call_id`s.
+- A bare `AssistantChatMessage` with no tool_calls (terminal reply).
+
+Walking backward, the boundary **never splits a round mid-pair** — the OpenAI API rejects payloads where a tool message references a `tool_call_id` without the matching assistant message in the same array. `ToolCallRoundIdentifier` enforces this invariant.
+
+## Provider availability
+
+| Provider | Compactor | Notes |
+|---|---|---|
+| Claude | `ClaudeContextCompactor` (p0008) | Uses Anthropic native `cache_control: ephemeral` — verifiable cache hits |
+| OpenAI | `OpenAiContextCompactor` (p0114) | Uses chat-completions; opaque automatic prompt caching |
+| Azure-OpenAI | `OpenAiContextCompactor` (p0114) | Same impl; Azure delegates via shared composition |
+| Gemini | NoOp (placeholder) | Same long-loop quadratic cost as the others — **NOT** "doesn't need it". Follow-up phase. |
+| Ollama | NoOp (placeholder) | Local model still re-processes the full history each turn. Follow-up phase. |
+
+## Configuration
+
+```yaml
+agent:
+  type: azure-openai
+  model: gpt-4.1
+  compaction:
+    is_enabled: true                    # default true; disable for traceability/regulated runs
+    threshold_iterations: 8             # fire once iterations reach this
+    max_context_tokens: 80000           # fire once estimate reaches this
+    keep_recent_iterations: 3           # legacy field; OpenAi compactor keeps 2 complete rounds
+    summary_model: claude-haiku-4-5     # used by Claude compactor
+    deployment_name: gpt-4o-mini-deployment  # NEW p0114: route summarizer to a smaller deployment
+```
+
+`deployment_name` is the most impactful operator knob: compaction is summarization, which doesn't need the primary model. Routing it to `gpt-4o-mini-deployment` (or equivalent) cuts the summarization-call cost by ~5× without degrading the summary quality.
+
+## Failure handling
+
+Summarizer failures are **non-fatal**:
+
+- HTTP 429 (rate-limited summarizer deployment), 5xx, malformed response — caught at the compactor.
+- Compactor returns `OpenAiCompactionResult(messages: original, Event: ForFailure(...))` — agentic loop continues with un-compacted history.
+- Failure is logged at WARN with the original exception type + reason.
+
+Pretending compaction succeeded with a broken summary is worse than running on the full history.
+
+## Audit trail
+
+Every `CompactionEvent` carries a `PromptHash` (8-char SHA-256 prefix of the resolved summarization-prompt). Operators correlating output regressions to prompt drift can diff hashes across runs. The prompt is loaded via `IPromptCatalog.Get("openai-context-compactor-system")` — operators can override it locally via `IPromptOverrideSource` (consistent with all other prompts in the codebase).
+
+Log line for a successful compaction:
+
+```
+info  Compacted 24→3 messages; verified 18000 input tokens (saved est. 116000; summarizer cost 1200 tokens; prompt bae9264d)
+```
+
+The `verified` figure is the next API response's `usage.prompt_tokens` — ground truth, not estimate.
+
+## Sequence assumption
+
+The compaction point fires **synchronously between rounds**, never mid-tool-call. Every call site has an inline comment:
+
+```csharp
+// COMPACTION POINT — runs synchronously between rounds, after a complete
+// assistant→tool-results round. Must NEVER fire while a tool_call is
+// in-flight or unanswered. Future parallelization of the agentic loop
+// must move this point or guard it explicitly.
+```
+
+If the agentic loop ever gets parallel-fanout for independent tool calls, this assumption breaks and the compaction point must be moved or guarded.

--- a/docs/concepts/spawned-jobs.md
+++ b/docs/concepts/spawned-jobs.md
@@ -1,0 +1,95 @@
+# Spawned Jobs
+
+Queue-driven pipeline runs (webhook + poll) execute in **ephemeral CLI containers** spawned per run, not in-process inside the Server pod. The Server is orchestration: it polls, claims, queues, dispatches, and tracks lifecycle. The actual pipeline — git operations, agentic LLM rounds, test execution — runs in a per-run container that has the project's toolchain (dotnet SDK, git, etc.).
+
+This page documents the cross-process flow, the recovery story, and the contracts between the two halves.
+
+## Why ephemeral containers
+
+The Server pod is fundamentally a dispatcher. Running pipelines in-process means its container needs every language's toolchain (dotnet SDK, npm, python, …) for steps like `TestCommand`. That doesn't scale across a multi-language platform — and the architectural intent has always been ephemeral job containers per run. The chat-intent path (Slack/Teams) already uses `IJobSpawner` for this; **p0113** closes the gap on the queue path.
+
+## The two halves
+
+```
+┌──────────────────────────── Server pod ──────────────────────────┐
+│                                                                  │
+│   webhook / poll                                                 │
+│        │                                                         │
+│        ▼                                                         │
+│   TicketClaimService ──── Pending → Enqueued ───────► Redis      │
+│        │                                              queue      │
+│        │                                              │          │
+│        ▼                                              ▼          │
+│   PipelineQueueConsumer ◄──────────────── dequeues ──┘          │
+│        │                                                         │
+│        ▼                                                         │
+│   IPipelineJobDispatcher                                         │
+│   (JobSpawnerPipelineDispatcher)                                 │
+│        │                                                         │
+│        ├── 1. SaveAsync(jobId, request) ──► Redis (1h TTL)       │
+│        │                                                         │
+│        └── 2. SpawnQueueJobAsync(jobId, redisUrl, configPath)    │
+│                                       │                          │
+└───────────────────────────────────────┼──────────────────────────┘
+                                        │ (Docker run / K8s Job)
+                                        ▼
+┌──────────────────────────── CLI container ──────────────────────┐
+│                                                                  │
+│   agent-smith run-claimed-job                                    │
+│       --job-id <id>                                              │
+│       --redis-url <url>                                          │
+│       --config /app/config/agentsmith.yml                        │
+│                                                                  │
+│   1. Connect to Redis                                            │
+│   2. IPipelineRequestStore.LoadAsync(jobId) ──► PipelineRequest  │
+│   3. ExecutePipelineUseCase.ExecuteAsync(request, configPath)    │
+│   4. Lifecycle: Enqueued → InProgress → Done | Failed            │
+│                                                                  │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+## Why Redis-handoff (not CLI args)
+
+`PipelineRequest` carries structured fields: `ProjectName`, `PipelineName`, `TicketId`, `IsInit`, `Headless`, plus a `Context` dictionary that some flows populate (e.g. `ScanBranch`). Stuffing this through CLI args is fragile — escaping issues, shell quoting on different platforms, length limits, and the `Context` dictionary doesn't have a clean argv encoding.
+
+The Server stores the request as JSON under `agentsmith:pipeline-request:{jobId}` with a 1h TTL. The container's CLI args stay short — just the jobId, the Redis URL, and the config path. The container loads the structured request and calls the **structured** `ExecutePipelineUseCase.ExecuteAsync(PipelineRequest, ...)` overload directly — bypassing the intent parser that the Slack-flow uses.
+
+The 1h TTL is a soft contract: spawn must complete and the container must load the request within the hour. Long-running pipelines are unaffected — they've already moved past the load-and-discard phase by then.
+
+## Lifecycle across the boundary
+
+| Transition | Side | Detail |
+|------------|------|--------|
+| Pending → Enqueued | Server (`TicketClaimService`) | SETNX claim-lock; atomic per ticket |
+| Enqueued → InProgress | **Container** (via `PipelineExecutor` inside `ExecutePipelineUseCase`) | First lifecycle write inside the spawned container |
+| InProgress → Done / Failed | **Container** (via `LifecycleScope.Dispose`) | At pipeline end |
+
+Between the Server's `Enqueued` write and the container's `InProgress` write sits the **spawn window** — if `SpawnQueueJobAsync` succeeds but the container fails to start (image pull error, K8s quota, Docker daemon down), or starts but never reaches the lifecycle code (config load throws, DI build fails), the ticket would stay `Enqueued` forever without intervention.
+
+`EnqueuedReconciler` (existing, p0095c) is the load-bearing recovery: it sweeps `Enqueued` tickets without active heartbeat back to `Pending` after the configured stale-window (default 10 min). That window is short enough for actionable recovery, long enough that slow-starting containers don't get reset mid-spawn.
+
+## What this MVP ships (p0113a)
+
+- **`IPipelineJobDispatcher`** (Application/Contracts) — the abstraction PipelineQueueConsumer depends on
+- **`JobSpawnerPipelineDispatcher`** (Server) — generates jobId, persists request via `IPipelineRequestStore`, calls `IJobSpawner.SpawnQueueJobAsync`
+- **`IPipelineRequestStore` + `RedisPipelineRequestStore`** — the Redis-backed handoff
+- **`IJobSpawner.SpawnQueueJobAsync`** — added to both `DockerJobSpawner` and `KubernetesJobSpawner`
+- **`run-claimed-job`** — hidden CLI subcommand the spawned container runs
+- **`PipelineQueueConsumer`** — switched from in-process `ExecutePipelineUseCase` invocation to `IPipelineJobDispatcher.DispatchAsync`
+
+## What is deferred to p0113b
+
+- **`SecretsForwardingPolicy`** whitelist — explicit env-var allow-list crossing the spawn boundary. Today: hard-coded list inside each spawner.
+- **`JobRequest.ImageOverride` resolution chain** (`request → pipeline → default`) for projects needing per-language toolchain images.
+- **Heartbeat-gap mitigation**: write the first heartbeat **before** the DI build inside `run-claimed-job` so a DI-build crash doesn't ghost the ticket. Today: relies on `EnqueuedReconciler` to revert.
+- **`AGENTSMITH_TEST_FAIL_AFTER` env-var fail-injection** for reproducible CI of the persist+recovery paths.
+- **Server Dockerfile**: drop SDK if any remains (already aspnet:8.0); CLI Dockerfile remove `p4x` TODO comment.
+
+## Backpressure
+
+`PipelineQueueConsumer` keeps its `SemaphoreSlim` bounded by `QueueConfig.MaxParallel` (default 4). Post-refactor, this gates **concurrent dispatch calls** (each fast: one SETEX + one spawn API call), not in-flight pipeline count. The real binding constraint downstream is LLM-deployment quota, which scales with operator-side configuration (Azure OpenAI deployment, provider rate limits) — agent-smith does not enforce that bound centrally.
+
+## Related
+
+- [Ticket Lifecycle](ticket-lifecycle.md) — the full state machine and what survives what
+- [Pipeline System](pipeline-system.md) — command/handler model

--- a/docs/concepts/ticket-lifecycle.md
+++ b/docs/concepts/ticket-lifecycle.md
@@ -92,6 +92,7 @@ The lifecycle is the source of truth, so transitions must be atomic against conc
 |---------|-------------|------------------|
 | Receiver pod crash mid-claim | Nothing — claim is atomic per ticket | Next webhook/poll re-claims; the lock TTL is 30s |
 | Consumer pod crash mid-pipeline | Heartbeat stops renewing; ticket is left InProgress | StaleJobDetector reverts to Pending within 1 minute after TTL |
+| Pipeline command fails mid-run | Working tree on the consumer's `/tmp` is gone when the pod restarts | `PersistWorkBranchHandler` pushes a `[wip]` commit on `agent-smith/{ticketId}` before MarkFailed; next run resumes from `origin/{branch}` — see [Branch Persistence](branch-persistence.md) |
 | Redis loss + restart | Queue is empty, all heartbeats gone | EnqueuedReconciler re-enqueues every Enqueued ticket within 10 minutes; StaleJobDetector reverts orphaned InProgress within ~3 minutes |
 | Network partition between receiver and consumer pods | Nothing — receiver only enqueues, consumer pulls when reachable | Self-heals once partition lifts |
 | Operator manually deletes lifecycle label | Ticket appears Pending again | Next webhook/poll re-claims it |
@@ -109,6 +110,7 @@ To inspect lifecycle state for a project at a glance, list issues by label in th
 
 ## Related
 
+- [Branch Persistence](branch-persistence.md) — how partial pipeline work survives mid-run failures
 - [Polling Setup](../setup/polling.md) — opt-in per project
 - [Webhook Configuration](../configuration/webhooks.md) — claim flow and HTTP responses
 - [Polling vs Webhooks](../setup/polling-vs-webhooks.md) — when to choose which

--- a/docs/concepts/ticket-lifecycle.md
+++ b/docs/concepts/ticket-lifecycle.md
@@ -47,12 +47,12 @@ The `agent-smith:` prefix marks lifecycle labels owned by the framework. Other l
 
 | Transition | Owner | When |
 |------------|-------|------|
-| Pending → Enqueued | `TicketClaimService` | Webhook or poll fires; pre-checks pass; SETNX claim-lock acquired |
-| Enqueued → InProgress | `PipelineExecutor` | Consumer dequeues a `PipelineRequest`, before the first command runs |
-| InProgress → Done | `PipelineExecutor` (via `LifecycleScope.Dispose`) | All pipeline commands succeeded |
-| InProgress → Failed | `PipelineExecutor` (via `LifecycleScope.MarkFailed` + Dispose) | Any command failed; error comment posted to ticket |
-| InProgress → Pending | `StaleJobDetector` | No Redis heartbeat for the ticket and the consumer pod is gone — pipeline is presumed crashed |
-| Enqueued → Enqueued (re-push) | `EnqueuedReconciler` | Ticket is Enqueued but the queue has no entry and no in-flight pipeline owns it |
+| Pending → Enqueued | `TicketClaimService` (Server) | Webhook or poll fires; pre-checks pass; SETNX claim-lock acquired |
+| Enqueued → InProgress | `PipelineExecutor` (**inside the spawned CLI container**, p0113) | Container loads `PipelineRequest` from `IPipelineRequestStore` and starts the pipeline |
+| InProgress → Done | `PipelineExecutor` (container, via `LifecycleScope.Dispose`) | All pipeline commands succeeded |
+| InProgress → Failed | `PipelineExecutor` (container, via `LifecycleScope.MarkFailed` + Dispose) | Any command failed; error comment posted to ticket |
+| InProgress → Pending | `StaleJobDetector` | No Redis heartbeat for the ticket and the container is gone — pipeline is presumed crashed |
+| Enqueued → Pending | `EnqueuedReconciler` | Ticket is Enqueued but no container ever wrote a heartbeat — spawn failed or container crashed before lifecycle init (see [Spawned Jobs](spawned-jobs.md)) |
 
 ## Concurrency primitives
 
@@ -111,6 +111,7 @@ To inspect lifecycle state for a project at a glance, list issues by label in th
 ## Related
 
 - [Branch Persistence](branch-persistence.md) — how partial pipeline work survives mid-run failures
+- [Spawned Jobs](spawned-jobs.md) — how the cross-process boundary is wired
 - [Polling Setup](../setup/polling.md) — opt-in per project
 - [Webhook Configuration](../configuration/webhooks.md) — claim flow and HTTP responses
 - [Polling vs Webhooks](../setup/polling-vs-webhooks.md) — when to choose which

--- a/docs/configuration/agentsmith-yml.md
+++ b/docs/configuration/agentsmith-yml.md
@@ -40,12 +40,19 @@ projects:
         is_enabled: true
         strategy: automatic
 
-      compaction:                   # Context window management
+      compaction:                   # Context window management — see docs/concepts/context-compaction.md
         is_enabled: true
-        threshold_iterations: 8     # Compact after N agentic loop iterations
-        max_context_tokens: 80000   # Target token limit
-        keep_recent_iterations: 3   # Preserve last N iterations verbatim
-        summary_model: claude-haiku-4-5-20251001
+        threshold_iterations: 8     # Fire when iterations >= N (boolean OR with max_context_tokens)
+        max_context_tokens: 80000   # Fire when estimated tokens >= N (boolean OR with threshold_iterations)
+        keep_recent_iterations: 3   # Claude compactor knob; OpenAi compactor keeps 2 complete tool-call rounds
+        summary_model: claude-haiku-4-5-20251001  # Claude compactor — summarizer model
+        deployment_name: gpt-4o-mini-deployment   # OpenAI/Azure compactor — summarizer deployment override (cheaper than primary)
+        # Provider availability:
+        #   claude        ✓  ClaudeContextCompactor (p0008)
+        #   openai        ✓  OpenAiContextCompactor (p0114)
+        #   azure-openai  ✓  OpenAiContextCompactor (p0114)
+        #   gemini        ✗  NoOp placeholder — same long-loop cost; follow-up phase
+        #   ollama        ✗  NoOp placeholder — same long-loop cost; follow-up phase
 
       models:                       # Multi-model routing (optional)
         scout:

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -93,6 +93,7 @@ nav:
     - concepts/index.md
     - Pipeline System: concepts/pipeline-system.md
     - Ticket Lifecycle: concepts/ticket-lifecycle.md
+    - Branch Persistence: concepts/branch-persistence.md
     - Phases & Runs: concepts/phases-and-runs.md
     - Self-Documentation: concepts/self-documentation.md
     - Multi-Agent Orchestration: concepts/multi-agent-orchestration.md

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -97,6 +97,7 @@ nav:
     - Self-Documentation: concepts/self-documentation.md
     - Multi-Agent Orchestration: concepts/multi-agent-orchestration.md
     - Triage: concepts/triage.md
+    - Context Compaction: concepts/context-compaction.md
     - Multi-Skill Architecture: concepts/multi-skill.md
     - Decision Logging: concepts/decisions.md
     - Cost Tracking: concepts/cost-tracking.md

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -94,6 +94,7 @@ nav:
     - Pipeline System: concepts/pipeline-system.md
     - Ticket Lifecycle: concepts/ticket-lifecycle.md
     - Branch Persistence: concepts/branch-persistence.md
+    - Spawned Jobs: concepts/spawned-jobs.md
     - Phases & Runs: concepts/phases-and-runs.md
     - Self-Documentation: concepts/self-documentation.md
     - Multi-Agent Orchestration: concepts/multi-agent-orchestration.md

--- a/src/AgentSmith.Application/Extensions/ServiceCollectionExtensions.cs
+++ b/src/AgentSmith.Application/Extensions/ServiceCollectionExtensions.cs
@@ -76,6 +76,7 @@ public static class ServiceCollectionExtensions
         services.AddTransient<StructuredTriageStrategy>();
         services.AddTransient<ITriageStrategySelector, TriageStrategySelector>();
         services.AddTransient<ICommandHandler<PhaseAdvanceContext>, PhaseAdvanceHandler>();
+        services.AddTransient<ICommandHandler<PersistWorkBranchContext>, PersistWorkBranchHandler>();
         services.AddTransient<PlanConsolidator>();
         services.AddTransient<ICommandHandler<ConvergenceCheckContext>, ConvergenceCheckHandler>();
         services.AddTransient<ICommandHandler<GenerateTestsContext>, GenerateTestsHandler>();
@@ -145,6 +146,7 @@ public static class ServiceCollectionExtensions
         AddBuilder<FilterRoundContextBuilder>(services, CommandNames.FilterRound);
         AddBuilder<RunReviewPhaseContextBuilder>(services, CommandNames.RunReviewPhase);
         AddBuilder<RunFinalPhaseContextBuilder>(services, CommandNames.RunFinalPhase);
+        AddBuilder<PersistWorkBranchContextBuilder>(services, CommandNames.PersistWorkBranch);
         AddBuilder<ConvergenceCheckContextBuilder>(services, CommandNames.ConvergenceCheck);
         AddBuilder<GenerateTestsContextBuilder>(services, CommandNames.GenerateTests);
         AddBuilder<GenerateDocsContextBuilder>(services, CommandNames.GenerateDocs);

--- a/src/AgentSmith.Application/Models/PersistWorkBranchContext.cs
+++ b/src/AgentSmith.Application/Models/PersistWorkBranchContext.cs
@@ -1,0 +1,13 @@
+using AgentSmith.Contracts.Commands;
+using AgentSmith.Contracts.Models.Configuration;
+
+namespace AgentSmith.Application.Models;
+
+/// <summary>
+/// Context for the PersistWorkBranchCommand — runs in the pipeline's failure path
+/// when local changes exist that would otherwise be lost with the container's /tmp.
+/// </summary>
+public sealed record PersistWorkBranchContext(
+    SourceConfig Source,
+    AgentConfig AgentConfig,
+    PipelineContext Pipeline) : ICommandContext;

--- a/src/AgentSmith.Application/Prompts/Resources/openai-context-compactor-system.md
+++ b/src/AgentSmith.Application/Prompts/Resources/openai-context-compactor-system.md
@@ -1,0 +1,16 @@
+You are a context compactor. Summarize the following conversation history between an AI assistant and tool calls into a single concise paragraph.
+
+Preserve:
+- The original user task / goal.
+- Every file path that was read, modified, or referenced.
+- Key decisions made and the reasoning behind them.
+- Error messages encountered and how they were resolved (or that they remain unresolved).
+- The current state of the implementation: what's done, what's in progress, what's next.
+
+Drop:
+- Raw file contents (just note which files were read).
+- Redundant or repeated tool-call/result pairs.
+- Verbose command output (note the outcome only).
+- Internal monologue from the assistant that doesn't carry decisions or state.
+
+Format: a single paragraph of plain text. No markdown headings, no JSON, no lists. The summary will be inserted as a [Context Summary] message before the recent conversation tail. Be precise and complete; an assistant reading only the summary should be able to continue the work without surprise.

--- a/src/AgentSmith.Application/Services/Builders/PersistWorkBranchContextBuilder.cs
+++ b/src/AgentSmith.Application/Services/Builders/PersistWorkBranchContextBuilder.cs
@@ -1,0 +1,13 @@
+using AgentSmith.Application.Models;
+using AgentSmith.Contracts.Commands;
+using AgentSmith.Contracts.Models.Configuration;
+using AgentSmith.Contracts.Services;
+using AgentSmith.Domain.Models;
+
+namespace AgentSmith.Application.Services.Builders;
+
+public sealed class PersistWorkBranchContextBuilder : IContextBuilder
+{
+    public ICommandContext Build(PipelineCommand command, ProjectConfig project, PipelineContext pipeline)
+        => new PersistWorkBranchContext(project.Source, pipeline.Resolved().Agent, pipeline);
+}

--- a/src/AgentSmith.Application/Services/Builders/SourceContextBuilders.cs
+++ b/src/AgentSmith.Application/Services/Builders/SourceContextBuilders.cs
@@ -23,7 +23,7 @@ public sealed class CheckoutSourceContextBuilder : IContextBuilder
         var branch = pipeline.TryGet<string>(ContextKeys.CheckoutBranch, out var b) && !string.IsNullOrWhiteSpace(b)
             ? new BranchName(b)
             : pipeline.TryGet<TicketId>(ContextKeys.TicketId, out var ticketId)
-                ? BranchName.FromTicket(ticketId!)
+                ? TicketBranchNamer.Compose(ticketId!)
                 : null;
 
         return new CheckoutSourceContext(project.Source, branch, pipeline);

--- a/src/AgentSmith.Application/Services/Handlers/PersistWorkBranchHandler.cs
+++ b/src/AgentSmith.Application/Services/Handlers/PersistWorkBranchHandler.cs
@@ -1,0 +1,105 @@
+using AgentSmith.Application.Models;
+using AgentSmith.Contracts.Commands;
+using AgentSmith.Contracts.Models.Configuration;
+using AgentSmith.Contracts.Models.Lifecycle;
+using AgentSmith.Contracts.Providers;
+using AgentSmith.Domain.Models;
+using Microsoft.Extensions.Logging;
+using Repository = AgentSmith.Domain.Entities.Repository;
+
+namespace AgentSmith.Application.Services.Handlers;
+
+/// <summary>
+/// Pushes the work branch when the pipeline failed mid-run after local changes
+/// exist. Stamps the failure kind into <see cref="ContextKeys.PersistFailureKind"/>
+/// on the pipeline context so the executor's wrapper can route logs accordingly.
+/// </summary>
+public sealed class PersistWorkBranchHandler(
+    ISourceProviderFactory sourceProviderFactory,
+    ILogger<PersistWorkBranchHandler> logger) : ICommandHandler<PersistWorkBranchContext>
+{
+    public async Task<CommandResult> ExecuteAsync(
+        PersistWorkBranchContext context, CancellationToken cancellationToken)
+    {
+        var pipeline = context.Pipeline;
+        if (!pipeline.TryGet<Repository>(ContextKeys.Repository, out var repo) || repo is null)
+            return RecordAndFail(pipeline, PersistFailureKind.Unknown,
+                "PersistWorkBranch: no Repository in pipeline context");
+
+        var commitMessage = BuildCommitMessage(pipeline);
+        var provider = sourceProviderFactory.Create(context.Source);
+
+        try
+        {
+            await provider.CommitAndPushAsync(repo, commitMessage, cancellationToken);
+            logger.LogInformation(
+                "PersistWorkBranch: pushed WIP commit on branch {Branch}", repo.CurrentBranch);
+            return CommandResult.Ok($"Persisted WIP branch {repo.CurrentBranch}");
+        }
+        catch (Exception ex) when (LooksLikeEmptyCommit(ex))
+        {
+            logger.LogInformation("PersistWorkBranch: working tree clean — nothing to persist");
+            return RecordAndFail(pipeline, PersistFailureKind.NoChanges,
+                "No local changes to persist");
+        }
+        catch (Exception ex) when (LooksLikeAuth(ex))
+        {
+            logger.LogError(ex, "PersistWorkBranch: auth denied on push");
+            return RecordAndFail(pipeline, PersistFailureKind.AuthDenied,
+                $"Persist failed (auth denied): {ex.Message}", ex);
+        }
+        catch (Exception ex) when (LooksLikeDivergent(ex))
+        {
+            logger.LogError(ex, "PersistWorkBranch: remote diverged — refusing to force-push");
+            return RecordAndFail(pipeline, PersistFailureKind.RemoteDivergent,
+                $"Persist failed (remote diverged, no force-push): {ex.Message}", ex);
+        }
+        catch (HttpRequestException ex)
+        {
+            logger.LogWarning(ex, "PersistWorkBranch: transient network failure");
+            return RecordAndFail(pipeline, PersistFailureKind.NetworkBlip,
+                $"Persist failed (network): {ex.Message}", ex);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "PersistWorkBranch: unexpected failure");
+            return RecordAndFail(pipeline, PersistFailureKind.Unknown,
+                $"Persist failed: {ex.Message}", ex);
+        }
+    }
+
+    private static CommandResult RecordAndFail(
+        PipelineContext pipeline, PersistFailureKind kind, string message, Exception? exception = null)
+    {
+        pipeline.Set(ContextKeys.PersistFailureKind, kind);
+        return CommandResult.Fail(message, exception);
+    }
+
+    private static string BuildCommitMessage(PipelineContext pipeline)
+    {
+        var runId = pipeline.TryGet<string>(ContextKeys.RunId, out var rid) ? rid : "unknown";
+        var pipelineName = pipeline.TryGet<ResolvedPipelineConfig>(
+            ContextKeys.ResolvedPipeline, out var resolved) && resolved is not null
+            ? resolved.PipelineName : "unknown";
+        var failedStep = pipeline.TryGet<string>(ContextKeys.FailedStepName, out var fs) ? fs : "unknown";
+        return $"[wip] agent-smith run {runId}\n\n" +
+               $"Run-Id: {runId}\n" +
+               $"Pipeline: {pipelineName}\n" +
+               $"Failed-Step: {failedStep}\n";
+    }
+
+    private static bool LooksLikeEmptyCommit(Exception ex) =>
+        ex.GetType().Name.Contains("EmptyCommit", StringComparison.OrdinalIgnoreCase)
+        || ex.Message.Contains("nothing to commit", StringComparison.OrdinalIgnoreCase)
+        || ex.Message.Contains("no changes", StringComparison.OrdinalIgnoreCase);
+
+    private static bool LooksLikeAuth(Exception ex) =>
+        ex.Message.Contains("authentication", StringComparison.OrdinalIgnoreCase)
+        || ex.Message.Contains("401")
+        || ex.Message.Contains("403")
+        || ex.Message.Contains("unauthorized", StringComparison.OrdinalIgnoreCase);
+
+    private static bool LooksLikeDivergent(Exception ex) =>
+        ex.Message.Contains("non-fast-forward", StringComparison.OrdinalIgnoreCase)
+        || ex.Message.Contains("rejected", StringComparison.OrdinalIgnoreCase);
+}

--- a/src/AgentSmith.Application/Services/PipelineExecutor.cs
+++ b/src/AgentSmith.Application/Services/PipelineExecutor.cs
@@ -72,6 +72,7 @@ public sealed class PipelineExecutor(
 
             if (!result.IsSuccess)
             {
+                await TryPersistWorkBranchAsync(projectConfig, context, result, cancellationToken);
                 lifecycle.MarkFailed();
                 return result;
             }
@@ -81,6 +82,40 @@ public sealed class PipelineExecutor(
 
         logger.LogInformation("Pipeline completed successfully");
         return CommandResult.Ok("Pipeline completed successfully");
+    }
+
+    /// <summary>
+    /// Best-effort persist of the WIP branch when the pipeline fails after producing
+    /// local changes (p0112). Wrapped in its OWN try/catch so any persist exception
+    /// can NEVER overwrite the original failure cause already in <paramref name="originalFailure"/>.
+    /// </summary>
+    private async Task TryPersistWorkBranchAsync(
+        ProjectConfig projectConfig, PipelineContext context,
+        CommandResult originalFailure, CancellationToken cancellationToken)
+    {
+        try
+        {
+            // Stamp the failed step name into context for the WIP commit's trailer block.
+            context.Set(ContextKeys.FailedStepName, originalFailure.StepName);
+
+            // Skip persist for source-less / discussion-style runs.
+            if (!context.TryGet<AgentSmith.Domain.Entities.Repository>(ContextKeys.Repository, out _))
+                return;
+
+            var persistCmd = PipelineCommand.Simple(CommandNames.PersistWorkBranch);
+            var persistContext = contextFactory.Create(persistCmd, projectConfig, context);
+            var persistResult = await commandExecutor.ExecuteAsync(persistContext, cancellationToken);
+
+            if (persistResult.IsSuccess)
+                logger.LogInformation("Work branch persisted: {Message}", persistResult.Message);
+            else
+                logger.LogWarning("Work branch persist did not complete: {Message}", persistResult.Message);
+        }
+        catch (Exception ex)
+        {
+            // Never let a persist failure mask the original pipeline failure cause.
+            logger.LogError(ex, "Work branch persist threw an exception — original failure cause preserved");
+        }
     }
 
     internal static List<LinkedListNode<PipelineCommand>> PeelBatch(

--- a/src/AgentSmith.Application/Services/PipelineQueueConsumer.cs
+++ b/src/AgentSmith.Application/Services/PipelineQueueConsumer.cs
@@ -6,10 +6,14 @@ using Microsoft.Extensions.Logging;
 namespace AgentSmith.Application.Services;
 
 /// <summary>
-/// Pulls PipelineRequests off IRedisJobQueue and runs them with bounded concurrency
-/// (SemaphoreSlim = backpressure knob). On shutdown, stops pulling and waits up to
-/// shutdownGraceSeconds for in-flight pipelines to finish (so they can transition to Failed
-/// and release their heartbeat once p95c lands).
+/// p0113: Pulls PipelineRequests off IRedisJobQueue and dispatches them to
+/// ephemeral CLI containers via IPipelineJobDispatcher. The Server pod is
+/// orchestration-only — language toolchains live in the per-run job container.
+///
+/// SemaphoreSlim bounds concurrent dispatch calls (fast — SETEX + spawn API).
+/// In-flight pipeline count downstream is governed by the cluster (K8s/Docker
+/// capacity), not this knob. On shutdown, waits up to shutdownGraceSeconds
+/// for in-flight dispatch calls to settle.
 /// </summary>
 public sealed class PipelineQueueConsumer(
     IServiceProvider services,
@@ -19,12 +23,17 @@ public sealed class PipelineQueueConsumer(
     int shutdownGraceSeconds,
     ILogger<PipelineQueueConsumer> logger)
 {
+    // configPath is unused post-p0113 (dispatch carries the path through the
+    // Server's ServerContext). Retained on the constructor so the hosted-service
+    // wiring stays stable; can be dropped in a follow-up.
+    private readonly string _configPath = configPath;
+
     public async Task RunAsync(CancellationToken cancellationToken)
     {
         using var semaphore = new SemaphoreSlim(maxParallelJobs);
         var inFlight = new List<Task>();
         logger.LogInformation(
-            "PipelineQueueConsumer started (max parallel: {Max}, grace: {Grace}s)",
+            "PipelineQueueConsumer started (max parallel dispatches: {Max}, grace: {Grace}s)",
             maxParallelJobs, shutdownGraceSeconds);
 
         try
@@ -33,7 +42,7 @@ public sealed class PipelineQueueConsumer(
             {
                 await semaphore.WaitAsync(cancellationToken);
                 logger.LogInformation(
-                    "Dequeued: {Project}/#{Ticket} pipeline={Pipeline} (in-flight: {InFlight}/{Max})",
+                    "Dequeued: {Project}/#{Ticket} pipeline={Pipeline} (in-flight dispatch: {InFlight}/{Max})",
                     request.ProjectName, request.TicketId?.Value ?? "—",
                     request.PipelineName, inFlight.Count(t => !t.IsCompleted) + 1, maxParallelJobs);
                 var task = Task.Run(
@@ -55,19 +64,17 @@ public sealed class PipelineQueueConsumer(
         try
         {
             using var scope = services.CreateScope();
-            var useCase = scope.ServiceProvider.GetRequiredService<ExecutePipelineUseCase>();
-            var result = await useCase.ExecuteAsync(request, configPath, ct);
-            logger.Log(
-                result.IsSuccess ? LogLevel.Information : LogLevel.Warning,
-                "Pipeline {Outcome}: {Project}/{Ticket} — {Msg}",
-                result.IsSuccess ? "succeeded" : "failed",
-                request.ProjectName, request.TicketId?.Value, result.Message);
+            var dispatcher = scope.ServiceProvider.GetRequiredService<IPipelineJobDispatcher>();
+            var jobId = await dispatcher.DispatchAsync(request, ct);
+            logger.LogInformation(
+                "Dispatched: {Project}/{Ticket} job={JobId}",
+                request.ProjectName, request.TicketId?.Value ?? "—", jobId);
         }
         catch (Exception ex)
         {
             logger.LogError(ex,
-                "Pipeline execution error for {Project}/{Ticket}",
-                request.ProjectName, request.TicketId?.Value);
+                "Dispatch failed for {Project}/{Ticket} — request remains claimed; reconciler will recover",
+                request.ProjectName, request.TicketId?.Value ?? "—");
         }
         finally
         {

--- a/src/AgentSmith.Application/Services/TicketBranchNamer.cs
+++ b/src/AgentSmith.Application/Services/TicketBranchNamer.cs
@@ -1,0 +1,56 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.RegularExpressions;
+using AgentSmith.Domain.Exceptions;
+using AgentSmith.Domain.Models;
+
+namespace AgentSmith.Application.Services;
+
+/// <summary>
+/// Static helper for the agent-smith work-branch naming convention.
+/// Single-segment (<c>agent-smith/&lt;ticketId&gt;</c>) when no project context is provided —
+/// sufficient for one-repo-per-ticket-system deployments (the AAD-DEV pattern).
+/// Future deployments can pass platform + projectName for the hierarchical
+/// <c>agent-smith/&lt;platform&gt;/&lt;projectSlug&gt;/&lt;ticketId&gt;</c> form.
+/// </summary>
+public static class TicketBranchNamer
+{
+    public const string Prefix = "agent-smith";
+    private const int MaxSlugChars = 64;
+    private const int MaxBranchChars = 200;
+    private static readonly Regex NonAlnum = new(@"[^a-z0-9]+", RegexOptions.Compiled);
+
+    /// <summary>Single-segment form for one-repo-per-ticket setups.</summary>
+    public static BranchName Compose(TicketId ticketId) =>
+        new($"{Prefix}/{ticketId.Value}");
+
+    /// <summary>Hierarchical form. Throws ConfigurationException when projectName slugifies to empty.</summary>
+    public static BranchName Compose(string platform, string projectName, TicketId ticketId)
+    {
+        if (string.IsNullOrWhiteSpace(projectName))
+            throw new ConfigurationException("projectName must not be empty");
+        var platformSlug = Slugify(platform);
+        var projectSlug = Slugify(projectName);
+        if (string.IsNullOrEmpty(projectSlug))
+            throw new ConfigurationException(
+                $"projectName '{projectName}' produced empty slug after sanitization");
+        if (projectSlug.Length > MaxSlugChars)
+            projectSlug = TruncateWithHash(projectSlug);
+        var branch = $"{Prefix}/{platformSlug}/{projectSlug}/{ticketId.Value}";
+        if (branch.Length > MaxBranchChars)
+            throw new ConfigurationException(
+                $"Composed branch name exceeds {MaxBranchChars} chars: '{branch}'");
+        return new BranchName(branch);
+    }
+
+    private static string Slugify(string input) =>
+        NonAlnum.Replace(input.ToLowerInvariant(), "-").Trim('-');
+
+    private static string TruncateWithHash(string slug)
+    {
+        var bytes = SHA1.HashData(Encoding.UTF8.GetBytes(slug));
+        var hash = Convert.ToHexString(bytes)[..7].ToLowerInvariant();
+        var head = slug[..(MaxSlugChars - 8)];
+        return $"{head}-{hash}";
+    }
+}

--- a/src/AgentSmith.Cli/Commands/RunClaimedJobCommand.cs
+++ b/src/AgentSmith.Cli/Commands/RunClaimedJobCommand.cs
@@ -1,0 +1,84 @@
+using System.CommandLine;
+using System.CommandLine.Invocation;
+using AgentSmith.Application.Services;
+using AgentSmith.Contracts.Services;
+using AgentSmith.Domain.Models;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace AgentSmith.Cli.Commands;
+
+/// <summary>
+/// p0113: Hidden CLI subcommand used by Server-spawned containers to pick up a
+/// queue-claimed PipelineRequest. Server saves the structured request under a
+/// jobId via IPipelineRequestStore; this command loads it and drives the
+/// pipeline via the structured ExecutePipelineUseCase overload — no string
+/// round-tripping through the intent parser.
+///
+/// Reachable for debugging via:
+///   agent-smith run-claimed-job --job-id &lt;id&gt; --redis-url &lt;url&gt; --config &lt;path&gt;
+/// (hidden from --help).
+/// </summary>
+internal static class RunClaimedJobCommand
+{
+    public static Command Create(Option<string> configOption, Option<bool> verboseOption)
+    {
+        var jobIdOption = new Option<string>("--job-id", "Job id assigned by the dispatcher") { IsRequired = true };
+        var redisUrlOption = new Option<string>("--redis-url", "Redis connection URL") { IsRequired = true };
+
+        var cmd = new Command("run-claimed-job", "Internal: pick up a queue-claimed pipeline job (hidden)")
+        {
+            jobIdOption, redisUrlOption, configOption, verboseOption,
+        };
+        cmd.IsHidden = true;
+
+        cmd.SetHandler(async (InvocationContext ctx) =>
+        {
+            var jobId = ctx.ParseResult.GetValueForOption(jobIdOption)!;
+            var redisUrl = ctx.ParseResult.GetValueForOption(redisUrlOption)!;
+            var configPath = ctx.ParseResult.GetValueForOption(configOption)!;
+            var verbose = ctx.ParseResult.GetValueForOption(verboseOption);
+
+            var provider = ServiceProviderFactory.Build(
+                verbose, headless: true, jobId: jobId, redisUrl: redisUrl, configPath: configPath);
+            var logger = provider.GetRequiredService<ILogger<Program>>();
+
+            var store = provider.GetRequiredService<IPipelineRequestStore>();
+            var request = await store.LoadAsync(jobId, CancellationToken.None);
+            if (request is null)
+            {
+                logger.LogError(
+                    "PipelineRequest for job {JobId} not found in Redis (key missing or expired). " +
+                    "Exiting non-zero so the orchestrator marks the job failed.",
+                    jobId);
+                ctx.ExitCode = 2;
+                return;
+            }
+
+            logger.LogInformation(
+                "Picked up job {JobId}: {Project}/#{Ticket} pipeline={Pipeline}",
+                jobId, request.ProjectName, request.TicketId?.Value ?? "—", request.PipelineName);
+
+            CommandResult result;
+            try
+            {
+                var useCase = provider.GetRequiredService<ExecutePipelineUseCase>();
+                result = await useCase.ExecuteAsync(request, configPath, CancellationToken.None);
+            }
+            catch (Exception ex)
+            {
+                result = CommandResult.Fail($"Unhandled exception: {ex.Message}");
+                logger.LogError(ex, "Pipeline execution threw for job {JobId}", jobId);
+            }
+
+            if (result.IsSuccess)
+                logger.LogInformation("Job {JobId} succeeded: {Message}", jobId, result.Message);
+            else
+                logger.LogWarning("Job {JobId} failed: {Message}", jobId, result.Message);
+
+            ctx.ExitCode = result.IsSuccess ? 0 : 1;
+        });
+
+        return cmd;
+    }
+}

--- a/src/AgentSmith.Cli/Program.cs
+++ b/src/AgentSmith.Cli/Program.cs
@@ -24,6 +24,7 @@ var rootCommand = new RootCommand("Agent Smith — self-hosted AI orchestration"
     AutonomousCommand.Create(configOption, verboseOption),
     SkillsCommand.Create(configOption, verboseOption),
     runCommand,
+    RunClaimedJobCommand.Create(configOption, verboseOption),
 };
 
 return await rootCommand.InvokeAsync(args);

--- a/src/AgentSmith.Cli/ServiceProviderFactory.cs
+++ b/src/AgentSmith.Cli/ServiceProviderFactory.cs
@@ -8,6 +8,7 @@ using AgentSmith.Infrastructure;
 using AgentSmith.Infrastructure.Models;
 using AgentSmith.Infrastructure.Services.Bus;
 using AgentSmith.Infrastructure.Services.Dialogue;
+using AgentSmith.Infrastructure.Services.Queue;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using StackExchange.Redis;
@@ -53,6 +54,7 @@ internal static class ServiceProviderFactory
             services.AddSingleton<IConnectionMultiplexer>(multiplexer);
             services.AddSingleton<IMessageBus, RedisMessageBus>();
             services.AddSingleton<IDialogueTransport, RedisDialogueTransport>();
+            services.AddSingleton<IPipelineRequestStore, RedisPipelineRequestStore>();
             services.AddSingleton<IProgressReporter>(sp =>
                 new RedisProgressReporter(
                     sp.GetRequiredService<IMessageBus>(), jobId,

--- a/src/AgentSmith.Contracts/Commands/CommandNames.cs
+++ b/src/AgentSmith.Contracts/Commands/CommandNames.cs
@@ -67,6 +67,9 @@ public static class CommandNames
     public const string RunReviewPhase = "RunReviewPhaseCommand";
     public const string RunFinalPhase = "RunFinalPhaseCommand";
 
+    // p0112: branch persistence — pipeline-failure recovery commit + push
+    public const string PersistWorkBranch = "PersistWorkBranchCommand";
+
     public static string GetLabel(string commandName)
     {
         if (Labels.TryGetValue(commandName, out var label))
@@ -141,5 +144,6 @@ public static class CommandNames
         [FilterRound] = "Filter round",
         [RunReviewPhase] = "Running review phase",
         [RunFinalPhase] = "Running final phase",
+        [PersistWorkBranch] = "Persisting work branch",
     };
 }

--- a/src/AgentSmith.Contracts/Commands/ContextKeys.cs
+++ b/src/AgentSmith.Contracts/Commands/ContextKeys.cs
@@ -100,4 +100,12 @@ public static class ContextKeys
     /// <summary>Short correlation id (8 hex chars) generated per pipeline run, attached as
     /// log scope so concurrent runs are filterable in shared log streams.</summary>
     public const string RunId = "RunId";
+
+    /// <summary>Display label of the pipeline step that failed (set by PipelineExecutor before
+    /// the failure-recovery wrapper invokes PersistWorkBranchHandler). Used in WIP commit trailer.</summary>
+    public const string FailedStepName = "FailedStepName";
+
+    /// <summary>Typed PersistFailureKind set by PersistWorkBranchHandler before returning Fail.
+    /// Read by PipelineExecutor's wrapper for log-level routing and counter escalation.</summary>
+    public const string PersistFailureKind = "PersistFailureKind";
 }

--- a/src/AgentSmith.Contracts/Models/Compaction/CompactionEvent.cs
+++ b/src/AgentSmith.Contracts/Models/Compaction/CompactionEvent.cs
@@ -1,0 +1,36 @@
+namespace AgentSmith.Contracts.Models.Compaction;
+
+/// <summary>
+/// Telemetry record emitted by a context compactor on each fire (success or failure).
+/// Pre-compaction estimate drives the trigger decision; post-compaction value is the
+/// authoritative <c>usage.prompt_tokens</c> from the next API response, populated when
+/// the agentic loop makes the next chat-completions call.
+/// </summary>
+public sealed record CompactionEvent(
+    int OldMessageCount,
+    int NewMessageCount,
+    int PreCompactionEstimatedTokens,
+    int? PostCompactionVerifiedTokens,
+    int SummarizationCallTokens,
+    string PromptHash,
+    bool Failed,
+    string? FailureReason)
+{
+    public int? VerifiedSavedTokens =>
+        PostCompactionVerifiedTokens is null ? null
+        : PreCompactionEstimatedTokens - PostCompactionVerifiedTokens.Value;
+
+    public CompactionEvent WithVerifiedTokens(int verifiedTokens) =>
+        this with { PostCompactionVerifiedTokens = verifiedTokens };
+
+    public static CompactionEvent ForFailure(int oldCount, int estimatedTokens, string promptHash, string reason) =>
+        new(
+            OldMessageCount: oldCount,
+            NewMessageCount: oldCount, // unchanged on failure
+            PreCompactionEstimatedTokens: estimatedTokens,
+            PostCompactionVerifiedTokens: null,
+            SummarizationCallTokens: 0,
+            PromptHash: promptHash,
+            Failed: true,
+            FailureReason: reason);
+}

--- a/src/AgentSmith.Contracts/Models/Configuration/CompactionConfig.cs
+++ b/src/AgentSmith.Contracts/Models/Configuration/CompactionConfig.cs
@@ -11,4 +11,12 @@ public sealed class CompactionConfig
     public int MaxContextTokens { get; set; } = 80000;
     public int KeepRecentIterations { get; set; } = 3;
     public string SummaryModel { get; set; } = "claude-haiku-4-5-20251001";
+
+    /// <summary>
+    /// Optional deployment-name override for the compactor's summarization call (OpenAI / Azure OpenAI).
+    /// Null falls back to the agent's Primary deployment. Set to a smaller-model deployment
+    /// (e.g. <c>gpt-4o-mini-deployment</c>) to reduce compaction overhead. Compaction is summarization,
+    /// which doesn't need the full primary-task model.
+    /// </summary>
+    public string? DeploymentName { get; set; }
 }

--- a/src/AgentSmith.Contracts/Models/Lifecycle/PersistFailureKind.cs
+++ b/src/AgentSmith.Contracts/Models/Lifecycle/PersistFailureKind.cs
@@ -1,0 +1,15 @@
+namespace AgentSmith.Contracts.Models.Lifecycle;
+
+/// <summary>
+/// Categorises why a PersistWorkBranchHandler invocation failed.
+/// NetworkBlip is transient; everything else accumulates in PersistFailureCounter
+/// and escalates after the configured threshold.
+/// </summary>
+public enum PersistFailureKind
+{
+    NoChanges,
+    AuthDenied,
+    RemoteDivergent,
+    NetworkBlip,
+    Unknown
+}

--- a/src/AgentSmith.Contracts/Services/IPipelineJobDispatcher.cs
+++ b/src/AgentSmith.Contracts/Services/IPipelineJobDispatcher.cs
@@ -1,0 +1,21 @@
+using AgentSmith.Contracts.Models;
+
+namespace AgentSmith.Contracts.Services;
+
+/// <summary>
+/// Application-level abstraction over how a PipelineRequest is handed off
+/// for execution. Lets PipelineQueueConsumer (Application layer) stay
+/// independent of the spawn mechanism (Server layer).
+///
+/// Production binding: Server's JobSpawnerPipelineDispatcher generates a
+/// jobId, persists the request via IPipelineRequestStore, and spawns an
+/// ephemeral CLI container that loads the request by jobId.
+/// </summary>
+public interface IPipelineJobDispatcher
+{
+    /// <summary>
+    /// Hand off the request for execution. Returns the assigned jobId so the
+    /// caller can correlate logs / heartbeats with the spawned job.
+    /// </summary>
+    Task<string> DispatchAsync(PipelineRequest request, CancellationToken cancellationToken);
+}

--- a/src/AgentSmith.Contracts/Services/IPipelineRequestStore.cs
+++ b/src/AgentSmith.Contracts/Services/IPipelineRequestStore.cs
@@ -1,0 +1,18 @@
+using AgentSmith.Contracts.Models;
+
+namespace AgentSmith.Contracts.Services;
+
+/// <summary>
+/// p0113: cross-process handoff for queue-spawned jobs. Server saves the
+/// PipelineRequest under a jobId; the spawned CLI container loads it and
+/// runs the structured pipeline. CLI args stay short (jobId + redisUrl +
+/// configPath) — full request payload travels via Redis with a TTL guard.
+/// </summary>
+public interface IPipelineRequestStore
+{
+    /// <summary>Save the request under the given jobId. Existing key is overwritten.</summary>
+    Task SaveAsync(string jobId, PipelineRequest request, TimeSpan ttl, CancellationToken cancellationToken);
+
+    /// <summary>Returns null when the key is missing or expired.</summary>
+    Task<PipelineRequest?> LoadAsync(string jobId, CancellationToken cancellationToken);
+}

--- a/src/AgentSmith.Domain/Models/BranchName.cs
+++ b/src/AgentSmith.Domain/Models/BranchName.cs
@@ -1,7 +1,8 @@
 namespace AgentSmith.Domain.Models;
 
 /// <summary>
-/// Git branch name, with factory method for ticket-based naming.
+/// Git branch name. For ticket-based naming, use
+/// <c>AgentSmith.Application.Services.TicketBranchNamer.Compose</c>.
 /// </summary>
 public sealed record BranchName
 {
@@ -11,11 +12,6 @@ public sealed record BranchName
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
         Value = value;
-    }
-
-    public static BranchName FromTicket(TicketId ticketId, string prefix = "fix")
-    {
-        return new BranchName($"{prefix}/{ticketId.Value}");
     }
 
     public override string ToString() => Value;

--- a/src/AgentSmith.Infrastructure/Services/Factories/AgenticAnalyzerFactory.cs
+++ b/src/AgentSmith.Infrastructure/Services/Factories/AgenticAnalyzerFactory.cs
@@ -1,10 +1,15 @@
+using System.ClientModel;
 using AgentSmith.Contracts.Models.Configuration;
 using AgentSmith.Contracts.Services;
 using AgentSmith.Domain.Exceptions;
 using AgentSmith.Infrastructure.Core.Services.Configuration;
 using AgentSmith.Infrastructure.Models;
 using AgentSmith.Infrastructure.Services.Providers.Agent.Adapters;
+using AgentSmith.Infrastructure.Services.Providers.Agent.Compaction;
+using Azure.AI.OpenAI;
 using Microsoft.Extensions.Logging;
+using OpenAI;
+using OpenAI.Chat;
 
 namespace AgentSmith.Infrastructure.Services.Factories;
 
@@ -16,6 +21,7 @@ namespace AgentSmith.Infrastructure.Services.Factories;
 /// </summary>
 public sealed class AgenticAnalyzerFactory(
     SecretsProvider secrets,
+    IPromptCatalog promptCatalog,
     ILoggerFactory loggerFactory) : IAgenticAnalyzerFactory
 {
     private readonly Dictionary<string, Func<AgentConfig, IAgenticAnalyzer>> _creators =
@@ -23,9 +29,9 @@ public sealed class AgenticAnalyzerFactory(
         {
             ["claude"] = config => CreateClaude(config, secrets, loggerFactory),
             ["anthropic"] = config => CreateClaude(config, secrets, loggerFactory),
-            ["openai"] = config => CreateOpenAi(config, secrets, loggerFactory),
-            ["azure-openai"] = config => CreateAzureOpenAi(config, secrets, loggerFactory),
-            ["azure"] = config => CreateAzureOpenAi(config, secrets, loggerFactory),
+            ["openai"] = config => CreateOpenAi(config, secrets, promptCatalog, loggerFactory),
+            ["azure-openai"] = config => CreateAzureOpenAi(config, secrets, promptCatalog, loggerFactory),
+            ["azure"] = config => CreateAzureOpenAi(config, secrets, promptCatalog, loggerFactory),
             ["gemini"] = config => CreateGemini(config, secrets, loggerFactory),
             ["google"] = config => CreateGemini(config, secrets, loggerFactory),
         };
@@ -59,18 +65,23 @@ public sealed class AgenticAnalyzerFactory(
     }
 
     private static OpenAiAgenticAnalyzer CreateOpenAi(
-        AgentConfig config, SecretsProvider secrets, ILoggerFactory loggerFactory)
+        AgentConfig config, SecretsProvider secrets, IPromptCatalog promptCatalog, ILoggerFactory loggerFactory)
     {
         var secretName = config.ApiKeySecret ?? "OPENAI_API_KEY";
         var apiKey = secrets.GetRequired(secretName);
         var endpoint = config.Endpoint is not null ? new Uri(config.Endpoint) : null;
+        var compactor = config.Compaction.IsEnabled
+            ? BuildOpenAiCompactor(apiKey, config, endpoint, promptCatalog, loggerFactory)
+            : null;
         return new OpenAiAgenticAnalyzer(
             apiKey, config.Model, endpoint, config.Retry,
-            loggerFactory.CreateLogger<OpenAiAgenticAnalyzer>());
+            loggerFactory.CreateLogger<OpenAiAgenticAnalyzer>(),
+            chatClientFactory: null,
+            compactor: compactor);
     }
 
     private static AzureOpenAiAgenticAnalyzer CreateAzureOpenAi(
-        AgentConfig config, SecretsProvider secrets, ILoggerFactory loggerFactory)
+        AgentConfig config, SecretsProvider secrets, IPromptCatalog promptCatalog, ILoggerFactory loggerFactory)
     {
         var secretName = config.ApiKeySecret ?? "AZURE_OPENAI_API_KEY";
         var apiKey = secrets.GetRequired(secretName);
@@ -80,9 +91,39 @@ public sealed class AgenticAnalyzerFactory(
             ?? throw new ConfigurationException(
                 "Azure OpenAI requires a deployment name. Set agent.deployment in agentsmith.yml, " +
                 "OR set agent.models.Planning.deployment (the analyzer falls back to the Planning task's deployment).");
+        var compactor = config.Compaction.IsEnabled
+            ? BuildAzureCompactor(apiKey, new Uri(endpoint), deployment, config, promptCatalog, loggerFactory)
+            : null;
         return new AzureOpenAiAgenticAnalyzer(
             apiKey, new Uri(endpoint), deployment, config.Retry,
-            loggerFactory.CreateLogger<AzureOpenAiAgenticAnalyzer>());
+            loggerFactory.CreateLogger<AzureOpenAiAgenticAnalyzer>(),
+            compactor: compactor);
+    }
+
+    private static IOpenAiContextCompactor BuildOpenAiCompactor(
+        string apiKey, AgentConfig config, Uri? endpoint,
+        IPromptCatalog promptCatalog, ILoggerFactory loggerFactory)
+    {
+        var summarizerModel = config.Compaction.DeploymentName ?? config.Model;
+        var options = new OpenAIClientOptions();
+        if (endpoint is not null) options.Endpoint = endpoint;
+        var client = new OpenAIClient(new ApiKeyCredential(apiKey), options);
+        var summarizer = client.GetChatClient(summarizerModel);
+        return new OpenAiContextCompactor(
+            summarizer, config.Compaction, promptCatalog,
+            loggerFactory.CreateLogger<OpenAiContextCompactor>());
+    }
+
+    private static IOpenAiContextCompactor BuildAzureCompactor(
+        string apiKey, Uri endpoint, string primaryDeployment,
+        AgentConfig config, IPromptCatalog promptCatalog, ILoggerFactory loggerFactory)
+    {
+        var summarizerDeployment = config.Compaction.DeploymentName ?? primaryDeployment;
+        var azureClient = new AzureOpenAIClient(endpoint, new ApiKeyCredential(apiKey));
+        var summarizer = azureClient.GetChatClient(summarizerDeployment);
+        return new OpenAiContextCompactor(
+            summarizer, config.Compaction, promptCatalog,
+            loggerFactory.CreateLogger<OpenAiContextCompactor>());
     }
 
     private static string? ResolveAzureDeployment(AgentConfig config)

--- a/src/AgentSmith.Infrastructure/Services/Providers/Agent/Adapters/AzureOpenAiAgenticAnalyzer.cs
+++ b/src/AgentSmith.Infrastructure/Services/Providers/Agent/Adapters/AzureOpenAiAgenticAnalyzer.cs
@@ -2,6 +2,7 @@ using System.ClientModel;
 using System.ClientModel.Primitives;
 using AgentSmith.Contracts.Models.Configuration;
 using AgentSmith.Contracts.Services;
+using AgentSmith.Infrastructure.Services.Providers.Agent.Compaction;
 using Azure.AI.OpenAI;
 using Microsoft.Extensions.Logging;
 using OpenAI.Chat;
@@ -11,19 +12,22 @@ namespace AgentSmith.Infrastructure.Services.Providers.Agent.Adapters;
 /// <summary>
 /// IAgenticAnalyzer for Azure OpenAI. Same shape as OpenAiAgenticAnalyzer but
 /// uses AzureOpenAIClient with deployment routing. Composes the OpenAi
-/// adapter via a custom ChatClient factory.
+/// adapter via a custom ChatClient factory. Optional context compaction (p0114)
+/// passes through to the inner OpenAi analyzer.
 /// </summary>
 public sealed class AzureOpenAiAgenticAnalyzer(
     string apiKey,
     Uri endpoint,
     string deployment,
     RetryConfig retryConfig,
-    ILogger<AzureOpenAiAgenticAnalyzer> logger) : IAgenticAnalyzer
+    ILogger<AzureOpenAiAgenticAnalyzer> logger,
+    IOpenAiContextCompactor? compactor = null) : IAgenticAnalyzer
 {
     private readonly OpenAiAgenticAnalyzer _inner = new(
         apiKey, deployment, endpoint, retryConfig,
         new TypedLogger<OpenAiAgenticAnalyzer>(logger),
-        () => CreateAzureChatClient(apiKey, endpoint, deployment, retryConfig, logger));
+        () => CreateAzureChatClient(apiKey, endpoint, deployment, retryConfig, logger),
+        compactor);
 
     public Task<AnalysisResult> AnalyzeAsync(
         string systemPrompt, string userPrompt,

--- a/src/AgentSmith.Infrastructure/Services/Providers/Agent/Adapters/OpenAiAgenticAnalyzer.cs
+++ b/src/AgentSmith.Infrastructure/Services/Providers/Agent/Adapters/OpenAiAgenticAnalyzer.cs
@@ -1,7 +1,9 @@
 using System.ClientModel;
 using System.Text.Json.Nodes;
+using AgentSmith.Contracts.Models.Compaction;
 using AgentSmith.Contracts.Models.Configuration;
 using AgentSmith.Contracts.Services;
+using AgentSmith.Infrastructure.Services.Providers.Agent.Compaction;
 using Microsoft.Extensions.Logging;
 using OpenAI;
 using OpenAI.Chat;
@@ -12,6 +14,7 @@ namespace AgentSmith.Infrastructure.Services.Providers.Agent.Adapters;
 /// IAgenticAnalyzer implementation backed by the OpenAI Chat Completions
 /// API. Translates ToolDefinition to ChatTool and back; relies on the SDK's
 /// JSON-serialized FunctionArguments / FunctionName / Id round-trip.
+/// Optional context compaction (p0114) flat-lines token growth on long runs.
 /// </summary>
 public sealed class OpenAiAgenticAnalyzer(
     string apiKey,
@@ -19,7 +22,8 @@ public sealed class OpenAiAgenticAnalyzer(
     Uri? endpoint,
     RetryConfig retryConfig,
     ILogger<OpenAiAgenticAnalyzer> logger,
-    Func<ChatClient>? chatClientFactory = null) : IAgenticAnalyzer
+    Func<ChatClient>? chatClientFactory = null,
+    IOpenAiContextCompactor? compactor = null) : IAgenticAnalyzer
 {
     public async Task<AnalysisResult> AnalyzeAsync(
         string systemPrompt, string userPrompt,
@@ -39,10 +43,12 @@ public sealed class OpenAiAgenticAnalyzer(
         var totalIn = 0; var totalOut = 0; var toolCallCount = 0;
         var iteration = 0;
         var finalText = string.Empty;
+        CompactionEvent? pendingCompaction = null;
 
         for (; iteration < maxIterations; iteration++)
         {
             ChatCompletion completion = await client.CompleteChatAsync(messages, options, cancellationToken);
+            pendingCompaction = FinalizePendingCompaction(pendingCompaction, completion, logger);
             totalIn += completion.Usage?.InputTokenCount ?? 0;
             totalOut += completion.Usage?.OutputTokenCount ?? 0;
             messages.Add(new AssistantChatMessage(completion));
@@ -64,6 +70,24 @@ public sealed class OpenAiAgenticAnalyzer(
                     new ToolCall(call.Id, call.FunctionName, input), cancellationToken);
                 messages.Add(new ToolChatMessage(result.Id, result.Content));
             }
+
+            // COMPACTION POINT — runs synchronously between rounds, after a complete
+            // assistant→tool-results round. Must NEVER fire while a tool_call is
+            // in-flight or unanswered. Future parallelization of the agentic loop
+            // must move this point or guard it explicitly.
+            if (compactor is not null)
+            {
+                var estimated = OpenAiContextCompactor.EstimateTokens(messages);
+                var compactionResult = await compactor.CompactIfNeededAsync(messages, iteration + 1, estimated, cancellationToken);
+                if (compactionResult.Event is not null)
+                {
+                    messages = compactionResult.Messages.ToList();
+                    if (compactionResult.Event.Failed)
+                        logger.LogWarning("OpenAi analyzer: compaction failed — {Reason}", compactionResult.Event.FailureReason);
+                    else
+                        pendingCompaction = compactionResult.Event;
+                }
+            }
         }
 
         logger.LogDebug(
@@ -73,6 +97,19 @@ public sealed class OpenAiAgenticAnalyzer(
         return new AnalysisResult(
             finalText, iteration, toolCallCount,
             new AnalyzerTokenUsage(totalIn, totalOut));
+    }
+
+    private static CompactionEvent? FinalizePendingCompaction(
+        CompactionEvent? pending, ChatCompletion completion, ILogger logger)
+    {
+        if (pending is null || completion.Usage is null) return pending;
+        var finalized = pending.WithVerifiedTokens(completion.Usage.InputTokenCount);
+        logger.LogInformation(
+            "Compacted {Old}→{New} messages; verified {Verified} input tokens (saved est. {Saved}; summarizer cost {Summary} tokens; prompt {Hash})",
+            finalized.OldMessageCount, finalized.NewMessageCount,
+            finalized.PostCompactionVerifiedTokens, finalized.VerifiedSavedTokens,
+            finalized.SummarizationCallTokens, finalized.PromptHash);
+        return null;
     }
 
     private static ChatTool ToChatTool(ToolDefinition def) =>

--- a/src/AgentSmith.Infrastructure/Services/Providers/Agent/Compaction/IOpenAiContextCompactor.cs
+++ b/src/AgentSmith.Infrastructure/Services/Providers/Agent/Compaction/IOpenAiContextCompactor.cs
@@ -1,0 +1,28 @@
+using AgentSmith.Contracts.Models.Compaction;
+using OpenAI.Chat;
+
+namespace AgentSmith.Infrastructure.Services.Providers.Agent.Compaction;
+
+/// <summary>
+/// Compacts the conversation history of an OpenAI / Azure-OpenAI agentic loop when the
+/// trigger threshold is crossed. Provider-specific because <see cref="ChatMessage"/>
+/// is OpenAI-SDK-bound — Claude has its own SDK-specific implementation.
+/// </summary>
+public interface IOpenAiContextCompactor
+{
+    /// <summary>
+    /// Evaluates the trigger and either summarizes the prefix or returns the input unchanged.
+    /// Trigger is boolean OR: <c>currentIterations &gt;= ThresholdIterations || estimatedTokens &gt;= MaxContextTokens</c>.
+    /// On summarizer failure, returns input messages unchanged with a <see cref="CompactionEvent"/>
+    /// where Failed=true — never throws into the agentic loop.
+    /// </summary>
+    Task<OpenAiCompactionResult> CompactIfNeededAsync(
+        IReadOnlyList<ChatMessage> messages,
+        int currentIterations,
+        int estimatedAccumulatedTokens,
+        CancellationToken cancellationToken);
+}
+
+public sealed record OpenAiCompactionResult(
+    IReadOnlyList<ChatMessage> Messages,
+    CompactionEvent? Event);

--- a/src/AgentSmith.Infrastructure/Services/Providers/Agent/Compaction/NoOpOpenAiContextCompactor.cs
+++ b/src/AgentSmith.Infrastructure/Services/Providers/Agent/Compaction/NoOpOpenAiContextCompactor.cs
@@ -1,0 +1,19 @@
+using AgentSmith.Contracts.Models.Compaction;
+using OpenAI.Chat;
+
+namespace AgentSmith.Infrastructure.Services.Providers.Agent.Compaction;
+
+/// <summary>
+/// Returns the input unchanged. Used when CompactionConfig.IsEnabled is false,
+/// when no ChatClient is available for the summarizer, and as a default for
+/// non-OpenAI agentic loops that are wired through DI but don't actually compact.
+/// </summary>
+public sealed class NoOpOpenAiContextCompactor : IOpenAiContextCompactor
+{
+    public Task<OpenAiCompactionResult> CompactIfNeededAsync(
+        IReadOnlyList<ChatMessage> messages,
+        int currentIterations,
+        int estimatedAccumulatedTokens,
+        CancellationToken cancellationToken) =>
+        Task.FromResult(new OpenAiCompactionResult(messages, Event: null));
+}

--- a/src/AgentSmith.Infrastructure/Services/Providers/Agent/Compaction/OpenAiContextCompactor.cs
+++ b/src/AgentSmith.Infrastructure/Services/Providers/Agent/Compaction/OpenAiContextCompactor.cs
@@ -1,0 +1,199 @@
+using System.Security.Cryptography;
+using System.Text;
+using AgentSmith.Contracts.Models.Compaction;
+using AgentSmith.Contracts.Models.Configuration;
+using AgentSmith.Contracts.Services;
+using Microsoft.Extensions.Logging;
+using OpenAI.Chat;
+
+namespace AgentSmith.Infrastructure.Services.Providers.Agent.Compaction;
+
+/// <summary>
+/// LLM-based compactor for the OpenAI / Azure-OpenAI agentic loops. Summarizes the
+/// pre-tail prefix into a single user message; keeps the original system prompt
+/// + the last N complete tool-call rounds verbatim. Trigger is boolean OR:
+/// iterations OR estimated tokens.
+/// </summary>
+public sealed class OpenAiContextCompactor(
+    ChatClient summarizerClient,
+    CompactionConfig config,
+    IPromptCatalog prompts,
+    ILogger<OpenAiContextCompactor> logger) : IOpenAiContextCompactor
+{
+    private const string PromptName = "openai-context-compactor-system";
+    private const int CharsPerTokenEstimate = 4;
+    private const int KeepRounds = 2;
+
+    private string? _cachedPrompt;
+    private string? _cachedPromptHash;
+
+    public async Task<OpenAiCompactionResult> CompactIfNeededAsync(
+        IReadOnlyList<ChatMessage> messages,
+        int currentIterations,
+        int estimatedAccumulatedTokens,
+        CancellationToken cancellationToken)
+    {
+        if (!config.IsEnabled)
+            return new OpenAiCompactionResult(messages, Event: null);
+
+        if (!ShouldFire(currentIterations, estimatedAccumulatedTokens))
+            return new OpenAiCompactionResult(messages, Event: null);
+
+        var tailStart = ToolCallRoundIdentifier.FindTailStartIndex(messages, KeepRounds);
+        var hasSystem = messages.Count > 0 && messages[0] is SystemChatMessage;
+        var prefixSize = hasSystem ? tailStart - 1 : tailStart;
+        var tailSize = messages.Count - tailStart;
+        if (prefixSize < 2 || tailSize == 0)
+        {
+            // Either the prefix is too small to be worth summarizing (just system + initial user),
+            // or no tail messages exist (nothing to preserve verbatim). No-op in both cases.
+            logger.LogDebug(
+                "Compaction trigger crossed but prefixSize={Prefix}, tailSize={Tail} — skipping",
+                prefixSize, tailSize);
+            return new OpenAiCompactionResult(messages, Event: null);
+        }
+
+        return await DoCompactAsync(messages, tailStart, estimatedAccumulatedTokens, cancellationToken);
+    }
+
+    private bool ShouldFire(int iterations, int estimatedTokens) =>
+        (iterations >= config.ThresholdIterations) ||
+        (estimatedTokens >= config.MaxContextTokens);
+
+    private async Task<OpenAiCompactionResult> DoCompactAsync(
+        IReadOnlyList<ChatMessage> messages, int tailStart,
+        int estimatedTokens, CancellationToken cancellationToken)
+    {
+        var systemMessage = ExtractSystem(messages);
+        var prefix = SlicePrefix(messages, systemMessage is null ? 0 : 1, tailStart);
+        var tail = messages.Skip(tailStart).ToList();
+        var promptHash = ResolvePromptHash();
+
+        var summary = await TrySummarize(prefix, cancellationToken);
+        if (summary is null)
+        {
+            return new OpenAiCompactionResult(
+                messages,
+                CompactionEvent.ForFailure(prefix.Count, estimatedTokens, promptHash, "summarizer call failed"));
+        }
+
+        var compacted = BuildCompactedList(systemMessage, summary.Value.SummaryText, tail);
+        logger.LogInformation(
+            "Compacted {Old} → {New} messages (est. {Estimate} tokens before; verified count from next response)",
+            messages.Count, compacted.Count, estimatedTokens);
+
+        return new OpenAiCompactionResult(
+            compacted,
+            new CompactionEvent(
+                OldMessageCount: messages.Count,
+                NewMessageCount: compacted.Count,
+                PreCompactionEstimatedTokens: estimatedTokens,
+                PostCompactionVerifiedTokens: null,
+                SummarizationCallTokens: summary.Value.TokensUsed,
+                PromptHash: promptHash,
+                Failed: false,
+                FailureReason: null));
+    }
+
+    private static SystemChatMessage? ExtractSystem(IReadOnlyList<ChatMessage> messages) =>
+        messages.Count > 0 && messages[0] is SystemChatMessage sys ? sys : null;
+
+    private static List<ChatMessage> SlicePrefix(IReadOnlyList<ChatMessage> messages, int from, int toExclusive)
+    {
+        var prefix = new List<ChatMessage>(toExclusive - from);
+        for (var i = from; i < toExclusive; i++) prefix.Add(messages[i]);
+        return prefix;
+    }
+
+    private async Task<(string SummaryText, int TokensUsed)?> TrySummarize(
+        IReadOnlyList<ChatMessage> prefix, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var promptText = ResolvePrompt();
+            var serialized = SerializePrefix(prefix);
+
+            var summaryMessages = new List<ChatMessage>
+            {
+                new SystemChatMessage(promptText),
+                new UserChatMessage(serialized)
+            };
+
+            var completion = await summarizerClient.CompleteChatAsync(summaryMessages, new ChatCompletionOptions(), cancellationToken);
+            var text = completion.Value.Content.FirstOrDefault()?.Text ?? string.Empty;
+            var tokens = (completion.Value.Usage?.InputTokenCount ?? 0) + (completion.Value.Usage?.OutputTokenCount ?? 0);
+            return (text, tokens);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "OpenAi context compactor: summarizer call failed — falling back to original messages");
+            return null;
+        }
+    }
+
+    private static List<ChatMessage> BuildCompactedList(
+        SystemChatMessage? system, string summaryText, List<ChatMessage> tail)
+    {
+        var result = new List<ChatMessage>(2 + tail.Count);
+        if (system is not null) result.Add(system);
+        result.Add(new UserChatMessage($"[Context Summary from previous iterations]\n{summaryText}"));
+        result.AddRange(tail);
+        return result;
+    }
+
+    private static string SerializePrefix(IReadOnlyList<ChatMessage> prefix)
+    {
+        var parts = new List<string>(prefix.Count);
+        foreach (var m in prefix) parts.Add(SerializeMessage(m));
+        return string.Join("\n\n", parts);
+    }
+
+    private static string SerializeMessage(ChatMessage m) => m switch
+    {
+        UserChatMessage u => $"[User] {string.Join("", u.Content.Select(c => c.Text))}",
+        AssistantChatMessage a => SerializeAssistant(a),
+        ToolChatMessage t => $"[Tool Result {Trunc(t.ToolCallId)}] {string.Join("", t.Content.Select(c => c.Text))}",
+        SystemChatMessage s => $"[System] {string.Join("", s.Content.Select(c => c.Text))}",
+        _ => $"[{m.GetType().Name}]"
+    };
+
+    private static string SerializeAssistant(AssistantChatMessage a)
+    {
+        var text = string.Join("", a.Content.Select(c => c.Text));
+        if (a.ToolCalls.Count == 0) return $"[Assistant] {text}";
+        var calls = string.Join(", ", a.ToolCalls.Select(tc => $"{tc.FunctionName}({Trunc(tc.Id)})"));
+        return $"[Assistant] {text} [tool_calls: {calls}]";
+    }
+
+    private static string Trunc(string s) => s.Length <= 8 ? s : s[..8];
+
+    private string ResolvePrompt() => _cachedPrompt ??= prompts.Get(PromptName);
+
+    private string ResolvePromptHash()
+    {
+        if (_cachedPromptHash is not null) return _cachedPromptHash;
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(ResolvePrompt()));
+        _cachedPromptHash = Convert.ToHexString(bytes)[..8].ToLowerInvariant();
+        return _cachedPromptHash;
+    }
+
+    /// <summary>Token-count estimate for trigger evaluation. ~4 chars/token; ±5% accuracy.</summary>
+    public static int EstimateTokens(IReadOnlyList<ChatMessage> messages)
+    {
+        var chars = 0;
+        foreach (var m in messages)
+        {
+            switch (m)
+            {
+                case UserChatMessage u: foreach (var c in u.Content) chars += c.Text?.Length ?? 0; break;
+                case AssistantChatMessage a:
+                    foreach (var c in a.Content) chars += c.Text?.Length ?? 0;
+                    foreach (var tc in a.ToolCalls) chars += tc.FunctionArguments.ToString().Length;
+                    break;
+                case ToolChatMessage t: foreach (var c in t.Content) chars += c.Text?.Length ?? 0; break;
+                case SystemChatMessage s: foreach (var c in s.Content) chars += c.Text?.Length ?? 0; break;
+            }
+        }
+        return chars / CharsPerTokenEstimate;
+    }
+}

--- a/src/AgentSmith.Infrastructure/Services/Providers/Agent/Compaction/ToolCallRoundIdentifier.cs
+++ b/src/AgentSmith.Infrastructure/Services/Providers/Agent/Compaction/ToolCallRoundIdentifier.cs
@@ -1,0 +1,45 @@
+using OpenAI.Chat;
+
+namespace AgentSmith.Infrastructure.Services.Providers.Agent.Compaction;
+
+/// <summary>
+/// Finds the boundary that separates the "tail" (last N complete tool-call rounds, kept verbatim)
+/// from the "prefix" (older messages, eligible for summarization).
+///
+/// A round is one of:
+///  • an <see cref="AssistantChatMessage"/> with tool_calls + all <see cref="ToolChatMessage"/>
+///    responses to those tool_call_ids (one logical exchange).
+///  • a bare <see cref="AssistantChatMessage"/> with no tool_calls (terminal reply).
+///
+/// Walking backward from the end of the message list, we never split a round mid-pair —
+/// the OpenAI API rejects payloads where a tool message references a tool_call_id without
+/// the matching assistant message in the same array.
+/// </summary>
+internal static class ToolCallRoundIdentifier
+{
+    /// <summary>
+    /// Returns the index at which the tail begins — everything from index 0 up to (but not
+    /// including) the returned index is "prefix" eligible for summarization.
+    /// Returns <paramref name="messages"/>.Count when N=0 or no rounds can be formed.
+    /// Returns 0 when all messages already fit in N rounds (no compaction needed).
+    /// </summary>
+    public static int FindTailStartIndex(IReadOnlyList<ChatMessage> messages, int completeRounds)
+    {
+        if (completeRounds <= 0 || messages.Count == 0) return messages.Count;
+
+        var roundsFound = 0;
+        var i = messages.Count - 1;
+
+        while (i >= 0 && roundsFound < completeRounds)
+        {
+            while (i >= 0 && messages[i] is ToolChatMessage) i--;
+
+            if (i < 0 || messages[i] is not AssistantChatMessage) break;
+
+            roundsFound++;
+            i--;
+        }
+
+        return i + 1;
+    }
+}

--- a/src/AgentSmith.Infrastructure/Services/Providers/Agent/OpenAiAgenticLoop.cs
+++ b/src/AgentSmith.Infrastructure/Services/Providers/Agent/OpenAiAgenticLoop.cs
@@ -1,8 +1,10 @@
 using AgentSmith.Infrastructure.Models;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using AgentSmith.Contracts.Models.Compaction;
 using AgentSmith.Contracts.Services;
 using AgentSmith.Domain.Entities;
+using AgentSmith.Infrastructure.Services.Providers.Agent.Compaction;
 using Microsoft.Extensions.Logging;
 using OpenAI.Chat;
 
@@ -10,7 +12,8 @@ namespace AgentSmith.Infrastructure.Services.Providers.Agent;
 
 /// <summary>
 /// Runs the agentic tool-calling loop against the OpenAI Chat Completions API.
-/// Mirrors the Claude AgenticLoop but uses OpenAI SDK types.
+/// Mirrors the Claude AgenticLoop but uses OpenAI SDK types. Optional context
+/// compaction (p0114) flat-lines token growth on long agentic-execute runs.
 /// </summary>
 public sealed class OpenAiAgenticLoop(
     ChatClient client,
@@ -18,7 +21,8 @@ public sealed class OpenAiAgenticLoop(
     ILogger logger,
     TokenUsageTracker tracker,
     IProgressReporter progressReporter,
-    int maxIterations)
+    int maxIterations,
+    IOpenAiContextCompactor? compactor = null)
 {
     public async Task<IReadOnlyList<CodeChange>> RunAsync(
         string systemPrompt,
@@ -35,6 +39,8 @@ public sealed class OpenAiAgenticLoop(
         foreach (var tool in OpenAiToolDefinitions.All)
             options.Tools.Add(tool);
 
+        CompactionEvent? pendingCompaction = null;
+
         for (var iteration = 0; iteration < maxIterations; iteration++)
         {
             logger.LogDebug("OpenAI agentic loop iteration {Iteration}", iteration + 1);
@@ -43,6 +49,7 @@ public sealed class OpenAiAgenticLoop(
             ChatCompletion completion = await client.CompleteChatAsync(
                 messages, options, cancellationToken);
 
+            pendingCompaction = FinalizePendingCompaction(pendingCompaction, completion);
             TrackUsage(completion, iteration + 1);
             messages.Add(new AssistantChatMessage(completion));
 
@@ -56,10 +63,40 @@ public sealed class OpenAiAgenticLoop(
             var toolResults = await ProcessToolCallsAsync(completion, cancellationToken);
             foreach (var result in toolResults)
                 messages.Add(result);
+
+            // COMPACTION POINT \u2014 runs synchronously between rounds, after a complete
+            // assistant\u2192tool-results round. Must NEVER fire while a tool_call is
+            // in-flight or unanswered. Future parallelization of the agentic loop
+            // must move this point or guard it explicitly.
+            if (compactor is not null)
+            {
+                var estimated = OpenAiContextCompactor.EstimateTokens(messages);
+                var compactionResult = await compactor.CompactIfNeededAsync(messages, iteration + 1, estimated, cancellationToken);
+                if (compactionResult.Event is not null)
+                {
+                    messages = compactionResult.Messages.ToList();
+                    if (compactionResult.Event.Failed)
+                        logger.LogWarning("OpenAi loop: compaction failed \u2014 {Reason}", compactionResult.Event.FailureReason);
+                    else
+                        pendingCompaction = compactionResult.Event;
+                }
+            }
         }
 
         tracker.LogSummary(logger);
         return toolExecutor.GetChanges();
+    }
+
+    private CompactionEvent? FinalizePendingCompaction(CompactionEvent? pending, ChatCompletion completion)
+    {
+        if (pending is null || completion.Usage is null) return pending;
+        var finalized = pending.WithVerifiedTokens(completion.Usage.InputTokenCount);
+        logger.LogInformation(
+            "Compacted {Old}\u2192{New} messages; verified {Verified} input tokens (saved est. {Saved}; summarizer cost {Summary} tokens; prompt {Hash})",
+            finalized.OldMessageCount, finalized.NewMessageCount,
+            finalized.PostCompactionVerifiedTokens, finalized.VerifiedSavedTokens,
+            finalized.SummarizationCallTokens, finalized.PromptHash);
+        return null;
     }
 
     private async Task<List<ToolChatMessage>> ProcessToolCallsAsync(

--- a/src/AgentSmith.Infrastructure/Services/Providers/Source/AzureGitOperations.cs
+++ b/src/AgentSmith.Infrastructure/Services/Providers/Source/AzureGitOperations.cs
@@ -30,10 +30,53 @@ internal sealed class AzureGitOperations(string personalAccessToken, ILogger log
 
     public Branch CheckoutBranch(Repository repo, string branchName)
     {
-        var existingBranch = repo.Branches[branchName];
-        var targetBranch = existingBranch ?? repo.CreateBranch(branchName);
-        Commands.Checkout(repo, targetBranch);
-        return targetBranch;
+        // p0112: resume from existing remote work-branch when present.
+        // Walk: (1) local exists → checkout. (2) remote tracking origin/<name> exists →
+        //   create local tracking branch + checkout (preserves prior WIP commits from
+        //   PersistWorkBranchHandler on a previous run for the same ticket).
+        // (3) neither → fresh branch from current HEAD (legacy behavior).
+        var local = repo.Branches[branchName];
+        if (local is not null)
+        {
+            Commands.Checkout(repo, local);
+            logger.LogInformation("Checked out existing local branch {Branch}", branchName);
+            return local;
+        }
+
+        FetchAllRemotes(repo);
+        var remote = repo.Branches[$"origin/{branchName}"];
+        if (remote is not null)
+        {
+            var resumed = repo.CreateBranch(branchName, remote.Tip);
+            repo.Branches.Update(resumed, b => b.TrackedBranch = remote.CanonicalName);
+            Commands.Checkout(repo, resumed);
+            logger.LogInformation(
+                "Resumed work branch {Branch} from origin (last commit {Sha} by {Author} at {When})",
+                branchName, remote.Tip.Sha[..7], remote.Tip.Author.Name, remote.Tip.Author.When.ToString("o"));
+            return resumed;
+        }
+
+        var fresh = repo.CreateBranch(branchName);
+        Commands.Checkout(repo, fresh);
+        logger.LogInformation("Created fresh branch {Branch} from HEAD", branchName);
+        return fresh;
+    }
+
+    private void FetchAllRemotes(Repository repo)
+    {
+        try
+        {
+            var remote = repo.Network.Remotes["origin"]
+                ?? throw new ProviderException("AzureRepos", "No 'origin' remote configured.");
+            var refSpecs = remote.FetchRefSpecs.Select(r => r.Specification);
+            var fetchOptions = new FetchOptions { CredentialsProvider = GetCredentialsHandler() };
+            Commands.Fetch(repo, remote.Name, refSpecs, fetchOptions, logMessage: null);
+        }
+        catch (Exception ex)
+        {
+            // Non-fatal: if fetch fails, we proceed with fresh-branch fallback.
+            logger.LogWarning(ex, "Fetch failed during checkout — proceeding without remote-resume probe");
+        }
     }
 
     public void StageAllChanges(Repository repo) =>

--- a/src/AgentSmith.Infrastructure/Services/Queue/RedisPipelineRequestStore.cs
+++ b/src/AgentSmith.Infrastructure/Services/Queue/RedisPipelineRequestStore.cs
@@ -1,0 +1,51 @@
+using System.Text.Json;
+using AgentSmith.Contracts.Models;
+using AgentSmith.Contracts.Services;
+using Microsoft.Extensions.Logging;
+using StackExchange.Redis;
+
+namespace AgentSmith.Infrastructure.Services.Queue;
+
+/// <summary>
+/// Redis-backed handoff for queue-spawned jobs (p0113). One key per jobId,
+/// SETEX with TTL — survives short dispatcher↔container races without
+/// growing unbounded. RedisJobQueue already uses the same JsonSerializer
+/// shape for PipelineRequest, so this reuses that round-trip contract.
+/// </summary>
+public sealed class RedisPipelineRequestStore(
+    IConnectionMultiplexer redis,
+    ILogger<RedisPipelineRequestStore> logger) : IPipelineRequestStore
+{
+    private const string KeyPrefix = "agentsmith:pipeline-request:";
+
+    public async Task SaveAsync(
+        string jobId, PipelineRequest request, TimeSpan ttl, CancellationToken cancellationToken)
+    {
+        var db = redis.GetDatabase();
+        var json = JsonSerializer.Serialize(request);
+        await db.StringSetAsync($"{KeyPrefix}{jobId}", json, ttl);
+        logger.LogDebug(
+            "Saved PipelineRequest for job {JobId} (project {Project}, pipeline {Pipeline}, ttl {Ttl}s)",
+            jobId, request.ProjectName, request.PipelineName, (int)ttl.TotalSeconds);
+    }
+
+    public async Task<PipelineRequest?> LoadAsync(string jobId, CancellationToken cancellationToken)
+    {
+        var db = redis.GetDatabase();
+        var json = await db.StringGetAsync($"{KeyPrefix}{jobId}");
+        if (json.IsNullOrEmpty)
+        {
+            logger.LogWarning("PipelineRequest not found for job {JobId} — key missing or expired", jobId);
+            return null;
+        }
+        try
+        {
+            return JsonSerializer.Deserialize<PipelineRequest>(json!);
+        }
+        catch (JsonException ex)
+        {
+            logger.LogError(ex, "Failed to deserialize PipelineRequest for job {JobId}", jobId);
+            return null;
+        }
+    }
+}

--- a/src/AgentSmith.Server/Contracts/IJobSpawner.cs
+++ b/src/AgentSmith.Server/Contracts/IJobSpawner.cs
@@ -10,10 +10,20 @@ namespace AgentSmith.Server.Contracts;
 public interface IJobSpawner
 {
     /// <summary>
-    /// Spawns an ephemeral agent job for the given request.
-    /// Returns the jobId that can be used to track progress via Redis Streams.
+    /// Spawns an ephemeral agent job for the given request (chat-intent flow:
+    /// Slack/Teams "fix #123 in my-project"). Returns the jobId so progress
+    /// can be tracked via Redis Streams.
     /// </summary>
     Task<string> SpawnAsync(JobRequest request, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// p0113: spawns an ephemeral agent job for a queue-claimed PipelineRequest.
+    /// The container picks up its work by reading from the IPipelineRequestStore
+    /// using the supplied jobId — CLI args stay short and structured request
+    /// data round-trips losslessly through Redis.
+    /// </summary>
+    Task SpawnQueueJobAsync(
+        string jobId, string redisUrl, string configPath, CancellationToken cancellationToken);
 
     /// <summary>
     /// Checks whether the container/pod for the given job is still running.

--- a/src/AgentSmith.Server/Extensions/ServiceCollectionExtensions.cs
+++ b/src/AgentSmith.Server/Extensions/ServiceCollectionExtensions.cs
@@ -30,6 +30,7 @@ internal static class ServiceCollectionExtensions
         var multiplexer = ConnectionMultiplexer.Connect(redisUrl);
         services.AddSingleton<IConnectionMultiplexer>(multiplexer);
         services.AddSingleton<IRedisJobQueue, RedisJobQueue>();
+        services.AddSingleton<IPipelineRequestStore, RedisPipelineRequestStore>();
         services.AddSingleton<IRedisClaimLock, RedisClaimLock>();
         services.AddSingleton<IRedisLeaderLease, RedisLeaderLease>();
         services.AddSingleton<IJobHeartbeatService, JobHeartbeatService>();
@@ -78,6 +79,9 @@ internal static class ServiceCollectionExtensions
         services.AddAgentSmithInfrastructure();
         services.AddAgentSmithCommands();
         services.AddIntentEngine();
+        // p0113: queue-driven dispatch goes through ephemeral CLI containers,
+        // not in-process pipeline execution.
+        services.AddSingleton<IPipelineJobDispatcher, JobSpawnerPipelineDispatcher>();
         return services;
     }
 

--- a/src/AgentSmith.Server/Services/DockerJobSpawner.cs
+++ b/src/AgentSmith.Server/Services/DockerJobSpawner.cs
@@ -76,6 +76,71 @@ public sealed class DockerJobSpawner(
         catch (DockerContainerNotFoundException) { return false; }
     }
 
+    public async Task SpawnQueueJobAsync(
+        string jobId, string redisUrl, string configPath, CancellationToken cancellationToken)
+    {
+        var containerName = $"agentsmith-{jobId}";
+        using var client = CreateDockerClient();
+
+        var networkResolver = new DockerNetworkResolver(options, logger);
+        var network = await networkResolver.ResolveAsync(client, cancellationToken);
+
+        var createParams = new CreateContainerParameters
+        {
+            Name = containerName, Image = options.Image,
+            Cmd =
+            [
+                "run-claimed-job",
+                "--job-id", jobId,
+                "--redis-url", redisUrl,
+                "--config", configPath,
+            ],
+            Env = BuildQueueEnv(jobId, redisUrl),
+            Labels = new Dictionary<string, string>
+            {
+                ["app"] = "agentsmith", ["job-id"] = jobId,
+                ["spawned-from"] = "queue",
+                ["managed-by"] = "agentsmith-dispatcher"
+            },
+            HostConfig = new HostConfig
+            {
+                AutoRemove = true, NetworkMode = network,
+                Memory = 1 * 1024 * 1024 * 1024L, MemoryReservation = 512 * 1024 * 1024L,
+                NanoCPUs = 1_000_000_000L,
+            }
+        };
+
+        logger.LogInformation(
+            "Creating Docker queue container {Name} (id={JobId})", containerName, jobId);
+
+        CreateContainerResponse response;
+        try { response = await client.Containers.CreateContainerAsync(createParams, cancellationToken); }
+        catch (DockerImageNotFoundException)
+        {
+            throw new InvalidOperationException(
+                $"Agent image '{options.Image}' not found. Run: docker build -t {options.Image} .");
+        }
+
+        await client.Containers.StartContainerAsync(response.ID, new ContainerStartParameters(), cancellationToken);
+        logger.LogInformation("Started queue container {Name} (jobId={JobId})", containerName, jobId);
+    }
+
+    private static List<string> BuildQueueEnv(string jobId, string redisUrl)
+    {
+        var env = new List<string>
+        {
+            $"JOB_ID={jobId}",
+            $"REDIS_URL={redisUrl}",
+        };
+        foreach (var varName in ForwardedEnvVars)
+        {
+            if (varName == "REDIS_URL") continue;
+            var value = Environment.GetEnvironmentVariable(varName);
+            if (!string.IsNullOrEmpty(value)) env.Add($"{varName}={value}");
+        }
+        return env;
+    }
+
     private static DockerClient CreateDockerClient()
     {
         var dockerHost = Environment.GetEnvironmentVariable("DOCKER_HOST");

--- a/src/AgentSmith.Server/Services/JobSpawnerPipelineDispatcher.cs
+++ b/src/AgentSmith.Server/Services/JobSpawnerPipelineDispatcher.cs
@@ -1,0 +1,36 @@
+using AgentSmith.Contracts.Models;
+using AgentSmith.Contracts.Models.Configuration;
+using AgentSmith.Contracts.Services;
+using AgentSmith.Server.Contracts;
+using Microsoft.Extensions.Logging;
+
+namespace AgentSmith.Server.Services;
+
+/// <summary>
+/// p0113: Server-side adapter from Application's IPipelineJobDispatcher to
+/// IJobSpawner. Generates jobId, persists the request via IPipelineRequestStore,
+/// then spawns an ephemeral CLI container that loads the request by jobId.
+/// </summary>
+public sealed class JobSpawnerPipelineDispatcher(
+    IJobSpawner jobSpawner,
+    IPipelineRequestStore requestStore,
+    ServerContext serverContext,
+    ILogger<JobSpawnerPipelineDispatcher> logger) : IPipelineJobDispatcher
+{
+    private static readonly TimeSpan RequestTtl = TimeSpan.FromHours(1);
+
+    public async Task<string> DispatchAsync(PipelineRequest request, CancellationToken cancellationToken)
+    {
+        var jobId = Guid.NewGuid().ToString("N")[..12];
+        var redisUrl = Environment.GetEnvironmentVariable("REDIS_URL") ?? "redis:6379";
+
+        await requestStore.SaveAsync(jobId, request, RequestTtl, cancellationToken);
+        await jobSpawner.SpawnQueueJobAsync(jobId, redisUrl, serverContext.ConfigPath, cancellationToken);
+
+        logger.LogInformation(
+            "Dispatched queue job {JobId}: {Project}/#{Ticket} pipeline={Pipeline}",
+            jobId, request.ProjectName, request.TicketId?.Value ?? "—", request.PipelineName);
+
+        return jobId;
+    }
+}

--- a/src/AgentSmith.Server/Services/KubernetesJobSpawner.cs
+++ b/src/AgentSmith.Server/Services/KubernetesJobSpawner.cs
@@ -58,6 +58,100 @@ public sealed class KubernetesJobSpawner(
         }
     }
 
+    public async Task SpawnQueueJobAsync(
+        string jobId, string redisUrl, string configPath, CancellationToken cancellationToken)
+    {
+        var jobName = $"agentsmith-{jobId}";
+        var job = BuildQueueJob(jobName, jobId, redisUrl, configPath);
+
+        await k8sClient.BatchV1.CreateNamespacedJobAsync(
+            job, options.Namespace, cancellationToken: cancellationToken);
+
+        logger.LogInformation(
+            "Spawned K8s queue Job {JobName} (id={JobId})", jobName, jobId);
+    }
+
+    private V1Job BuildQueueJob(string jobName, string jobId, string redisUrl, string configPath) => new()
+    {
+        Metadata = new V1ObjectMeta
+        {
+            Name = jobName,
+            NamespaceProperty = options.Namespace,
+            Labels = new Dictionary<string, string>
+            {
+                ["app"] = "agentsmith",
+                ["job-id"] = jobId,
+                ["spawned-from"] = "queue"
+            }
+        },
+        Spec = new V1JobSpec
+        {
+            TtlSecondsAfterFinished = options.TtlSecondsAfterFinished,
+            BackoffLimit = 0,
+            Template = new V1PodTemplateSpec
+            {
+                Metadata = new V1ObjectMeta
+                {
+                    Labels = new Dictionary<string, string>
+                    {
+                        ["app"] = "agentsmith",
+                        ["job-id"] = jobId,
+                        ["spawned-from"] = "queue"
+                    }
+                },
+                Spec = new V1PodSpec
+                {
+                    RestartPolicy = "Never",
+                    Containers =
+                    [
+                        new V1Container
+                        {
+                            Name = "agentsmith",
+                            Image = options.Image,
+                            ImagePullPolicy = options.ImagePullPolicy,
+                            Args =
+                            [
+                                "run-claimed-job",
+                                "--job-id", jobId,
+                                "--redis-url", redisUrl,
+                                "--config", configPath,
+                            ],
+                            Env = BuildQueueEnv(jobId, redisUrl),
+                            Resources = new V1ResourceRequirements
+                            {
+                                Requests = new Dictionary<string, ResourceQuantity>
+                                {
+                                    ["cpu"] = new("250m"),
+                                    ["memory"] = new("512Mi")
+                                },
+                                Limits = new Dictionary<string, ResourceQuantity>
+                                {
+                                    ["cpu"] = new("1000m"),
+                                    ["memory"] = new("1Gi")
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    };
+
+    private List<V1EnvVar> BuildQueueEnv(string jobId, string redisUrl) =>
+    [
+        EnvFromSecret("ANTHROPIC_API_KEY", options.SecretName, "anthropic-api-key"),
+        EnvFromSecret("AZURE_DEVOPS_TOKEN", options.SecretName, "azure-devops-token"),
+        EnvFromSecret("GITHUB_TOKEN", options.SecretName, "github-token"),
+        EnvFromSecret("OPENAI_API_KEY", options.SecretName, "openai-api-key"),
+        EnvFromSecret("AZURE_OPENAI_API_KEY", options.SecretName, "azure-openai-api-key"),
+        EnvFromSecret("GEMINI_API_KEY", options.SecretName, "gemini-api-key"),
+        EnvFromSecret("GITLAB_TOKEN", options.SecretName, "gitlab-token"),
+        EnvFromSecret("JIRA_TOKEN", options.SecretName, "jira-token"),
+        EnvFromSecret("JIRA_EMAIL", options.SecretName, "jira-email"),
+        new V1EnvVar { Name = "REDIS_URL", Value = redisUrl },
+        new V1EnvVar { Name = "JOB_ID", Value = jobId },
+    ];
+
     private V1Job BuildJob(string jobName, string jobId, JobRequest request, string redisUrl) => new()
     {
         Metadata = new V1ObjectMeta

--- a/tests/AgentSmith.Tests/Compaction/CompactionEventTests.cs
+++ b/tests/AgentSmith.Tests/Compaction/CompactionEventTests.cs
@@ -1,0 +1,56 @@
+using AgentSmith.Contracts.Models.Compaction;
+using FluentAssertions;
+
+namespace AgentSmith.Tests.Compaction;
+
+public sealed class CompactionEventTests
+{
+    [Fact]
+    public void WithVerifiedTokens_ReturnsNewInstanceWithFieldPopulated()
+    {
+        var pending = new CompactionEvent(
+            OldMessageCount: 24, NewMessageCount: 3,
+            PreCompactionEstimatedTokens: 134_000,
+            PostCompactionVerifiedTokens: null,
+            SummarizationCallTokens: 1_200,
+            PromptHash: "abc12345",
+            Failed: false, FailureReason: null);
+
+        var finalized = pending.WithVerifiedTokens(18_000);
+
+        finalized.PostCompactionVerifiedTokens.Should().Be(18_000);
+        finalized.OldMessageCount.Should().Be(24);
+        finalized.PromptHash.Should().Be("abc12345");
+        // Original unchanged (record immutability)
+        pending.PostCompactionVerifiedTokens.Should().BeNull();
+    }
+
+    [Fact]
+    public void VerifiedSavedTokens_PendingVerified_ReturnsNull()
+    {
+        var pending = new CompactionEvent(0, 0, 100, null, 0, "h", false, null);
+        pending.VerifiedSavedTokens.Should().BeNull();
+    }
+
+    [Fact]
+    public void VerifiedSavedTokens_AfterFinalization_ComputesDifference()
+    {
+        var finalized = new CompactionEvent(0, 0, 134_000, 18_000, 1_200, "h", false, null);
+        finalized.VerifiedSavedTokens.Should().Be(116_000);
+    }
+
+    [Fact]
+    public void ForFailure_ProducesEventWithFailedTrueAndReason()
+    {
+        var ev = CompactionEvent.ForFailure(oldCount: 12, estimatedTokens: 50_000, promptHash: "xyz", reason: "summarizer 429");
+
+        ev.Failed.Should().BeTrue();
+        ev.FailureReason.Should().Be("summarizer 429");
+        ev.OldMessageCount.Should().Be(12);
+        ev.NewMessageCount.Should().Be(12); // unchanged on failure
+        ev.PreCompactionEstimatedTokens.Should().Be(50_000);
+        ev.PostCompactionVerifiedTokens.Should().BeNull();
+        ev.SummarizationCallTokens.Should().Be(0);
+        ev.PromptHash.Should().Be("xyz");
+    }
+}

--- a/tests/AgentSmith.Tests/Compaction/OpenAiContextCompactorTests.cs
+++ b/tests/AgentSmith.Tests/Compaction/OpenAiContextCompactorTests.cs
@@ -1,0 +1,94 @@
+using AgentSmith.Contracts.Models.Configuration;
+using AgentSmith.Infrastructure.Services.Providers.Agent.Compaction;
+using AgentSmith.Tests.TestSupport;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using OpenAI.Chat;
+
+namespace AgentSmith.Tests.Compaction;
+
+public sealed class OpenAiContextCompactorTests
+{
+    private static readonly CompactionConfig EnabledConfig = new()
+    {
+        IsEnabled = true, ThresholdIterations = 8, MaxContextTokens = 80_000
+    };
+
+    [Fact]
+    public async Task CompactIfNeededAsync_DisabledConfig_ReturnsInputUnchangedNullEvent()
+    {
+        var disabled = new CompactionConfig { IsEnabled = false };
+        var sut = NewSut(disabled);
+        var messages = TwoMessages();
+
+        var result = await sut.CompactIfNeededAsync(messages, currentIterations: 100, estimatedAccumulatedTokens: 999_999, CancellationToken.None);
+
+        result.Messages.Should().BeSameAs(messages);
+        result.Event.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task CompactIfNeededAsync_BelowBothThresholds_ReturnsInputUnchanged()
+    {
+        var sut = NewSut(EnabledConfig);
+        var messages = TwoMessages();
+
+        var result = await sut.CompactIfNeededAsync(messages, currentIterations: 1, estimatedAccumulatedTokens: 100, CancellationToken.None);
+
+        result.Messages.Should().BeSameAs(messages);
+        result.Event.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task CompactIfNeededAsync_TriggerCrossedButTinyMessageList_ReturnsInputUnchanged()
+    {
+        // Iteration trigger crosses but only system + user are present — nothing to compact.
+        var sut = NewSut(EnabledConfig);
+        var messages = TwoMessages();
+
+        var result = await sut.CompactIfNeededAsync(messages, currentIterations: 100, estimatedAccumulatedTokens: 100, CancellationToken.None);
+
+        result.Messages.Should().BeSameAs(messages);
+        result.Event.Should().BeNull();
+    }
+
+    [Fact]
+    public void EstimateTokens_EmptyList_ReturnsZero()
+    {
+        OpenAiContextCompactor.EstimateTokens(Array.Empty<ChatMessage>()).Should().Be(0);
+    }
+
+    [Fact]
+    public void EstimateTokens_KnownText_RoundsToCharsPerTokenHeuristic()
+    {
+        var messages = new List<ChatMessage>
+        {
+            new SystemChatMessage("0123456789AB") // 12 chars → 12/4 = 3 tokens
+        };
+        OpenAiContextCompactor.EstimateTokens(messages).Should().Be(3);
+    }
+
+    [Fact]
+    public async Task CompactIfNeededAsync_NoOpVariant_ReturnsInputUnchanged()
+    {
+        var sut = new NoOpOpenAiContextCompactor();
+
+        var result = await sut.CompactIfNeededAsync(TwoMessages(), 999, 999_999, CancellationToken.None);
+
+        result.Messages.Should().NotBeNull();
+        result.Event.Should().BeNull();
+    }
+
+    private static List<ChatMessage> TwoMessages() => new()
+    {
+        new SystemChatMessage("system"),
+        new UserChatMessage("hi")
+    };
+
+    private static OpenAiContextCompactor NewSut(CompactionConfig config) =>
+        new(
+            summarizerClient: new ChatClient("gpt-4o-mini", "test-key"),
+            config: config,
+            prompts: new FakePromptCatalog().WithPrompt("openai-context-compactor-system", "summarize"),
+            logger: NullLogger<OpenAiContextCompactor>.Instance);
+}

--- a/tests/AgentSmith.Tests/Compaction/ToolCallRoundIdentifierTests.cs
+++ b/tests/AgentSmith.Tests/Compaction/ToolCallRoundIdentifierTests.cs
@@ -1,0 +1,104 @@
+using AgentSmith.Infrastructure.Services.Providers.Agent.Compaction;
+using FluentAssertions;
+using OpenAI.Chat;
+
+namespace AgentSmith.Tests.Compaction;
+
+public sealed class ToolCallRoundIdentifierTests
+{
+    [Fact]
+    public void FindTailStartIndex_NoMessages_ReturnsZero()
+    {
+        ToolCallRoundIdentifier.FindTailStartIndex(Array.Empty<ChatMessage>(), 2)
+            .Should().Be(0);
+    }
+
+    [Fact]
+    public void FindTailStartIndex_NRoundsZero_ReturnsCount()
+    {
+        var messages = new List<ChatMessage>
+        {
+            new SystemChatMessage("sys"),
+            new UserChatMessage("hi")
+        };
+        ToolCallRoundIdentifier.FindTailStartIndex(messages, 0)
+            .Should().Be(messages.Count);
+    }
+
+    [Fact]
+    public void FindTailStartIndex_BareAssistantReply_CountsAsOneRound()
+    {
+        var messages = new List<ChatMessage>
+        {
+            new SystemChatMessage("sys"),
+            new UserChatMessage("hi"),
+            new AssistantChatMessage("plain reply")
+        };
+
+        var idx = ToolCallRoundIdentifier.FindTailStartIndex(messages, 1);
+
+        // The assistant reply is the only round; tail starts at index 2.
+        idx.Should().Be(2);
+    }
+
+    [Fact]
+    public void FindTailStartIndex_TwoCompleteToolRounds_BoundaryRespectsPair()
+    {
+        var fakeToolCall1 = ChatToolCall.CreateFunctionToolCall("call_1", "list_files", BinaryData.FromString("{}"));
+        var fakeToolCall2 = ChatToolCall.CreateFunctionToolCall("call_2", "read_file", BinaryData.FromString("{}"));
+
+        var messages = new List<ChatMessage>
+        {
+            new SystemChatMessage("sys"),
+            new UserChatMessage("analyze"),
+            new AssistantChatMessage(new[] { fakeToolCall1 }),
+            new ToolChatMessage("call_1", "result_1"),
+            new AssistantChatMessage(new[] { fakeToolCall2 }),
+            new ToolChatMessage("call_2", "result_2"),
+            new AssistantChatMessage("done")
+        };
+
+        var idxKeep2 = ToolCallRoundIdentifier.FindTailStartIndex(messages, 2);
+
+        // 2 rounds at tail = "done" (round 1) + read_file pair (round 2).
+        // Tail starts at the AssistantChatMessage with read_file (index 4).
+        idxKeep2.Should().Be(4);
+    }
+
+    [Fact]
+    public void FindTailStartIndex_AllMessagesFitInN_ReturnsFirstAssistantRoundIndex()
+    {
+        var fakeToolCall = ChatToolCall.CreateFunctionToolCall("call_x", "f", BinaryData.FromString("{}"));
+        var messages = new List<ChatMessage>
+        {
+            new SystemChatMessage("sys"),
+            new UserChatMessage("u"),
+            new AssistantChatMessage(new[] { fakeToolCall }),
+            new ToolChatMessage("call_x", "r")
+        };
+
+        var idx = ToolCallRoundIdentifier.FindTailStartIndex(messages, 5);
+
+        // Only 1 complete round exists; identifier returns its boundary.
+        idx.Should().Be(2);
+    }
+
+    [Fact]
+    public void FindTailStartIndex_ToolMessageWithoutAssistant_StopsAtUserBoundary()
+    {
+        // Pathological: tool messages without preceding assistant. Identifier should not crash;
+        // it gives up when a non-Assistant non-Tool message blocks the walk.
+        var messages = new List<ChatMessage>
+        {
+            new SystemChatMessage("sys"),
+            new UserChatMessage("u"),
+            new ToolChatMessage("orphan_call", "weird")
+        };
+
+        var idx = ToolCallRoundIdentifier.FindTailStartIndex(messages, 1);
+
+        // Walking backward: skip ToolChatMessage(orphan_call), hit UserChatMessage —
+        // not an assistant, can't form a round. idx points after walked tool messages.
+        idx.Should().Be(2);
+    }
+}

--- a/tests/AgentSmith.Tests/Factories/AgenticAnalyzerFactoryTests.cs
+++ b/tests/AgentSmith.Tests/Factories/AgenticAnalyzerFactoryTests.cs
@@ -21,7 +21,7 @@ public class AgenticAnalyzerFactoryTests : IDisposable
         Environment.SetEnvironmentVariable("OPENAI_API_KEY", "test-key");
         Environment.SetEnvironmentVariable("GEMINI_API_KEY", "test-key");
         Environment.SetEnvironmentVariable("AZURE_OPENAI_API_KEY", "test-key");
-        _sut = new AgenticAnalyzerFactory(_secrets, NullLoggerFactory.Instance);
+        _sut = new AgenticAnalyzerFactory(_secrets, new FakePromptCatalog(), NullLoggerFactory.Instance);
     }
 
     public void Dispose()

--- a/tests/AgentSmith.Tests/Handlers/PersistWorkBranchHandlerTests.cs
+++ b/tests/AgentSmith.Tests/Handlers/PersistWorkBranchHandlerTests.cs
@@ -1,0 +1,173 @@
+using AgentSmith.Application.Models;
+using AgentSmith.Application.Services.Handlers;
+using AgentSmith.Contracts.Commands;
+using AgentSmith.Contracts.Models.Configuration;
+using AgentSmith.Contracts.Models.Lifecycle;
+using AgentSmith.Contracts.Providers;
+using AgentSmith.Domain.Entities;
+using AgentSmith.Domain.Models;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace AgentSmith.Tests.Handlers;
+
+public sealed class PersistWorkBranchHandlerTests
+{
+    private readonly Mock<ISourceProviderFactory> _factoryMock = new();
+    private readonly Mock<ISourceProvider> _providerMock = new();
+    private readonly PersistWorkBranchHandler _handler;
+
+    public PersistWorkBranchHandlerTests()
+    {
+        _factoryMock.Setup(f => f.Create(It.IsAny<SourceConfig>())).Returns(_providerMock.Object);
+        _handler = new PersistWorkBranchHandler(
+            _factoryMock.Object,
+            NullLogger<PersistWorkBranchHandler>.Instance);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NoRepositoryInPipeline_FailsWithUnknownKind()
+    {
+        var pipeline = new PipelineContext();
+        var ctx = NewContext(pipeline);
+
+        var result = await _handler.ExecuteAsync(ctx, CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        pipeline.Get<PersistFailureKind>(ContextKeys.PersistFailureKind)
+            .Should().Be(PersistFailureKind.Unknown);
+        _providerMock.Verify(p => p.CommitAndPushAsync(
+            It.IsAny<Repository>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_CommitAndPushSucceeds_ReturnsOkAndDoesNotSetFailureKind()
+    {
+        var pipeline = NewPipelineWithRepo();
+        var ctx = NewContext(pipeline);
+
+        var result = await _handler.ExecuteAsync(ctx, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        pipeline.TryGet<PersistFailureKind>(ContextKeys.PersistFailureKind, out _).Should().BeFalse();
+        _providerMock.Verify(p => p.CommitAndPushAsync(
+            It.IsAny<Repository>(),
+            It.Is<string>(m => m.Contains("Run-Id:") && m.Contains("Pipeline:") && m.Contains("Failed-Step:")),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_CommitMessageIncludesPipelineContextValues()
+    {
+        var pipeline = NewPipelineWithRepo();
+        pipeline.Set(ContextKeys.RunId, "abc12345");
+        pipeline.Set(ContextKeys.FailedStepName, "Generating plan");
+        pipeline.Set(ContextKeys.ResolvedPipeline,
+            new ResolvedPipelineConfig("default", new AgentConfig(), "/skills", null));
+        var ctx = NewContext(pipeline);
+        string? capturedMessage = null;
+        _providerMock.Setup(p => p.CommitAndPushAsync(
+                It.IsAny<Repository>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Callback<Repository, string, CancellationToken>((_, msg, _) => capturedMessage = msg)
+            .Returns(Task.CompletedTask);
+
+        await _handler.ExecuteAsync(ctx, CancellationToken.None);
+
+        capturedMessage.Should().NotBeNull();
+        capturedMessage!.Should().Contain("Run-Id: abc12345");
+        capturedMessage.Should().Contain("Pipeline: default");
+        capturedMessage.Should().Contain("Failed-Step: Generating plan");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_EmptyCommitException_FailsWithNoChangesKind()
+    {
+        var pipeline = NewPipelineWithRepo();
+        _providerMock.Setup(p => p.CommitAndPushAsync(
+                It.IsAny<Repository>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("nothing to commit, working tree clean"));
+
+        var result = await _handler.ExecuteAsync(NewContext(pipeline), CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        pipeline.Get<PersistFailureKind>(ContextKeys.PersistFailureKind)
+            .Should().Be(PersistFailureKind.NoChanges);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_AuthFailureMessage_FailsWithAuthDeniedKind()
+    {
+        var pipeline = NewPipelineWithRepo();
+        _providerMock.Setup(p => p.CommitAndPushAsync(
+                It.IsAny<Repository>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("HTTP 401 Unauthorized"));
+
+        var result = await _handler.ExecuteAsync(NewContext(pipeline), CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        pipeline.Get<PersistFailureKind>(ContextKeys.PersistFailureKind)
+            .Should().Be(PersistFailureKind.AuthDenied);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_DivergentRemoteMessage_FailsWithRemoteDivergentKind()
+    {
+        var pipeline = NewPipelineWithRepo();
+        _providerMock.Setup(p => p.CommitAndPushAsync(
+                It.IsAny<Repository>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("push rejected: non-fast-forward update"));
+
+        var result = await _handler.ExecuteAsync(NewContext(pipeline), CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        pipeline.Get<PersistFailureKind>(ContextKeys.PersistFailureKind)
+            .Should().Be(PersistFailureKind.RemoteDivergent);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_HttpRequestException_FailsWithNetworkBlipKind()
+    {
+        var pipeline = NewPipelineWithRepo();
+        _providerMock.Setup(p => p.CommitAndPushAsync(
+                It.IsAny<Repository>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("Connection reset by peer"));
+
+        var result = await _handler.ExecuteAsync(NewContext(pipeline), CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        pipeline.Get<PersistFailureKind>(ContextKeys.PersistFailureKind)
+            .Should().Be(PersistFailureKind.NetworkBlip);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_UnclassifiedException_FailsWithUnknownKind()
+    {
+        var pipeline = NewPipelineWithRepo();
+        _providerMock.Setup(p => p.CommitAndPushAsync(
+                It.IsAny<Repository>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("disk full"));
+
+        var result = await _handler.ExecuteAsync(NewContext(pipeline), CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        pipeline.Get<PersistFailureKind>(ContextKeys.PersistFailureKind)
+            .Should().Be(PersistFailureKind.Unknown);
+    }
+
+    private static PipelineContext NewPipelineWithRepo()
+    {
+        var pipeline = new PipelineContext();
+        var repo = new Repository(
+            "/tmp/work",
+            new BranchName("agent-smith/18693"),
+            "https://example.com/x/y.git");
+        pipeline.Set(ContextKeys.Repository, repo);
+        return pipeline;
+    }
+
+    private static PersistWorkBranchContext NewContext(PipelineContext pipeline) =>
+        new(new SourceConfig { Type = "azurerepos", Url = "https://dev.azure.com/x/y" },
+            new AgentConfig(),
+            pipeline);
+}

--- a/tests/AgentSmith.Tests/Server/ServerDiLifetimeTests.cs
+++ b/tests/AgentSmith.Tests/Server/ServerDiLifetimeTests.cs
@@ -180,6 +180,7 @@ public sealed class ServerDiLifetimeTests
     {
         services.AddSingleton(Mock.Of<IConnectionMultiplexer>());
         services.AddSingleton<IRedisJobQueue, NullRedisJobQueue>();
+        services.AddSingleton(Mock.Of<IPipelineRequestStore>());
         services.AddSingleton(Mock.Of<IRedisClaimLock>());
         services.AddSingleton<IRedisLeaderLease, NullRedisLeaderLease>();
         services.AddSingleton<IJobHeartbeatService, NullJobHeartbeatService>();

--- a/tests/AgentSmith.Tests/Services/CommandContextFactoryTests.cs
+++ b/tests/AgentSmith.Tests/Services/CommandContextFactoryTests.cs
@@ -72,7 +72,7 @@ public class CommandContextFactoryTests
 
         result.Should().BeOfType<CheckoutSourceContext>();
         var ctx = (CheckoutSourceContext)result;
-        ctx.Branch!.Value.Should().Be("fix/456");
+        ctx.Branch!.Value.Should().Be("agent-smith/456");
     }
 
     [Fact]

--- a/tests/AgentSmith.Tests/Services/PipelineQueueConsumerTests.cs
+++ b/tests/AgentSmith.Tests/Services/PipelineQueueConsumerTests.cs
@@ -1,0 +1,100 @@
+using AgentSmith.Application.Services;
+using AgentSmith.Contracts.Models;
+using AgentSmith.Contracts.Services;
+using AgentSmith.Domain.Models;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace AgentSmith.Tests.Services;
+
+public sealed class PipelineQueueConsumerTests
+{
+    [Fact]
+    public async Task RunAsync_ConsumesRequest_DispatchesViaJobDispatcher()
+    {
+        var dispatched = new List<PipelineRequest>();
+        var dispatcher = new Mock<IPipelineJobDispatcher>();
+        dispatcher.Setup(d => d.DispatchAsync(It.IsAny<PipelineRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<PipelineRequest, CancellationToken>((req, _) => dispatched.Add(req))
+            .ReturnsAsync("job-12345678");
+
+        var queue = new StubQueue([
+            new PipelineRequest("proj-a", "fix-bug", new TicketId("11"), Headless: true),
+            new PipelineRequest("proj-b", "fix-bug", new TicketId("12"), Headless: true),
+        ]);
+
+        var services = new ServiceCollection();
+        services.AddSingleton(dispatcher.Object);
+        var provider = services.BuildServiceProvider();
+
+        var consumer = new PipelineQueueConsumer(
+            provider, queue, configPath: "/tmp/config.yml",
+            maxParallelJobs: 2, shutdownGraceSeconds: 1,
+            NullLogger<PipelineQueueConsumer>.Instance);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        await consumer.RunAsync(cts.Token);
+
+        dispatched.Should().HaveCount(2);
+        dispatched.Select(r => r.ProjectName).Should().BeEquivalentTo(["proj-a", "proj-b"]);
+        dispatcher.Verify(d => d.DispatchAsync(It.IsAny<PipelineRequest>(), It.IsAny<CancellationToken>()),
+            Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task RunAsync_DispatcherThrows_LogsAndContinues()
+    {
+        var dispatcher = new Mock<IPipelineJobDispatcher>();
+        var calls = 0;
+        dispatcher.Setup(d => d.DispatchAsync(It.IsAny<PipelineRequest>(), It.IsAny<CancellationToken>()))
+            .Returns<PipelineRequest, CancellationToken>((_, _) =>
+            {
+                calls++;
+                if (calls == 1) throw new InvalidOperationException("spawn failed");
+                return Task.FromResult("job-second");
+            });
+
+        var queue = new StubQueue([
+            new PipelineRequest("proj-a", "fix-bug", new TicketId("1"), Headless: true),
+            new PipelineRequest("proj-b", "fix-bug", new TicketId("2"), Headless: true),
+        ]);
+
+        var services = new ServiceCollection();
+        services.AddSingleton(dispatcher.Object);
+        var provider = services.BuildServiceProvider();
+
+        var consumer = new PipelineQueueConsumer(
+            provider, queue, configPath: "/tmp/config.yml",
+            maxParallelJobs: 1, shutdownGraceSeconds: 1,
+            NullLogger<PipelineQueueConsumer>.Instance);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        await consumer.RunAsync(cts.Token);
+
+        calls.Should().Be(2);
+    }
+
+    private sealed class StubQueue(IReadOnlyList<PipelineRequest> items) : IRedisJobQueue
+    {
+        public Task EnqueueAsync(PipelineRequest request, CancellationToken cancellationToken) =>
+            Task.CompletedTask;
+
+        public Task<long> LenAsync(CancellationToken cancellationToken) =>
+            Task.FromResult((long)items.Count);
+
+        public async IAsyncEnumerable<PipelineRequest> ConsumeAsync(
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            foreach (var item in items)
+            {
+                if (cancellationToken.IsCancellationRequested) yield break;
+                yield return item;
+                await Task.Yield();
+            }
+            // Stay open until cancellation so the consumer's await foreach awaits.
+            await Task.Delay(Timeout.Infinite, cancellationToken).ContinueWith(_ => { }, TaskScheduler.Default);
+        }
+    }
+}

--- a/tests/AgentSmith.Tests/Services/TicketBranchNamerTests.cs
+++ b/tests/AgentSmith.Tests/Services/TicketBranchNamerTests.cs
@@ -1,0 +1,65 @@
+using AgentSmith.Application.Services;
+using AgentSmith.Domain.Exceptions;
+using AgentSmith.Domain.Models;
+using FluentAssertions;
+
+namespace AgentSmith.Tests.Services;
+
+public sealed class TicketBranchNamerTests
+{
+    [Fact]
+    public void Compose_SingleSegment_ReturnsAgentSmithSlashTicketId()
+    {
+        var branch = TicketBranchNamer.Compose(new TicketId("18693"));
+        branch.Value.Should().Be("agent-smith/18693");
+    }
+
+    [Fact]
+    public void Compose_HierarchicalForm_LowercasesAndSlugifiesPlatformAndProject()
+    {
+        var branch = TicketBranchNamer.Compose("AzureRepos", "Cloud Development", new TicketId("18693"));
+        branch.Value.Should().Be("agent-smith/azurerepos/cloud-development/18693");
+    }
+
+    [Fact]
+    public void Compose_HierarchicalForm_UnicodeProjectNameSlugifiesToAscii()
+    {
+        var branch = TicketBranchNamer.Compose("github", "Käseträger Über-Service", new TicketId("42"));
+        branch.Value.Should().Be("agent-smith/github/k-setr-ger-ber-service/42");
+    }
+
+    [Fact]
+    public void Compose_HierarchicalForm_EmptyProjectName_Throws()
+    {
+        var act = () => TicketBranchNamer.Compose("github", "", new TicketId("1"));
+        act.Should().Throw<ConfigurationException>().WithMessage("*projectName must not be empty*");
+    }
+
+    [Fact]
+    public void Compose_HierarchicalForm_AllPunctuationProjectName_ThrowsAfterSlugify()
+    {
+        var act = () => TicketBranchNamer.Compose("github", "!!!---???", new TicketId("1"));
+        act.Should().Throw<ConfigurationException>().WithMessage("*empty slug*");
+    }
+
+    [Fact]
+    public void Compose_HierarchicalForm_OversizeProjectName_TruncatesWithSha1Suffix()
+    {
+        var longName = new string('a', 200);
+        var branch = TicketBranchNamer.Compose("github", longName, new TicketId("1"));
+
+        branch.Value.Should().StartWith("agent-smith/github/");
+        // Slug is capped at 64 chars: 56-char head + dash + 7-char hex hash
+        var slug = branch.Value.Split('/')[2];
+        slug.Length.Should().Be(64);
+        slug.Should().MatchRegex(@"^a{56}-[0-9a-f]{7}$");
+    }
+
+    [Fact]
+    public void Compose_HierarchicalForm_StableForSameInputs()
+    {
+        var b1 = TicketBranchNamer.Compose("AzureRepos", "Cloud Development", new TicketId("18693"));
+        var b2 = TicketBranchNamer.Compose("AzureRepos", "Cloud Development", new TicketId("18693"));
+        b1.Value.Should().Be(b2.Value);
+    }
+}


### PR DESCRIPTION
## Summary

Combined PR for the three follow-up phases scoped from the AAD-DEV production-run findings. Each is independent (no `requires` chain in the spec) but they ship together for one review pass.

| Commit | Phase | What it does |
|--------|-------|--------------|
| eb2a311 | **p0114** | OpenAI / Azure-OpenAI context compactor — flat-line token growth on long agentic loops |
| 0211dfb | **p0112a** | Branch persistence MVP — push `[wip]` commit on pipeline failure so the next run resumes from the remote |
| c006e2e | **p0113a** | Spawn pipeline jobs MVP — Server becomes dispatcher, ephemeral CLI containers execute |

Replaces the three individual PRs (#60, #61, #62) — those will be closed in favor of this one.

---

## p0114: OpenAI context compactor

**Problem.** `p0008` shipped \`ClaudeContextCompactor\`; the OpenAI / Azure-OpenAI agentic loops never got the equivalent. Long runs (ProjectAnalyzer at ~864k tokens, AgenticExecute over many iterations) accumulate the full conversation history each turn — quadratic cost.

**Ships.**
- \`OpenAiContextCompactor\` with the same trigger model as Claude (\`CompactionConfig\` threshold-iterations / max-context-tokens), tuned summarization prompt loaded via \`IPromptCatalog\`, separate cost tracking for the summarizer call.
- \`ToolCallRoundIdentifier\` — walks message history backward to find the last N **complete** tool-call rounds (assistant + matching tool messages). Naive last-N slicing would split tool_calls from their tool-result responses and the next API call would reject with \"tool_call_id without matching tool message\".
- \`CompactionEvent\` — pre-compaction estimated tokens (drives trigger) AND post-compaction verified tokens (next response's \`usage.prompt_tokens\` is authoritative). Two distinct numbers, two purposes.
- \`CompactionConfig.DeploymentName\` configurable from day one (compaction is summarization — \`gpt-4o-mini\` suffices and saves real money).
- Plumbed through \`OpenAiAgenticAnalyzer\`, \`AzureOpenAiAgenticAnalyzer\`, \`OpenAiAgenticLoop\` with explicit \"COMPACTION POINT\" comments at each call site to flag tool-call sequence assumptions.
- 18 new tests (\`ToolCallRoundIdentifierTests\`, \`OpenAiContextCompactorTests\`, \`CompactionEventTests\`).
- Docs: \`docs/concepts/context-compaction.md\` + \`agentsmith-yml.md\` updates.

---

## p0112a: branch persistence MVP

**Problem.** When a pipeline fails after \`AgenticExecute\` has produced local code changes, today those changes die with the consumer pod's \`/tmp\` — re-runs replay every analyzer call from scratch (token waste, non-idempotent for LLM rounds).

**Ships.**
- \`TicketBranchNamer\` — static helper, composes \`agent-smith/<ticketId>\` (single-segment) or \`agent-smith/<platform>/<projectSlug>/<ticketId>\` (hierarchical), with slug rules and oversize SHA-1 truncation.
- \`PersistWorkBranchHandler\` — runs in the failure path, builds \`[wip]\` commit with \`Run-Id\` / \`Pipeline\` / \`Failed-Step\` trailers, classifies push exceptions into \`PersistFailureKind\` ∈ \`{NoChanges, AuthDenied, RemoteDivergent, NetworkBlip, Unknown}\`.
- \`PipelineExecutor.TryPersistWorkBranchAsync\` — invoked **before** \`lifecycle.MarkFailed()\`, with its own try/catch so persist exceptions can never replace the original pipeline failure cause.
- \`AzureGitOperations.CheckoutBranch\` — resume path: local → checkout, else fetch + look for \`origin/<branch>\` → tracking branch + checkout (preserves prior WIP commits), else fresh from HEAD.
- Legacy \`BranchName.FromTicket\` (\`fix/<ticketId>\`) **removed**. AAD-DEV is the production target; operator confirmed no in-flight work uses the legacy prefix.
- 15 new tests covering all five \`PersistFailureKind\` paths and the namer slug rules.
- Docs: \`docs/concepts/branch-persistence.md\` (new) + \`ticket-lifecycle.md\` \"What survives what\" row.

**Deferred to p0112b.** Multi-provider parity (only AzureGitOperations wired here), PR-aware push (flip to Draft on GitHub/GitLab), pre-push divergent-remote detection, \`PersistFailureCounter\` Redis-backed escalation, \`AGENTSMITH_TEST_FAIL_AFTER\` fail-injection.

---

## p0113a: spawn pipeline jobs from queue

**Problem.** \`PipelineQueueConsumer\` runs pipelines in-process inside the Server pod, which means Server's container needs every language's toolchain (dotnet SDK, npm, python, …) for steps like \`TestCommand\`. The Slack-intent path already uses \`IJobSpawner\`; the queue path is the architectural gap.

**Ships.**
- \`IPipelineJobDispatcher\` (Application/Contracts) — abstraction \`PipelineQueueConsumer\` depends on, independent of the spawn mechanism.
- \`JobSpawnerPipelineDispatcher\` (Server) — generates jobId, persists \`PipelineRequest\` via \`IPipelineRequestStore\` (Redis-backed, 1h TTL), then calls \`IJobSpawner.SpawnQueueJobAsync\`.
- \`IJobSpawner.SpawnQueueJobAsync\` — added to both \`DockerJobSpawner\` and \`KubernetesJobSpawner\` with full provider-token env forwarding (Anthropic / OpenAI / Azure-OpenAI / Gemini / GitHub / GitLab / AzureDevOps / Jira / Redis URL).
- \`run-claimed-job\` — hidden CLI subcommand (\`--job-id\`, \`--redis-url\`, \`--config\`). Loads \`PipelineRequest\` by jobId, calls the **structured** \`ExecutePipelineUseCase.ExecuteAsync(request, configPath, ct)\` overload — bypasses the intent parser, no string round-trip. Fails fast (exit code 2) when the request is missing/expired.
- \`PipelineQueueConsumer\` — switched from in-process \`useCase\` resolution to \`IPipelineJobDispatcher.DispatchAsync\`. \`SemaphoreSlim\` now bounds concurrent dispatch (fast: SETEX + spawn API) rather than in-flight pipeline count.
- 2 new consumer tests + DI lifetime test updated for the new graph.
- Docs: \`docs/concepts/spawned-jobs.md\` (new) + \`ticket-lifecycle.md\` updated for the cross-process boundary.

**Cross-boundary lifecycle:** \`Pending → Enqueued\` on Server (\`TicketClaimService\`); \`Enqueued → InProgress → Done | Failed\` inside the spawned container (\`PipelineExecutor\`). Spawn-window gap: \`EnqueuedReconciler\` (existing) sweeps stuck \`Enqueued\` tickets back to \`Pending\` after the configured stale-window.

**Deferred to p0113b.** \`SecretsForwardingPolicy\` whitelist, \`JobRequest.ImageOverride\` resolution chain, heartbeat-gap mitigation (write first heartbeat before DI build), \`AGENTSMITH_TEST_FAIL_AFTER\` env-var, Server/CLI Dockerfile cleanup.

---

## Risk + rollout

The three changes have very different blast radii:

- **p0114** is contained — it only changes the OpenAI/Azure-OpenAI agentic-loop behavior. Off-by-default per \`CompactionConfig\` thresholds. Lowest risk.
- **p0112a** is failure-path-only — it adds work in the pipeline's catch block. If \`PersistWorkBranchHandler\` itself throws, the executor's wrapper logs and preserves the original failure cause. Low risk.
- **p0113a materially changes runtime behavior of the queue path** — Server pods stop executing pipelines and start dispatching them. Slack-intent flow is **untouched**. Highest risk; rollout should: (1) ensure the CLI image is reachable from the Server's spawn target (Docker socket / K8s API), (2) confirm \`agentsmith-secrets\` (K8s) holds all provider tokens the running pipeline needs, (3) watch \`EnqueuedReconciler\` logs after deploy — \"reverted N orphan tickets\" indicates spawn issues.

If splitting the rollout is preferred, the commits can be cherry-picked individually from this branch.

## Test plan

- [x] \`dotnet build\` — 0 warnings, 0 errors.
- [x] \`dotnet test\` — 1340/1340 green.
- [ ] Smoke verify in AAD-DEV: trigger a fix-bug, confirm the Server logs end at \"Dispatched: ... job=...\" and the spawned container picks it up; force a failure mid-run, confirm \`agent-smith/<ticketId>\` lands on the remote with the WIP commit; re-trigger the same ticket, confirm \"Resumed work branch ... from origin\".
- [ ] Smoke verify long agentic run with OpenAI/Azure-OpenAI provider: confirm compactor fires at threshold, \`CompactionEvent\` log shows pre/post token counts, run cost reduction visible in cost summary.
- [ ] Smoke verify EnqueuedReconciler recovery: point spawner at a non-pullable image, confirm ticket reverts to Pending after the stale-window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)