### PR TITLE
fix: triage no-ticket fallback + robust libgit2 staging + scan-pipeli…

### DIFF
--- a/src/AgentSmith.Application/Services/PipelineExecutor.cs
+++ b/src/AgentSmith.Application/Services/PipelineExecutor.cs
@@ -72,7 +72,7 @@ public sealed class PipelineExecutor(
 
             if (!result.IsSuccess)
             {
-                await TryPersistWorkBranchAsync(projectConfig, context, result, cancellationToken);
+                await TryPersistWorkBranchAsync(commandNames, projectConfig, context, result, cancellationToken);
                 lifecycle.MarkFailed();
                 return result;
             }
@@ -90,7 +90,7 @@ public sealed class PipelineExecutor(
     /// can NEVER overwrite the original failure cause already in <paramref name="originalFailure"/>.
     /// </summary>
     private async Task TryPersistWorkBranchAsync(
-        ProjectConfig projectConfig, PipelineContext context,
+        IReadOnlyList<string> commandNames, ProjectConfig projectConfig, PipelineContext context,
         CommandResult originalFailure, CancellationToken cancellationToken)
     {
         try
@@ -100,6 +100,14 @@ public sealed class PipelineExecutor(
 
             // Skip persist for source-less / discussion-style runs.
             if (!context.TryGet<AgentSmith.Domain.Entities.Repository>(ContextKeys.Repository, out _))
+                return;
+
+            // Skip persist for read-only pipelines (security-scan, api-security-scan, …).
+            // Without a code-modifying handler in the pipeline, the workdir contains scan
+            // artifacts (ZAP reports, findings JSON, …) that should NOT be staged into a
+            // WIP branch. Code-modifying handlers are AgenticExecute / GenerateTests /
+            // GenerateDocs — pipelines without any of those produce no source mutation.
+            if (!ContainsCodeModifyingHandler(commandNames))
                 return;
 
             var persistCmd = PipelineCommand.Simple(CommandNames.PersistWorkBranch);
@@ -117,6 +125,11 @@ public sealed class PipelineExecutor(
             logger.LogError(ex, "Work branch persist threw an exception — original failure cause preserved");
         }
     }
+
+    private static bool ContainsCodeModifyingHandler(IReadOnlyList<string> commandNames) =>
+        commandNames.Any(n => n == CommandNames.AgenticExecute
+                           || n == CommandNames.GenerateTests
+                           || n == CommandNames.GenerateDocs);
 
     internal static List<LinkedListNode<PipelineCommand>> PeelBatch(
         LinkedListNode<PipelineCommand> start, int maxConcurrent)

--- a/src/AgentSmith.Application/Services/Triage/TriageOutputProducer.cs
+++ b/src/AgentSmith.Application/Services/Triage/TriageOutputProducer.cs
@@ -44,15 +44,29 @@ public sealed class TriageOutputProducer(
 
     private TriageInput BuildInput(PipelineContext pipeline)
     {
-        var ticket = pipeline.Get<Ticket>(ContextKeys.Ticket);
+        var (ticketText, labels) = ResolveTicketOrSyntheticInput(pipeline);
         var excerpt = excerptBuilder.Build(pipeline);
         var skillIndex = LoadSkillIndex(pipeline);
         return new TriageInput(
-            Ticket: $"{ticket.Title}\n\n{ticket.Description}",
+            Ticket: ticketText,
             ProjectMapExcerpt: excerpt,
             AvailableSkills: skillIndex,
             Phases: DefaultPhases,
-            TicketLabels: ticket.Labels);
+            TicketLabels: labels);
+    }
+
+    internal static (string Ticket, IReadOnlyList<string> Labels) ResolveTicketOrSyntheticInput(
+        PipelineContext pipeline)
+    {
+        if (pipeline.TryGet<Ticket>(ContextKeys.Ticket, out var ticket) && ticket is not null)
+        {
+            return ($"{ticket.Title}\n\n{ticket.Description}", ticket.Labels);
+        }
+
+        var synthetic = pipeline.TryGet<object>(ContextKeys.SwaggerSpec, out _)
+            ? "API security scan. No ticket context — triage based on the project map and available scan skills."
+            : "Security scan. No ticket context — triage based on the project map and available scan skills.";
+        return (synthetic, Array.Empty<string>());
     }
 
     private static IReadOnlyList<SkillIndexEntry> LoadSkillIndex(PipelineContext pipeline)

--- a/src/AgentSmith.Infrastructure/Services/Providers/Source/LocalSourceProvider.cs
+++ b/src/AgentSmith.Infrastructure/Services/Providers/Source/LocalSourceProvider.cs
@@ -78,10 +78,34 @@ public sealed class LocalSourceProvider(string basePath) : ISourceProvider
         return remote?.Url ?? "";
     }
 
-    private static void StageAllChanges(LibGit2Sharp.Repository repo)
+    internal static void StageAllChanges(LibGit2Sharp.Repository repo)
     {
-        Commands.Stage(repo, "*");
+        // Per-file staging via RetrieveStatus instead of Commands.Stage(repo, "*").
+        // The "*" glob expands inside libgit2 and can return directory-shaped paths
+        // (e.g. "RHS.CICD/") that git_index_add_bypath then rejects with
+        // "invalid path: ...". Iterating workdir entries and staging each file path
+        // sidesteps the glob entirely.
+        var status = repo.RetrieveStatus(new StatusOptions
+        {
+            IncludeIgnored = false,
+            IncludeUntracked = true,
+            RecurseUntrackedDirs = true
+        });
+        foreach (var entry in status)
+        {
+            if (IsWorkdirChange(entry.State))
+            {
+                Commands.Stage(repo, entry.FilePath);
+            }
+        }
     }
+
+    private static bool IsWorkdirChange(FileStatus state) =>
+        state.HasFlag(FileStatus.NewInWorkdir) ||
+        state.HasFlag(FileStatus.ModifiedInWorkdir) ||
+        state.HasFlag(FileStatus.DeletedFromWorkdir) ||
+        state.HasFlag(FileStatus.RenamedInWorkdir) ||
+        state.HasFlag(FileStatus.TypeChangeInWorkdir);
 
     private static void CommitChanges(LibGit2Sharp.Repository repo, string message)
     {

--- a/tests/AgentSmith.Tests/Providers/LocalSourceProviderStagingTests.cs
+++ b/tests/AgentSmith.Tests/Providers/LocalSourceProviderStagingTests.cs
@@ -1,0 +1,115 @@
+using AgentSmith.Infrastructure.Services.Providers.Source;
+using FluentAssertions;
+using LibGit2Sharp;
+
+namespace AgentSmith.Tests.Providers;
+
+/// <summary>
+/// Regression guard for LocalSourceProvider.StageAllChanges. Original implementation
+/// used Commands.Stage(repo, "*") which expanded the glob inside libgit2 and could
+/// emit directory-shaped paths (e.g. "RHS.CICD/") that git_index_add_bypath then
+/// rejected with "invalid path: ...". Replaced with per-file iteration via
+/// RetrieveStatus. These tests run against a real on-disk LibGit2Sharp repo.
+/// </summary>
+public sealed class LocalSourceProviderStagingTests : IDisposable
+{
+    private readonly string _repoDir;
+
+    public LocalSourceProviderStagingTests()
+    {
+        _repoDir = Path.Combine(Path.GetTempPath(), $"as-stage-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_repoDir);
+        Repository.Init(_repoDir);
+    }
+
+    [Fact]
+    public void StageAllChanges_NewFileInRoot_StagedSuccessfully()
+    {
+        File.WriteAllText(Path.Combine(_repoDir, "new.txt"), "hello");
+
+        using var repo = new Repository(_repoDir);
+        LocalSourceProvider.StageAllChanges(repo);
+
+        repo.Index.Should().Contain(e => e.Path == "new.txt");
+    }
+
+    [Fact]
+    public void StageAllChanges_NewFilesInUntrackedSubdirectory_AllStagedNoExceptions()
+    {
+        Directory.CreateDirectory(Path.Combine(_repoDir, "RHS.CICD"));
+        File.WriteAllText(Path.Combine(_repoDir, "RHS.CICD", "config.yaml"), "k: v");
+        File.WriteAllText(Path.Combine(_repoDir, "RHS.CICD", "deploy.yaml"), "k: v");
+
+        using var repo = new Repository(_repoDir);
+        var act = () => LocalSourceProvider.StageAllChanges(repo);
+
+        act.Should().NotThrow();
+        repo.Index.Should().Contain(e => e.Path == "RHS.CICD/config.yaml");
+        repo.Index.Should().Contain(e => e.Path == "RHS.CICD/deploy.yaml");
+    }
+
+    [Fact]
+    public void StageAllChanges_ModifiedTrackedFile_Staged()
+    {
+        var path = Path.Combine(_repoDir, "tracked.txt");
+        File.WriteAllText(path, "v1");
+        using (var repo = new Repository(_repoDir))
+        {
+            LibGit2Sharp.Commands.Stage(repo, "tracked.txt");
+            var sig = new Signature("Test", "test@example.com", DateTimeOffset.UtcNow);
+            repo.Commit("init", sig, sig);
+        }
+        File.WriteAllText(path, "v2");
+
+        using var repo2 = new Repository(_repoDir);
+        LocalSourceProvider.StageAllChanges(repo2);
+
+        var staged = repo2.Diff.Compare<TreeChanges>(repo2.Head.Tip.Tree, DiffTargets.Index);
+        staged.Modified.Should().Contain(c => c.Path == "tracked.txt");
+    }
+
+    [Fact]
+    public void StageAllChanges_DeletedTrackedFile_Staged()
+    {
+        var path = Path.Combine(_repoDir, "doomed.txt");
+        File.WriteAllText(path, "bye");
+        using (var repo = new Repository(_repoDir))
+        {
+            LibGit2Sharp.Commands.Stage(repo, "doomed.txt");
+            var sig = new Signature("Test", "test@example.com", DateTimeOffset.UtcNow);
+            repo.Commit("init", sig, sig);
+        }
+        File.Delete(path);
+
+        using var repo2 = new Repository(_repoDir);
+        LocalSourceProvider.StageAllChanges(repo2);
+
+        var staged = repo2.Diff.Compare<TreeChanges>(repo2.Head.Tip.Tree, DiffTargets.Index);
+        staged.Deleted.Should().Contain(c => c.Path == "doomed.txt");
+    }
+
+    [Fact]
+    public void StageAllChanges_NoChanges_DoesNotThrow()
+    {
+        using var repo = new Repository(_repoDir);
+        var act = () => LocalSourceProvider.StageAllChanges(repo);
+
+        act.Should().NotThrow();
+    }
+
+    public void Dispose()
+    {
+        if (!Directory.Exists(_repoDir)) return;
+        try
+        {
+            foreach (var path in Directory.EnumerateFileSystemEntries(_repoDir, "*", SearchOption.AllDirectories))
+            {
+                var attrs = File.GetAttributes(path);
+                if (attrs.HasFlag(FileAttributes.ReadOnly))
+                    File.SetAttributes(path, attrs & ~FileAttributes.ReadOnly);
+            }
+            Directory.Delete(_repoDir, recursive: true);
+        }
+        catch (IOException) { /* leftover .git locks on some platforms — best-effort cleanup */ }
+    }
+}

--- a/tests/AgentSmith.Tests/Services/PipelineExecutorPersistGuardTests.cs
+++ b/tests/AgentSmith.Tests/Services/PipelineExecutorPersistGuardTests.cs
@@ -1,0 +1,113 @@
+using AgentSmith.Application.Services;
+using AgentSmith.Contracts.Commands;
+using AgentSmith.Contracts.Models.Configuration;
+using AgentSmith.Contracts.Providers;
+using AgentSmith.Contracts.Services;
+using AgentSmith.Domain.Entities;
+using AgentSmith.Domain.Models;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace AgentSmith.Tests.Services;
+
+/// <summary>
+/// Covers PipelineExecutor's read-only-pipeline guard around the WIP-persist wrapper:
+/// scan pipelines (security-scan, api-security-scan) — which have no
+/// AgenticExecute/GenerateTests/GenerateDocs handlers — must not trigger
+/// PersistWorkBranch on failure even when a Repository is in context.
+/// Without the guard, scan-pipeline failures used to attempt to stage scan
+/// artifacts (ZAP reports, findings JSON) into a WIP branch.
+/// </summary>
+public sealed class PipelineExecutorPersistGuardTests
+{
+    private readonly Mock<ICommandExecutor> _executorMock = new();
+    private readonly Mock<ICommandContextFactory> _factoryMock = new();
+    private readonly Mock<ITicketProviderFactory> _ticketFactoryMock = new();
+    private readonly Mock<IPipelineLifecycleCoordinator> _lifecycleMock = new();
+    private readonly Mock<IProgressReporter> _progressReporterMock = new();
+    private readonly PipelineExecutor _sut;
+
+    public PipelineExecutorPersistGuardTests()
+    {
+        _lifecycleMock
+            .Setup(c => c.BeginAsync(It.IsAny<ProjectConfig>(), It.IsAny<PipelineContext>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Mock.Of<IAsyncPipelineLifecycle>());
+        _sut = new PipelineExecutor(
+            _executorMock.Object,
+            _factoryMock.Object,
+            _ticketFactoryMock.Object,
+            _lifecycleMock.Object,
+            _progressReporterMock.Object,
+            NullLogger<PipelineExecutor>.Instance);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ScanPipelineFails_DoesNotCallPersistWorkBranchEvenWithRepository()
+    {
+        var pipeline = NewPipelineWithRepository();
+        var commands = new[] { CommandNames.SpawnNuclei, CommandNames.Triage, CommandNames.DeliverFindings };
+        ArrangeFirstCommandFailure(commands[0]);
+
+        var result = await _sut.ExecuteAsync(commands, new ProjectConfig(), pipeline, CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        AssertPersistWasNotInvoked();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_SourcelessPipelineFails_DoesNotCallPersistWorkBranch()
+    {
+        var pipeline = new PipelineContext();
+        var commands = new[] { CommandNames.AgenticExecute };
+        ArrangeFirstCommandFailure(commands[0]);
+
+        var result = await _sut.ExecuteAsync(commands, new ProjectConfig(), pipeline, CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        AssertPersistWasNotInvoked();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_CodeModifyingPipelineFails_AttemptsPersistWorkBranch()
+    {
+        var pipeline = NewPipelineWithRepository();
+        var commands = new[] { CommandNames.AgenticExecute, CommandNames.Test };
+        ArrangeFirstCommandFailure(commands[0]);
+
+        var result = await _sut.ExecuteAsync(commands, new ProjectConfig(), pipeline, CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        _factoryMock.Verify(f => f.Create(
+            It.Is<PipelineCommand>(c => c.Name == CommandNames.PersistWorkBranch),
+            It.IsAny<ProjectConfig>(),
+            It.IsAny<PipelineContext>()),
+            Times.Once);
+    }
+
+    private static PipelineContext NewPipelineWithRepository()
+    {
+        var pipeline = new PipelineContext();
+        pipeline.Set(ContextKeys.Repository,
+            new Repository("/tmp/some/path", new BranchName("main"), "https://example.com/repo.git"));
+        return pipeline;
+    }
+
+    private void ArrangeFirstCommandFailure(string commandName)
+    {
+        _factoryMock.Setup(f => f.Create(
+            It.Is<PipelineCommand>(c => c.Name == commandName),
+            It.IsAny<ProjectConfig>(),
+            It.IsAny<PipelineContext>()))
+            .Throws(new Exception($"{commandName} crashed for test"));
+    }
+
+    private void AssertPersistWasNotInvoked()
+    {
+        _factoryMock.Verify(f => f.Create(
+            It.Is<PipelineCommand>(c => c.Name == CommandNames.PersistWorkBranch),
+            It.IsAny<ProjectConfig>(),
+            It.IsAny<PipelineContext>()),
+            Times.Never);
+    }
+}

--- a/tests/AgentSmith.Tests/Triage/TriageOutputProducerInputTests.cs
+++ b/tests/AgentSmith.Tests/Triage/TriageOutputProducerInputTests.cs
@@ -1,0 +1,62 @@
+using AgentSmith.Application.Services.Triage;
+using AgentSmith.Contracts.Commands;
+using AgentSmith.Domain.Entities;
+using AgentSmith.Domain.Models;
+using FluentAssertions;
+
+namespace AgentSmith.Tests.Triage;
+
+/// <summary>
+/// Covers the no-ticket fallback in TriageOutputProducer.ResolveTicketOrSyntheticInput.
+/// Regression guard against the p0111c regression where api-security-scan and
+/// security-scan (both ticket-less pipelines) crashed Triage with
+/// KeyNotFoundException 'Ticket'.
+/// </summary>
+public sealed class TriageOutputProducerInputTests
+{
+    [Fact]
+    public void ResolveTicketOrSyntheticInput_TicketPresent_ReturnsTicketTitleAndDescription()
+    {
+        var pipeline = new PipelineContext();
+        var ticket = new Ticket(
+            new TicketId("T-1"),
+            "Fix login bug",
+            "Users cannot log in after password reset",
+            acceptanceCriteria: null,
+            status: "Open",
+            source: "Test",
+            labels: new[] { "bug", "auth" });
+        pipeline.Set(ContextKeys.Ticket, ticket);
+
+        var (text, labels) = TriageOutputProducer.ResolveTicketOrSyntheticInput(pipeline);
+
+        text.Should().Contain("Fix login bug");
+        text.Should().Contain("Users cannot log in after password reset");
+        labels.Should().BeEquivalentTo(new[] { "bug", "auth" });
+    }
+
+    [Fact]
+    public void ResolveTicketOrSyntheticInput_NoTicket_ReturnsSecurityScanSyntheticInput()
+    {
+        var pipeline = new PipelineContext();
+
+        var (text, labels) = TriageOutputProducer.ResolveTicketOrSyntheticInput(pipeline);
+
+        text.Should().StartWith("Security scan");
+        text.Should().Contain("No ticket context");
+        labels.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ResolveTicketOrSyntheticInput_NoTicketButSwaggerSpecPresent_ReturnsApiScanSyntheticInput()
+    {
+        var pipeline = new PipelineContext();
+        pipeline.Set(ContextKeys.SwaggerSpec, new object());
+
+        var (text, labels) = TriageOutputProducer.ResolveTicketOrSyntheticInput(pipeline);
+
+        text.Should().StartWith("API security scan");
+        text.Should().Contain("No ticket context");
+        labels.Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
…ne persist guard

Three independent bugs surfaced by an api-security-scan run, all on main:

1. Triage regression in scan pipelines (since p0111c, 1bf57d3) TriageOutputProducer.BuildInput unconditionally pulled Ticket from the pipeline context, but the unified Triage from p0111c is now in the ApiSecurityScan and SecurityScan presets — both of which have no FetchTicket step. Result: KeyNotFoundException on every scan run. Fix: TryGet + synthetic input when missing — "API security scan" or "Security scan" depending on whether SwaggerSpec is present. Empty labels in the synthetic case. Ticket-driven pipelines unchanged.

2. LibGit2Sharp glob-staging is brittle Commands.Stage(repo, "*") expanded inside libgit2 and could emit directory-shaped paths (observed: "RHS.CICD/" with trailing slash) that git_index_add_bypath then rejected with "invalid path: ...". Fix: replace the glob with per-file iteration over RetrieveStatus and stage each FilePath individually. Bug-independent of context #3 below — would also bite FixBug flows that produce unusual workdirs.

3. PersistWorkBranch fired on read-only scan pipelines PipelineExecutor's failure-recovery wrapper triggered PersistWorkBranch whenever a Repository was in context, regardless of whether the pipeline actually mutated source. For scan pipelines that means staging scan artifacts (ZAP reports, findings JSON) into a WIP branch, which is wrong by intent. Fix: extend the skip condition to also bail when the pipeline contains no code-modifying handler (AgenticExecute / GenerateTests / GenerateDocs).

11 new tests cover the regressions:
  - TriageOutputProducerInputTests (3): ticket present, scan synthetic, api-scan synthetic with SwaggerSpec.
  - LocalSourceProviderStagingTests (5): new file, untracked subdir (RHS.CICD/ regression), modified, deleted, no-changes.
  - PipelineExecutorPersistGuardTests (3): scan pipeline skips persist, sourceless skips, code-modifying pipeline still triggers.

1349 tests total, all green. ResolveTicketOrSyntheticInput + StageAllChanges made internal to enable direct unit testing (InternalsVisibleTo "AgentSmith.Tests" was already configured on both projects).