### PR TITLE
fix(filter): preserve observations when filter LLM response is unparseable

### DIFF
--- a/src/AgentSmith.Application/Services/Handlers/FilterRoundHandler.cs
+++ b/src/AgentSmith.Application/Services/Handlers/FilterRoundHandler.cs
@@ -98,7 +98,24 @@ public sealed class FilterRoundHandler(
 
     private CommandResult ApplyList(string skillName, string responseText, PipelineContext pipeline)
     {
-        var reduced = ObservationParser.ParseWithoutIds(responseText, skillName, logger);
+        // Filter is reductive: parse failure means the LLM didn't deliver a usable filtered list.
+        // Falling through to FallbackSingle would wrap the raw LLM text as a single Info observation
+        // and overwrite the (potentially many) genuine observations the contributors emitted —
+        // a destructive failure that hides real findings. Preserve the originals instead.
+        var reduced = ObservationParser.TryParseWithoutIds(responseText, skillName, logger);
+        if (reduced is null)
+        {
+            var existingCount = pipeline.TryGet<List<SkillObservation>>(
+                ContextKeys.SkillObservations, out var existing) && existing is not null
+                ? existing.Count
+                : 0;
+            logger.LogWarning(
+                "{Skill} (Filter, list): LLM response unparseable — keeping {Count} original observations unchanged",
+                skillName, existingCount);
+            return CommandResult.Ok(
+                $"{skillName} (Filter): parse failed, {existingCount} original observations retained");
+        }
+
         var withIds = reduced.Select((o, i) => o with { Id = i + 1 }).ToList();
         pipeline.Set(ContextKeys.SkillObservations, withIds);
         logger.LogInformation(

--- a/src/AgentSmith.Application/Services/Handlers/ObservationParser.cs
+++ b/src/AgentSmith.Application/Services/Handlers/ObservationParser.cs
@@ -39,6 +39,41 @@ internal static class ObservationParser
         return parsed;
     }
 
+    /// <summary>
+    /// Strict variant: returns null when the response can't be parsed as a JSON observation
+    /// array (no FallbackSingle wrapping). Callers like FilterRoundHandler use this so they
+    /// can preserve the existing observation list instead of overwriting it with a single
+    /// auto-wrapped placeholder when the LLM filter response is unparseable.
+    /// </summary>
+    internal static List<SkillObservation>? TryParseWithoutIds(
+        string response, string role, ILogger? logger = null)
+    {
+        var json = ExtractJsonArray(response);
+        if (json is null) return null;
+
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            if (doc.RootElement.ValueKind != JsonValueKind.Array) return null;
+
+            var result = new List<SkillObservation>();
+            var perRunWarn = new HashSet<string>();
+            var index = 0;
+            foreach (var element in doc.RootElement.EnumerateArray())
+            {
+                var observation = TryBuildObservation(element, role, 0, index, perRunWarn, logger);
+                if (observation is not null) result.Add(observation);
+                index++;
+            }
+            return result.Count == 0 ? null : result;
+        }
+        catch (JsonException ex)
+        {
+            logger?.LogWarning(ex, "JSON parse failed strictly for {Role}", role);
+            return null;
+        }
+    }
+
     internal static List<SkillObservation> Parse(
         string response, string role, int startId, ILogger? logger = null)
     {

--- a/tests/AgentSmith.Tests/Services/ObservationParserTryParseTests.cs
+++ b/tests/AgentSmith.Tests/Services/ObservationParserTryParseTests.cs
@@ -1,0 +1,88 @@
+using AgentSmith.Application.Services.Handlers;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace AgentSmith.Tests.Services;
+
+public sealed class ObservationParserTryParseTests
+{
+    [Fact]
+    public void TryParseWithoutIds_ValidArray_ReturnsObservations()
+    {
+        const string response = """
+            [
+              {"concern":"security","description":"valid 1","severity":"high","confidence":80,"blocking":false},
+              {"concern":"security","description":"valid 2","severity":"medium","confidence":70,"blocking":false}
+            ]
+            """;
+
+        var result = ObservationParser.TryParseWithoutIds(response, "test-skill", NullLogger.Instance);
+
+        result.Should().NotBeNull();
+        result!.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void TryParseWithoutIds_NotJson_ReturnsNull()
+    {
+        var result = ObservationParser.TryParseWithoutIds(
+            "this is not JSON at all, just prose", "test-skill", NullLogger.Instance);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void TryParseWithoutIds_TruncatedJson_ReturnsNull()
+    {
+        // Simulates an LLM hitting max_tokens mid-response — opening bracket but no close.
+        const string truncated = """[{"concern":"security","description":"valid 1","severity":"high","confidence":80,"blocking":false},{"concern":"security",""";
+
+        var result = ObservationParser.TryParseWithoutIds(truncated, "test-skill", NullLogger.Instance);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void TryParseWithoutIds_EmptyArray_ReturnsNull()
+    {
+        // Empty array means parser succeeded but found nothing — caller should treat as
+        // "no usable observations" same as parse failure for filter purposes.
+        var result = ObservationParser.TryParseWithoutIds("[]", "test-skill", NullLogger.Instance);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void TryParseWithoutIds_AllElementsInvalid_ReturnsNull()
+    {
+        // Every element has a bad enum — none survive element-wise parsing.
+        const string response = """
+            [
+              {"concern":"security","description":"row","severity":"critical","confidence":80,"blocking":false},
+              {"concern":"security","description":"row","severity":"warning","confidence":70,"blocking":false}
+            ]
+            """;
+
+        var result = ObservationParser.TryParseWithoutIds(response, "test-skill", NullLogger.Instance);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void TryParseWithoutIds_MixedValidInvalid_ReturnsValidOnly()
+    {
+        // Same tolerance as Parse — bad elements skip, good ones survive.
+        const string response = """
+            [
+              {"concern":"security","description":"valid","severity":"high","confidence":80,"blocking":false},
+              {"concern":"security","description":"bad","severity":"critical","confidence":80,"blocking":false}
+            ]
+            """;
+
+        var result = ObservationParser.TryParseWithoutIds(response, "test-skill", NullLogger.Instance);
+
+        result.Should().NotBeNull();
+        result!.Should().HaveCount(1);
+        result[0].Description.Should().Be("valid");
+    }
+}


### PR DESCRIPTION
## Summary

Hotfix for destructive filter-failure surfaced in operator smoke run after the p0123 + triage-validator-tolerance PRs landed.

**Symptom**: 15 api-security contributor skills emitted ~75 observations total. The `false-positive-filter` LLM call hit \`max_tokens: 8192\` mid-JSON; parser fell back to \`FallbackSingle\` wrapping the raw LLM text as one Info observation; FilterRoundHandler.ApplyList overwrote all 75 observations with that one wrapper. Final output: 1 fake \`[INFO] General — [\` finding instead of dozens of real ones.

**Root cause**: \`ObservationParser.ParseWithoutIds\` falls back to a single auto-wrapped observation on parse failure. FilterRoundHandler can't distinguish \"LLM produced 1 valid observation\" from \"parser fell back\" → destructive overwrite.

**Fix**: New \`ObservationParser.TryParseWithoutIds\` variant returns \`null\` on parse failure (no FallbackSingle wrapping). FilterRoundHandler.ApplyList uses it; on null, keeps the original observations unchanged and logs a warning. Filter is reductive — failing to filter is acceptable; destroying findings is not.

## Test plan

- [x] 6 new ObservationParserTryParse tests covering valid, not-JSON, truncated, empty-array, all-invalid-elements, mixed-valid-invalid
- [x] 1145 main + 62 sandbox tests passing
- [ ] Operator re-run of \`agent-smith-api-security-azure-openai\` — expected: ~75 findings in console output (or however many contributors produced), with filter logging \"parse failed, N original observations retained\" if it still hits max_tokens

## Followups (out of scope)

The deeper question is *why* the filter LLM response was unparseable. Likely max_tokens=8192 truncation when the input list is large (~75 observations × prompt-rendering ~ many KB). Two paths for a future fix:
1. Bigger max_tokens specifically for filter-role tasks (TaskType.Filter or per-role override)
2. Smaller filter input — chunked filtering, or pre-filter in the contributor stage

Defense-in-depth wins for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)