### PR TITLE
fix(k8s): set CPU + memory limits on agent-loader initContainer

### DIFF
--- a/src/AgentSmith.Server/Services/Sandbox/PodSpecBuilder.cs
+++ b/src/AgentSmith.Server/Services/Sandbox/PodSpecBuilder.cs
@@ -48,7 +48,27 @@ public sealed class PodSpecBuilder
         Name = "agent-loader",
         Image = agentImage,
         Args = ["--inject", $"{SharedMount}/agent"],
-        VolumeMounts = [new V1VolumeMount { Name = SharedVolume, MountPath = SharedMount }]
+        VolumeMounts = [new V1VolumeMount { Name = SharedVolume, MountPath = SharedMount }],
+        // Fixed limits — loader only extracts the bundled .NET single-file agent
+        // (~75 MB) and copies one binary, then exits. Namespaces with a
+        // ResourceQuota that mandates limits.cpu/limits.memory on every
+        // container (init + main) reject the pod otherwise; pod creation fails
+        // with "must specify limits.cpu for: agent-loader" before the workload
+        // even starts. Values are sized for the bundle extraction headroom plus
+        // a brief CPU burst on startup.
+        Resources = new V1ResourceRequirements
+        {
+            Limits = new Dictionary<string, ResourceQuantity>
+            {
+                ["cpu"] = new("200m"),
+                ["memory"] = new("256Mi")
+            },
+            Requests = new Dictionary<string, ResourceQuantity>
+            {
+                ["cpu"] = new("50m"),
+                ["memory"] = new("128Mi")
+            }
+        }
     };
 
     private static V1Container BuildToolchainContainer(SandboxSpec spec, string jobId, string redisUrl)

--- a/tests/AgentSmith.Tests/Sandbox/PodSpecBuilderResourcesTests.cs
+++ b/tests/AgentSmith.Tests/Sandbox/PodSpecBuilderResourcesTests.cs
@@ -1,0 +1,58 @@
+using AgentSmith.Contracts.Sandbox;
+using AgentSmith.Server.Services.Sandbox;
+using FluentAssertions;
+
+namespace AgentSmith.Tests.Sandbox;
+
+/// <summary>
+/// Regression: k8s namespaces with a ResourceQuota that mandates limits.cpu
+/// and limits.memory on every container (init + main) reject the pod when
+/// any container is missing limits. The agent-loader initContainer was
+/// missing limits — pod create fails with "must specify limits.cpu for:
+/// agent-loader" before the workload starts.
+/// </summary>
+public sealed class PodSpecBuilderResourcesTests
+{
+    private static readonly PodSpecBuilder Builder = new();
+
+    private static readonly SandboxSpec MinimalSpec = new(
+        ToolchainImage: "debian:bookworm",
+        AgentImage: "agent-smith-sandbox-agent:latest");
+
+    [Fact]
+    public void Build_LoaderInitContainer_HasCpuAndMemoryLimits()
+    {
+        var pod = Builder.Build(
+            podName: "agentsmith-sandbox-abc",
+            jobId: "abc",
+            redisUrl: "redis:6379",
+            spec: MinimalSpec,
+            owner: null);
+
+        var loader = pod.Spec.InitContainers.Single(c => c.Name == "agent-loader");
+        loader.Resources.Should().NotBeNull();
+        loader.Resources.Limits.Should().ContainKey("cpu");
+        loader.Resources.Limits.Should().ContainKey("memory");
+    }
+
+    [Fact]
+    public void Build_LoaderInitContainer_HasCpuAndMemoryRequests()
+    {
+        var pod = Builder.Build("p", "j", "redis:6379", MinimalSpec, owner: null);
+
+        var loader = pod.Spec.InitContainers.Single(c => c.Name == "agent-loader");
+        loader.Resources.Requests.Should().ContainKey("cpu");
+        loader.Resources.Requests.Should().ContainKey("memory");
+    }
+
+    [Fact]
+    public void Build_ToolchainContainer_StillHasResourceLimits()
+    {
+        // Regression-protect the existing toolchain limits when refactoring.
+        var pod = Builder.Build("p", "j", "redis:6379", MinimalSpec, owner: null);
+
+        var toolchain = pod.Spec.Containers.Single(c => c.Name == "toolchain");
+        toolchain.Resources.Limits.Should().ContainKey("cpu");
+        toolchain.Resources.Limits.Should().ContainKey("memory");
+    }
+}


### PR DESCRIPTION
Namespaces with a ResourceQuota mandating limits.cpu/limits.memory on every container reject the sandbox pod with:

  HttpOperationException: Operation returned an invalid status code 'Forbidden'
  pods "agentsmith-sandbox-..." is forbidden: failed quota: agentsmith-quota:
  must specify limits.cpu for: agent-loader;
  must specify limits.memory for: agent-loader

PodSpecBuilder.BuildToolchainContainer already set limits derived from spec.Resources; BuildInitContainer set neither. Pod create fails before any workload runs, the lifecycle coordinator transitions the ticket to Failed with the kubectl Forbidden message bubbling up through the PipelineQueueConsumer.

The loader extracts the self-contained .NET 8 single-file agent (~75 MB bundle) into /tmp/.net/ and copies one binary, then exits. Fixed small limits suffice: 200m CPU / 256 MiB memory headroom, 50m / 128 MiB requests. Independent of spec.Resources because the loader's workload is constant regardless of the project's toolchain image.

Three new tests in PodSpecBuilderResourcesTests lock the loader limits + requests + the existing toolchain limits down so the regression doesn't recur on a future refactor.

1564 main + 62 sandbox tests passing.