### PR TITLE
fix(triage): tolerate skills with no activation criteria + clear warnings

### DIFF
--- a/src/AgentSmith.Application/Services/Handlers/GeneratePlanHandler.cs
+++ b/src/AgentSmith.Application/Services/Handlers/GeneratePlanHandler.cs
@@ -100,7 +100,7 @@ public sealed class GeneratePlanHandler(
                 : $"{projectContext}\n\n## Multi-Role Discussion\n\n{consolidated}";
         }
 
-        return projectContext;
+        return projectContext ?? string.Empty;
     }
 
     private static string BuildStructuredInput(ConvergenceResult convergenceResult)

--- a/src/AgentSmith.Application/Services/Handlers/TestHandler.cs
+++ b/src/AgentSmith.Application/Services/Handlers/TestHandler.cs
@@ -83,7 +83,7 @@ public sealed class TestHandler(
     private async Task<CommandResult> RunInSandboxAsync(
         TestContext context, ISandbox sandbox, TestCommand cmd, CancellationToken cancellationToken)
     {
-        logger.LogInformation("Running in sandbox: {Command} {Args}", cmd.Command, string.Join(' ', cmd.Args));
+        logger.LogInformation("Running in sandbox: {Command} {Args}", cmd.Command, string.Join(' ', cmd.Args ?? Array.Empty<string>()));
         var output = await ExecuteTestStepAsync(sandbox, cmd, cancellationToken);
 
         if (!cmd.IsTrxCapable)

--- a/src/AgentSmith.Application/Services/Triage/TriageOutputValidator.cs
+++ b/src/AgentSmith.Application/Services/Triage/TriageOutputValidator.cs
@@ -83,10 +83,25 @@ public sealed class TriageOutputValidator(TriageRationaleParser rationaleParser)
     {
         if (skill.Activation.Positive.Any(k => k.Key == key)) return true;
         if (skill.Activation.Negative.Any(k => k.Key == key)) return true;
-        if (!role.HasValue) return false;
-        var roleAssignment = skill.RoleAssignments.FirstOrDefault(r => r.Role == role.Value);
-        if (roleAssignment is null) return false;
-        return roleAssignment.Criteria.Positive.Any(k => k.Key == key)
-            || roleAssignment.Criteria.Negative.Any(k => k.Key == key);
+        if (role.HasValue)
+        {
+            var roleAssignment = skill.RoleAssignments.FirstOrDefault(r => r.Role == role.Value);
+            if (roleAssignment is not null
+                && (roleAssignment.Criteria.Positive.Any(k => k.Key == key)
+                    || roleAssignment.Criteria.Negative.Any(k => k.Key == key)))
+                return true;
+        }
+
+        // Defensive default: when a skill defines NO activation criteria and NO role-assignment
+        // criteria at all, treat any cited key as acceptable. The skill author hasn't expressed
+        // constraints, so the LLM has no valid keys to cite — rejecting them would block triage
+        // on a skill-metadata gap, not a real triage error.
+        return HasNoCriteriaAtAll(skill);
     }
+
+    private static bool HasNoCriteriaAtAll(SkillIndexEntry skill) =>
+        skill.Activation.Positive.Count == 0
+        && skill.Activation.Negative.Count == 0
+        && skill.RoleAssignments.All(r =>
+            r.Criteria.Positive.Count == 0 && r.Criteria.Negative.Count == 0);
 }

--- a/tests/AgentSmith.Tests/Triage/TriageOutputValidatorTests.cs
+++ b/tests/AgentSmith.Tests/Triage/TriageOutputValidatorTests.cs
@@ -87,6 +87,49 @@ public sealed class TriageOutputValidatorTests
         result.Errors.Should().BeEmpty();
     }
 
+    [Fact]
+    public void Validate_SkillWithNoCriteriaAtAll_AcceptsAnyKey()
+    {
+        // Defensive default: when a skill has no activation/role_assignment defined
+        // (e.g. older SKILL.md that lists only roles_supported), the validator must
+        // not reject every cited key. Otherwise the LLM has no valid keys to cite
+        // and triage fails on a metadata gap rather than a real error.
+        var skills = new[] { SkillIndex("filter-no-meta", roles: new[] { SkillRole.Filter }) };
+        var output = new TriageOutput(
+            new Dictionary<PipelinePhase, PhaseAssignment>
+            {
+                [PipelinePhase.Final] = new(null, Array.Empty<string>(), Array.Empty<string>(), "filter-no-meta")
+            },
+            85,
+            "filter=filter-no-meta:always_required;");
+
+        var result = _sut.Validate(output, skills);
+
+        result.IsValid.Should().BeTrue();
+        result.Errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Validate_SkillWithSomeCriteria_StillRejectsInventedKeys()
+    {
+        // Once a skill defines ANY criteria (positive or negative, activation or role-assignment),
+        // the strict path applies — invented keys are rejected. Only fully-empty skills get the
+        // defensive accept-all default.
+        var skills = new[] { SkillIndex("partial", roles: new[] { SkillRole.Analyst }, positiveKeys: new[] { "real-key" }) };
+        var output = new TriageOutput(
+            new Dictionary<PipelinePhase, PhaseAssignment>
+            {
+                [PipelinePhase.Plan] = new(null, new[] { "partial" }, Array.Empty<string>(), null)
+            },
+            85,
+            "analyst=partial:invented-key;");
+
+        var result = _sut.Validate(output, skills);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.Contains("invented-key"));
+    }
+
     private static SkillIndexEntry SkillIndex(string name, SkillRole[] roles, string[]? positiveKeys = null) =>
         new(name,
             $"Skill {name}",


### PR DESCRIPTION
## Summary

Hotfix for triage failure surfaced after p0123 merge: `TriageOutputValidator` was rejecting any rationale key cited for a skill that defined no `activation` / `role_assignment` metadata at all. LLM had no valid keys to cite for such skills → triage failed on a metadata gap rather than a real error.

**Root cause**: Pre-existing bug from p0111c. 16 of 17 api-security skills were missing activation metadata. `false-positive-filter` was the immediate trigger because the LLM specifically cited it in the Final phase rationale.

**Fix**: defensive default in `HasKey` — when a skill has no activation criteria AND no role-assignment criteria across any role, accept any cited key. Skills with ANY criteria still get strict validation; invented keys are still rejected.

Plus two pre-existing build warnings cleared (`TestHandler.cs` CS8604, `GeneratePlanHandler.cs` CS8603).

## Companion PR

agent-smith-skills: https://github.com/holgerleichsenring/agent-smith-skills/pull/new/fix/api-security-skills-activation-metadata

Adds proper activation + role_assignment blocks to all 16 api-security skills that were missing them. The agent-smith fix is the safety net; the skills fix is the data hygiene.

## Test plan

- [x] 1141 main + 62 sandbox tests passing (+2 new validator tests: empty-criteria-accepts-any-key, partial-criteria-still-rejects-invented-keys)
- [x] Build clean — 0 warnings
- [ ] Operator re-run of `agent-smith-api-security-azure-openai` should pass triage step where it previously crashed

🤖 Generated with [Claude Code](https://claude.com/claude-code)