### PR TITLE
chore(config): default skills source in agentsmith.yml

### DIFF
--- a/config/agentsmith.yml
+++ b/config/agentsmith.yml
@@ -553,6 +553,9 @@ projects:
   #       bug: fix-bug
   #     default_pipeline: fix-bug
   #     comment_keyword: "@agent-smith"
+skills:
+  source: default                      # default | path | url
+  version: v1.0.0                      # required when source: default
 
 secrets:
   azure_devops_token: ${AZURE_DEVOPS_TOKEN}


### PR DESCRIPTION
## Summary
- Adds `skills.source` / `skills.version` block to the default `config/agentsmith.yml` so SkillLoader resolves skills via the default catalog tarball (released by agent-smith-skills) without operators needing to configure it explicitly.
- 3-line addition; no code changes.

## Note
Branch was opened on 2026-05-03 with `version: v1.0.0` as the pin. The skills repo has since released `1.5.0` (per p0122). Reviewer: bump the pin to current before merge if desired, or leave at `v1.0.0` and rely on operator override.

## Test plan
- [ ] CLI/Server boots with the default config and successfully resolves the skill catalog at the pinned version
- [ ] Operator override (`skills.source: path` / `url`) still wins over the default

🤖 Generated with [Claude Code](https://claude.com/claude-code)