### PR TITLE
fix(k8s): pod-watcher detects init-container failures + leaves pod for inspection

### DIFF
--- a/src/AgentSmith.Server/Services/Sandbox/KubernetesPodWatcher.cs
+++ b/src/AgentSmith.Server/Services/Sandbox/KubernetesPodWatcher.cs
@@ -6,11 +6,22 @@ namespace AgentSmith.Server.Services.Sandbox;
 
 /// <summary>
 /// Polls Pod status until the toolchain container is Ready, throwing on
-/// ImagePullBackOff / Failed phase, or on timeout (after best-effort delete).
+/// detected pull / crash / config failures across BOTH the init-container
+/// (agent-loader) and the main container (toolchain), or on timeout. On
+/// failure or timeout the pod is left in place for `kubectl describe`
+/// inspection — the next pipeline-run uses a different unique pod name
+/// so it doesn't conflict.
 /// </summary>
 public sealed class KubernetesPodWatcher(IKubernetes client, ILogger logger)
 {
     private static readonly TimeSpan PollInterval = TimeSpan.FromSeconds(2);
+
+    private static readonly string[] FatalWaitingReasons =
+    [
+        "ImagePullBackOff", "ErrImagePull", "InvalidImageName",
+        "CrashLoopBackOff", "CreateContainerConfigError",
+        "CreateContainerError", "RunContainerError", "ContainerCannotRun"
+    ];
 
     public async Task WaitForReadyAsync(
         string podName, string ns, TimeSpan timeout, CancellationToken cancellationToken)
@@ -32,9 +43,14 @@ public sealed class KubernetesPodWatcher(IKubernetes client, ILogger logger)
             await Task.Delay(PollInterval, cancellationToken);
         }
 
-        await TryDeleteAsync(podName, ns);
+        // Pre-throw diagnostic dump — last-seen pod is fetched once more so the
+        // error message includes the actual stuck-container state instead of a
+        // generic "did not become ready". Pod is left in place for kubectl describe.
+        var finalPod = await TryReadPodAsync(podName, ns, cancellationToken);
         throw new TimeoutException(
-            $"Sandbox pod {podName} did not become ready within {timeout.TotalSeconds:F0}s");
+            $"Sandbox pod {podName} did not become ready within {timeout.TotalSeconds:F0}s. " +
+            $"Pod left in place for inspection: kubectl describe pod {podName} -n {ns}. " +
+            $"Last state: {SummarisePodState(finalPod)}");
     }
 
     private static void ThrowIfFailed(string podName, V1Pod pod)
@@ -43,14 +59,26 @@ public sealed class KubernetesPodWatcher(IKubernetes client, ILogger logger)
             throw new InvalidOperationException(
                 $"Sandbox pod {podName} entered Failed phase: {pod.Status.Reason ?? pod.Status.Message}");
 
-        var statuses = pod.Status?.ContainerStatuses ?? [];
-        foreach (var status in statuses)
-        {
-            var waiting = status.State?.Waiting;
-            if (waiting?.Reason is "ImagePullBackOff" or "ErrImagePull" or "InvalidImageName")
-                throw new InvalidOperationException(
-                    $"Sandbox pod {podName} container {status.Name} failed to pull image: {waiting.Message}");
-        }
+        // Both init and main container statuses can carry the failure reason.
+        // The init agent-loader fails here when the carrier image isn't
+        // pullable (k8s default to docker.io/library/<no-prefix> when the
+        // SandboxSpec.AgentImage doesn't include a registry namespace) — and
+        // the previous version of this code only inspected main containers, so
+        // the operator only ever saw the 120s timeout instead of the actual
+        // ImagePullBackOff signal.
+        foreach (var status in pod.Status?.InitContainerStatuses ?? [])
+            ThrowIfWaitingFatal(podName, status, "initContainer");
+        foreach (var status in pod.Status?.ContainerStatuses ?? [])
+            ThrowIfWaitingFatal(podName, status, "container");
+    }
+
+    private static void ThrowIfWaitingFatal(string podName, V1ContainerStatus status, string kind)
+    {
+        var waiting = status.State?.Waiting;
+        if (waiting?.Reason is { Length: > 0 } reason && FatalWaitingReasons.Contains(reason))
+            throw new InvalidOperationException(
+                $"Sandbox pod {podName} {kind} {status.Name} failed with {reason}: " +
+                $"{waiting.Message ?? "<no message>"}");
     }
 
     private static bool IsToolchainReady(V1Pod pod)
@@ -59,15 +87,31 @@ public sealed class KubernetesPodWatcher(IKubernetes client, ILogger logger)
         return toolchain?.Ready == true;
     }
 
-    private async Task TryDeleteAsync(string podName, string ns)
+    private async Task<V1Pod?> TryReadPodAsync(string podName, string ns, CancellationToken ct)
     {
-        try
-        {
-            await client.CoreV1.DeleteNamespacedPodAsync(podName, ns, gracePeriodSeconds: 0);
-        }
-        catch (Exception ex)
-        {
-            logger.LogWarning(ex, "Failed to delete sandbox pod {Pod} after timeout", podName);
-        }
+        try { return await client.CoreV1.ReadNamespacedPodAsync(podName, ns, cancellationToken: ct); }
+        catch { return null; }
+    }
+
+    private static string SummarisePodState(V1Pod? pod)
+    {
+        if (pod is null) return "<pod-read-failed>";
+        var parts = new List<string> { $"phase={pod.Status?.Phase ?? "<unknown>"}" };
+        foreach (var s in pod.Status?.InitContainerStatuses ?? [])
+            parts.Add(SummariseContainer("initContainer", s));
+        foreach (var s in pod.Status?.ContainerStatuses ?? [])
+            parts.Add(SummariseContainer("container", s));
+        return string.Join("; ", parts);
+    }
+
+    private static string SummariseContainer(string kind, V1ContainerStatus s)
+    {
+        if (s.State?.Waiting is { } waiting)
+            return $"{kind} {s.Name}=Waiting({waiting.Reason ?? "?"}: {waiting.Message ?? ""})";
+        if (s.State?.Terminated is { } term)
+            return $"{kind} {s.Name}=Terminated(exit={term.ExitCode}, {term.Reason ?? "?"})";
+        if (s.State?.Running is not null)
+            return $"{kind} {s.Name}=Running(ready={s.Ready})";
+        return $"{kind} {s.Name}=<unknown>";
     }
 }


### PR DESCRIPTION
## Summary

`KubernetesPodWatcher` only inspected `pod.Status.ContainerStatuses` (main containers) and a narrow set of failure reasons. Three observable gaps surfaced during k8s deployment of agent-smith:

1. The **agent-loader runs as an initContainer**; its statuses live on `pod.Status.InitContainerStatuses`. A stuck initContainer (e.g. `ImagePullBackOff` on the sandbox-agent carrier image) never surfaced — the toolchain main container also never starts (k8s ordering), so `IsToolchainReady` stays false until the 120s timeout. Operators saw "did not become ready within 120s" instead of the real `ImagePullBackOff` on the loader.

2. **`CrashLoopBackOff` / `CreateContainerConfigError` / `RunContainerError` / `ContainerCannotRun`** bypassed detection entirely — pod sat in `NotReady`, watcher polled, timed out.

3. On timeout the watcher **force-deleted the pod** with `gracePeriodSeconds=0` so `kubectl describe pod ...` returned `NotFound`. The operator couldn't diagnose what went wrong.

## Fix

- `ThrowIfFailed` now iterates BOTH `InitContainerStatuses` and `ContainerStatuses`
- `FatalWaitingReasons` array adds the five additional failure reasons we want to short-circuit on
- `TimeoutException` message now includes a one-line summary of every container's state (waiting/terminated/running with reason+message) plus the `kubectl describe` hint
- Pod is **NOT auto-deleted** on timeout — leftover pods are unique-named (UUID-suffixed) so they don't conflict with subsequent runs, and they stay around for `kubectl describe` + `kubectl logs` inspection

## Operator-actionable difference

Before:
```
TimeoutException: Sandbox pod ... did not become ready within 120s
```

After:
```
TimeoutException: Sandbox pod ... did not become ready within 120s.
Pod left in place for inspection: kubectl describe pod ... -n <ns>.
Last state: phase=Pending; initContainer agent-loader=Waiting(ImagePullBackOff: Back-off pulling image "agent-smith-sandbox-agent:latest")
```

OR (for fast-fail cases):
```
InvalidOperationException: Sandbox pod ... initContainer agent-loader failed
with ImagePullBackOff: Back-off pulling image "agent-smith-sandbox-agent:latest"
```

The actual root cause is now surfaced and points at the fix — typically: use the registry-prefixed image reference (`holgerleichsenring/agent-smith-sandbox-agent:vX.Y.Z`) instead of the bare `agent-smith-sandbox-agent:latest`.

## Test plan

- [x] Build clean
- [x] Full test suite green (1564 main + 62 sandbox)
- [ ] Manual: trigger a sandbox pod with a deliberately invalid image and verify the operator-facing error contains the real reason

🤖 Generated with [Claude Code](https://claude.com/claude-code)