### PR TITLE
fix: configurable sandbox agent image (registry + version) via agents…

### DIFF
--- a/config/agentsmith.example.yml
+++ b/config/agentsmith.example.yml
@@ -3,6 +3,15 @@
 # Supported AI providers: Claude (Anthropic), OpenAI, Azure OpenAI, Gemini (Google), Ollama
 # Supported source/ticket providers: GitHub, GitLab, Azure DevOps (Repos), Jira
 
+# --- Sandbox carrier image (REQUIRED for K8s/Docker spawners) ---
+# Process-wide defaults for the agent-smith-sandbox-agent carrier image
+# the server's spawner uses as an initContainer. agent_version MUST be
+# pinned (no 'latest' default in K8s production) — set it to the agent-smith
+# release that matches the agentsmith-server image you deploy.
+sandbox:
+  agent_registry: holgerleichsenring   # docker hub user / private registry path
+  agent_version: 0.48.0                # pin the agent-smith release tag
+
 projects:
   my-project:
     source:
@@ -158,15 +167,21 @@ projects:
     pipeline: fix-bug
     coding_principles_path: .agentsmith/coding-principles.md
 
-    # --- Per-project sandbox container resources (optional, p0136) ---
-    # When set, fully overrides the global Sandbox defaults from appsettings /
-    # the Sandbox__* environment variables. Partial overrides are not supported —
-    # provide all four fields, or leave the whole block out.
+    # --- Per-project sandbox overrides (optional) ---
+    # Each field falls back to the top-level sandbox: block when null. Mix and
+    # match — set only the fields that differ for this project; leave the
+    # whole sandbox: block out to inherit all globals.
     # sandbox:
+    #   # Carrier-image overrides (canary/rollback per project, or per-project mirror)
+    #   agent_registry: corp-mirror   # override top-level sandbox.agent_registry
+    #   agent_version: 0.49.0-beta    # override top-level sandbox.agent_version
+    #   # Toolchain image override (overrides the language-based auto-detection)
+    #   toolchain_image: my-registry/dotnet-sdk:8
+    #   # Container resources (all-or-nothing: provide all four or omit the block)
     #   resources:
-    #     cpu_request: 500m         # Kubernetes CPU quantity
+    #     cpu_request: 500m           # Kubernetes CPU quantity
     #     cpu_limit: 2000m
-    #     memory_request: 1Gi       # Kubernetes memory quantity
+    #     memory_request: 1Gi         # Kubernetes memory quantity
     #     memory_limit: 4Gi
 
     # --- Multi-pipeline form (p0106) ---

--- a/src/AgentSmith.Application/Extensions/ServiceCollectionExtensions.cs
+++ b/src/AgentSmith.Application/Extensions/ServiceCollectionExtensions.cs
@@ -320,6 +320,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IPhaseDataFlowResolver, PhaseDataFlowResolver>();
         services.AddSingleton<SandboxSpecBuilder>();
         services.AddSingleton<ISandboxResourceResolver, SandboxResourceResolver>();
+        services.AddSingleton<IAgentImageResolver, AgentImageResolver>();
         services.AddTransient<ISandboxLanguageResolver, SandboxLanguageResolver>();
         services.AddTransient<ISourceConfigOverrider, SourceConfigOverrider>();
         services.AddSingleton<IPipelineConfigResolver, PipelineConfigResolver>();

--- a/src/AgentSmith.Application/Services/Builders/SandboxSpecBuilder.cs
+++ b/src/AgentSmith.Application/Services/Builders/SandboxSpecBuilder.cs
@@ -12,7 +12,9 @@ namespace AgentSmith.Application.Services.Builders;
 /// resulting <see cref="SandboxSpec.Resources"/> always reflects the operator's
 /// per-project override or the global <c>Sandbox</c> options defaults.
 /// </summary>
-public sealed class SandboxSpecBuilder(ISandboxResourceResolver resourceResolver)
+public sealed class SandboxSpecBuilder(
+    ISandboxResourceResolver resourceResolver,
+    IAgentImageResolver agentImageResolver)
 {
     // Keys cover both ProjectMap.PrimaryLanguage's analyzer output (lowercase
     // canonical: csharp / node / typescript / python / go / rust) AND the
@@ -55,7 +57,8 @@ public sealed class SandboxSpecBuilder(ISandboxResourceResolver resourceResolver
     {
         var image = ResolveImage(projectConfig, language);
         var resources = resourceResolver.Resolve(projectConfig);
-        return new SandboxSpec(ToolchainImage: image, Resources: resources);
+        var agentImage = agentImageResolver.Resolve(projectConfig);
+        return new SandboxSpec(ToolchainImage: image, Resources: resources, AgentImage: agentImage);
     }
 
     // Generic fallback when no language-specific image can be resolved.

--- a/src/AgentSmith.Application/Services/Sandbox/AgentImageResolver.cs
+++ b/src/AgentSmith.Application/Services/Sandbox/AgentImageResolver.cs
@@ -1,0 +1,35 @@
+using AgentSmith.Contracts.Constants;
+using AgentSmith.Contracts.Models.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace AgentSmith.Application.Services.Sandbox;
+
+/// <summary>
+/// Two-layer resolver: per-project SandboxConfig fields win field-by-field
+/// over the top-level <see cref="SandboxGlobalConfig"/>. Missing version is
+/// a configuration error — caught here with a clear message rather than
+/// surfacing as an ErrImagePull on the spawned pod.
+/// </summary>
+public sealed class AgentImageResolver(IOptions<SandboxGlobalConfig> globalConfig) : IAgentImageResolver
+{
+    public string Resolve(ProjectConfig projectConfig)
+    {
+        var global = globalConfig.Value;
+        var registry = FirstNonEmpty(projectConfig.Sandbox?.AgentRegistry, global.AgentRegistry);
+        var version = FirstNonEmpty(projectConfig.Sandbox?.AgentVersion, global.AgentVersion);
+
+        if (string.IsNullOrEmpty(version))
+        {
+            throw new InvalidOperationException(
+                "Sandbox agent version is not configured. Set 'sandbox.agent_version' at the top level of agentsmith.yml or under projects.<name>.sandbox.agent_version. " +
+                "Operator should pin a published tag (e.g. '0.48.0') matching the agent-smith release in use.");
+        }
+
+        return string.IsNullOrEmpty(registry)
+            ? $"{AgentImageDefaults.SandboxAgentImageName}:{version}"
+            : $"{registry}/{AgentImageDefaults.SandboxAgentImageName}:{version}";
+    }
+
+    private static string? FirstNonEmpty(string? a, string? b) =>
+        !string.IsNullOrEmpty(a) ? a : b;
+}

--- a/src/AgentSmith.Application/Services/Sandbox/IAgentImageResolver.cs
+++ b/src/AgentSmith.Application/Services/Sandbox/IAgentImageResolver.cs
@@ -1,0 +1,14 @@
+using AgentSmith.Contracts.Models.Configuration;
+
+namespace AgentSmith.Application.Services.Sandbox;
+
+/// <summary>
+/// Resolves the fully-qualified sandbox agent carrier-image reference for
+/// a specific project by walking projects.&lt;name&gt;.sandbox per-project
+/// overrides on top of the top-level agentsmith.yml <c>sandbox:</c> block.
+/// </summary>
+public interface IAgentImageResolver
+{
+    /// <summary>Returns "{registry}/{image-name}:{version}". Throws when no version is configured at either layer.</summary>
+    string Resolve(ProjectConfig projectConfig);
+}

--- a/src/AgentSmith.Contracts/Constants/AgentImageDefaults.cs
+++ b/src/AgentSmith.Contracts/Constants/AgentImageDefaults.cs
@@ -1,0 +1,17 @@
+namespace AgentSmith.Contracts.Constants;
+
+/// <summary>
+/// Build-time constants identifying the agent's carrier image. Registry
+/// (where to pull from) and version (which tag) are operator-configurable
+/// via agentsmith.yml — see <c>SandboxGlobalConfig</c> for global defaults
+/// and <c>SandboxConfig</c> for per-project overrides. The image *name*
+/// is the project's published identity and lives here as a single constant.
+/// </summary>
+public static class AgentImageDefaults
+{
+    /// <summary>Image name (sans registry, sans tag) of the sandbox carrier image published by this project's CI.</summary>
+    public const string SandboxAgentImageName = "agent-smith-sandbox-agent";
+
+    /// <summary>Default container registry for the sandbox agent image when neither agentsmith.yml nor per-project config specifies one.</summary>
+    public const string DefaultRegistry = "holgerleichsenring";
+}

--- a/src/AgentSmith.Contracts/Models/Configuration/AgentSmithConfig.cs
+++ b/src/AgentSmith.Contracts/Models/Configuration/AgentSmithConfig.cs
@@ -46,4 +46,11 @@ public sealed class AgentSmithConfig
     /// gate logs warnings on undeclared reads but doesn't fail the run.
     /// </summary>
     public PipelineDataFlowConfig PipelineDataFlow { get; set; } = new();
+
+    /// <summary>
+    /// Process-wide sandbox defaults — agent carrier registry + version that
+    /// every spawned sandbox pod references unless a project's
+    /// <see cref="SandboxConfig"/> block overrides them. See <see cref="SandboxGlobalConfig"/>.
+    /// </summary>
+    public SandboxGlobalConfig Sandbox { get; set; } = new();
 }

--- a/src/AgentSmith.Contracts/Models/Configuration/SandboxConfig.cs
+++ b/src/AgentSmith.Contracts/Models/Configuration/SandboxConfig.cs
@@ -29,4 +29,19 @@ public sealed class SandboxConfig
     /// without cpu_limit) are not supported — pick one resolution layer.
     /// </summary>
     public ResourceLimits? Resources { get; set; }
+
+    /// <summary>
+    /// Per-project override of the sandbox agent's container registry
+    /// (e.g. <c>my-corp-mirror</c>). Null = inherit the top-level <c>sandbox.agent_registry</c>
+    /// from agentsmith.yml. Use this when a single project must pull the agent
+    /// image from a different registry than the rest of the deployment.
+    /// </summary>
+    public string? AgentRegistry { get; set; }
+
+    /// <summary>
+    /// Per-project override of the sandbox agent's image tag (e.g. <c>0.49.0-beta</c>).
+    /// Null = inherit the top-level <c>sandbox.agent_version</c> from agentsmith.yml.
+    /// Use this to pin a specific project to a different agent build (canary, rollback).
+    /// </summary>
+    public string? AgentVersion { get; set; }
 }

--- a/src/AgentSmith.Contracts/Models/Configuration/SandboxGlobalConfig.cs
+++ b/src/AgentSmith.Contracts/Models/Configuration/SandboxGlobalConfig.cs
@@ -1,0 +1,27 @@
+namespace AgentSmith.Contracts.Models.Configuration;
+
+/// <summary>
+/// Process-wide sandbox defaults, loaded from agentsmith.yml's top-level
+/// <c>sandbox:</c> block. Per-project <see cref="SandboxConfig"/> blocks
+/// override these field-by-field.
+/// </summary>
+public sealed class SandboxGlobalConfig
+{
+    /// <summary>
+    /// Container registry the sandbox agent image is pulled from
+    /// (e.g. <c>holgerleichsenring</c>, <c>ghcr.io/my-org</c>, or a private
+    /// mirror). Combined with the constant image-name and <see cref="AgentVersion"/>
+    /// to form the fully-qualified image reference.
+    /// </summary>
+    public string AgentRegistry { get; set; } = AgentSmith.Contracts.Constants.AgentImageDefaults.DefaultRegistry;
+
+    /// <summary>
+    /// Sandbox agent image tag (e.g. <c>0.48.0</c>). No default — operators MUST set this
+    /// in agentsmith.yml under either the top-level <c>sandbox:</c> block or a
+    /// per-project <c>projects.&lt;name&gt;.sandbox:</c> override. Empty value triggers a
+    /// fail-loud at sandbox-spawn time so a misconfigured deployment is caught
+    /// before the first ticket lands instead of producing an ErrImagePull at the
+    /// pod level.
+    /// </summary>
+    public string AgentVersion { get; set; } = string.Empty;
+}

--- a/src/AgentSmith.Infrastructure/Extensions/SandboxServiceCollectionExtensions.cs
+++ b/src/AgentSmith.Infrastructure/Extensions/SandboxServiceCollectionExtensions.cs
@@ -1,6 +1,9 @@
+using AgentSmith.Contracts.Models.Configuration;
 using AgentSmith.Contracts.Sandbox;
 using AgentSmith.Infrastructure.Services.Sandbox;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
 
 namespace AgentSmith.Infrastructure.Extensions;
 
@@ -9,10 +12,17 @@ public static class SandboxServiceCollectionExtensions
     /// <summary>
     /// Registers the in-process ISandbox implementation. Used by CLI mode,
     /// or as the default fallback in Server's auto-detected registration.
+    /// Includes a placeholder <see cref="IOptions{TOptions}"/> of
+    /// <see cref="SandboxGlobalConfig"/> so the AgentImageResolver does not
+    /// fail-loud in InProcess mode where the spawned agent image is unused.
+    /// Server (K8s/Docker) overrides this registration with one loaded from
+    /// agentsmith.yml via AddSandboxGlobalConfig — last-registered wins.
     /// </summary>
     public static IServiceCollection AddInProcessSandbox(this IServiceCollection services)
     {
         services.AddSingleton<ISandboxFactory, InProcessSandboxFactory>();
+        services.TryAddSingleton<IOptions<SandboxGlobalConfig>>(_ =>
+            Options.Create(new SandboxGlobalConfig { AgentVersion = "in-process" }));
         return services;
     }
 }

--- a/src/AgentSmith.Server/Extensions/SandboxServiceCollectionExtensions.cs
+++ b/src/AgentSmith.Server/Extensions/SandboxServiceCollectionExtensions.cs
@@ -1,5 +1,7 @@
 using AgentSmith.Application.Models;
+using AgentSmith.Contracts.Models.Configuration;
 using AgentSmith.Contracts.Sandbox;
+using AgentSmith.Contracts.Services;
 using AgentSmith.Infrastructure.Services.Sandbox;
 using AgentSmith.Server.Services.Sandbox;
 using Docker.DotNet;
@@ -7,6 +9,7 @@ using k8s;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using StackExchange.Redis;
 
 namespace AgentSmith.Server.Extensions;
@@ -22,6 +25,23 @@ internal static class SandboxServiceCollectionExtensions
         this IServiceCollection services, IConfiguration configuration)
     {
         services.Configure<SandboxOptions>(configuration.GetSection("Sandbox"));
+        return services;
+    }
+
+    /// <summary>
+    /// Registers <see cref="IOptions{TOptions}"/> of <see cref="SandboxGlobalConfig"/>
+    /// pulled from the loaded agentsmith.yml top-level <c>sandbox:</c> block.
+    /// Consumed by <see cref="AgentSmith.Application.Services.Sandbox.AgentImageResolver"/>
+    /// (and any future agentsmith.yml-driven sandbox setting).
+    /// </summary>
+    internal static IServiceCollection AddSandboxGlobalConfig(this IServiceCollection services)
+    {
+        services.AddSingleton<IOptions<SandboxGlobalConfig>>(sp =>
+        {
+            var loader = sp.GetRequiredService<IConfigurationLoader>();
+            var context = sp.GetRequiredService<ServerContext>();
+            return Options.Create(loader.LoadConfig(context.ConfigPath).Sandbox);
+        });
         return services;
     }
 

--- a/src/AgentSmith.Server/Program.cs
+++ b/src/AgentSmith.Server/Program.cs
@@ -53,6 +53,7 @@ builder.Services
     .AddServerCompositionOverrides()
     .AddSandbox()
     .AddSandboxOptions(builder.Configuration)
+    .AddSandboxGlobalConfig()
     .AddSlackAdapter()
     .AddTeamsAdapter()
     .AddIntentHandlers()

--- a/tests/AgentSmith.Tests/Configuration/SandboxAgentImageYamlTests.cs
+++ b/tests/AgentSmith.Tests/Configuration/SandboxAgentImageYamlTests.cs
@@ -1,0 +1,74 @@
+using AgentSmith.Infrastructure.Core.Services;
+using AgentSmith.Infrastructure.Core.Services.Configuration;
+using FluentAssertions;
+
+namespace AgentSmith.Tests.Configuration;
+
+public sealed class SandboxAgentImageYamlTests : IDisposable
+{
+    private readonly string _tempFile = Path.Combine(Path.GetTempPath(),
+        $"agentsmith-agent-image-yaml-{Guid.NewGuid():N}.yml");
+
+    public void Dispose()
+    {
+        if (File.Exists(_tempFile)) File.Delete(_tempFile);
+    }
+
+    [Fact]
+    public void LoadConfig_TopLevelSandboxBlock_PopulatesGlobalDefaults()
+    {
+        File.WriteAllText(_tempFile, """
+            sandbox:
+              agent_registry: corp-registry
+              agent_version: 0.48.0
+            projects: {}
+            secrets: {}
+            """);
+        var loader = new YamlConfigurationLoader(new ProjectConfigNormalizer(), new AgentSmithPaths());
+
+        var cfg = loader.LoadConfig(_tempFile);
+
+        cfg.Sandbox.AgentRegistry.Should().Be("corp-registry");
+        cfg.Sandbox.AgentVersion.Should().Be("0.48.0");
+    }
+
+    [Fact]
+    public void LoadConfig_PerProjectAgentOverride_PopulatesSandboxConfig()
+    {
+        File.WriteAllText(_tempFile, """
+            sandbox:
+              agent_registry: holgerleichsenring
+              agent_version: 0.48.0
+            projects:
+              demo:
+                source:
+                  type: Local
+                  path: ./repo
+                sandbox:
+                  agent_registry: corp-mirror
+                  agent_version: 0.49.0-beta
+            secrets: {}
+            """);
+        var loader = new YamlConfigurationLoader(new ProjectConfigNormalizer(), new AgentSmithPaths());
+
+        var cfg = loader.LoadConfig(_tempFile);
+
+        cfg.Projects["demo"].Sandbox!.AgentRegistry.Should().Be("corp-mirror");
+        cfg.Projects["demo"].Sandbox!.AgentVersion.Should().Be("0.49.0-beta");
+    }
+
+    [Fact]
+    public void LoadConfig_NoSandboxBlock_KeepsDefaultRegistryAndEmptyVersion()
+    {
+        File.WriteAllText(_tempFile, """
+            projects: {}
+            secrets: {}
+            """);
+        var loader = new YamlConfigurationLoader(new ProjectConfigNormalizer(), new AgentSmithPaths());
+
+        var cfg = loader.LoadConfig(_tempFile);
+
+        cfg.Sandbox.AgentRegistry.Should().Be("holgerleichsenring");
+        cfg.Sandbox.AgentVersion.Should().Be("");
+    }
+}

--- a/tests/AgentSmith.Tests/Sandbox/AgentImageResolverTests.cs
+++ b/tests/AgentSmith.Tests/Sandbox/AgentImageResolverTests.cs
@@ -1,0 +1,81 @@
+using AgentSmith.Application.Services.Sandbox;
+using AgentSmith.Contracts.Models.Configuration;
+using FluentAssertions;
+using Microsoft.Extensions.Options;
+
+namespace AgentSmith.Tests.Sandbox;
+
+public sealed class AgentImageResolverTests
+{
+    [Fact]
+    public void Resolve_GlobalVersionSet_ReturnsRegistryNameVersion()
+    {
+        var sut = new AgentImageResolver(Options.Create(new SandboxGlobalConfig
+        {
+            AgentRegistry = "holgerleichsenring",
+            AgentVersion = "0.48.0"
+        }));
+
+        sut.Resolve(new ProjectConfig())
+            .Should().Be("holgerleichsenring/agent-smith-sandbox-agent:0.48.0");
+    }
+
+    [Fact]
+    public void Resolve_PerProjectRegistryOverride_WinsOverGlobal()
+    {
+        var sut = new AgentImageResolver(Options.Create(new SandboxGlobalConfig
+        {
+            AgentRegistry = "holgerleichsenring",
+            AgentVersion = "0.48.0"
+        }));
+        var project = new ProjectConfig
+        {
+            Sandbox = new SandboxConfig { AgentRegistry = "corp-mirror" }
+        };
+
+        sut.Resolve(project).Should().Be("corp-mirror/agent-smith-sandbox-agent:0.48.0");
+    }
+
+    [Fact]
+    public void Resolve_PerProjectVersionOverride_WinsOverGlobal()
+    {
+        var sut = new AgentImageResolver(Options.Create(new SandboxGlobalConfig
+        {
+            AgentRegistry = "holgerleichsenring",
+            AgentVersion = "0.48.0"
+        }));
+        var project = new ProjectConfig
+        {
+            Sandbox = new SandboxConfig { AgentVersion = "0.49.0-beta" }
+        };
+
+        sut.Resolve(project).Should().Be("holgerleichsenring/agent-smith-sandbox-agent:0.49.0-beta");
+    }
+
+    [Fact]
+    public void Resolve_VersionMissingEverywhere_ThrowsClearMessage()
+    {
+        var sut = new AgentImageResolver(Options.Create(new SandboxGlobalConfig
+        {
+            AgentRegistry = "holgerleichsenring",
+            AgentVersion = ""
+        }));
+
+        var act = () => sut.Resolve(new ProjectConfig());
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*sandbox.agent_version*");
+    }
+
+    [Fact]
+    public void Resolve_EmptyRegistry_OmitsPrefix()
+    {
+        var sut = new AgentImageResolver(Options.Create(new SandboxGlobalConfig
+        {
+            AgentRegistry = "",
+            AgentVersion = "1.0.0"
+        }));
+
+        sut.Resolve(new ProjectConfig()).Should().Be("agent-smith-sandbox-agent:1.0.0");
+    }
+}

--- a/tests/AgentSmith.Tests/Sandbox/SandboxSpecBuilderResourcesTests.cs
+++ b/tests/AgentSmith.Tests/Sandbox/SandboxSpecBuilderResourcesTests.cs
@@ -11,7 +11,7 @@ public sealed class SandboxSpecBuilderResourcesTests
     public void Build_PopulatesResourcesFromResolver()
     {
         var resolverResult = new ResourceLimits("750m", "3000m", "1Gi", "8Gi");
-        var sut = new SandboxSpecBuilder(new StubSandboxResourceResolver(resolverResult));
+        var sut = new SandboxSpecBuilder(new StubSandboxResourceResolver(resolverResult), new StubAgentImageResolver());
 
         var spec = sut.Build(new ProjectConfig(), language: "csharp");
 
@@ -21,7 +21,7 @@ public sealed class SandboxSpecBuilderResourcesTests
     [Fact]
     public void Build_WithoutLanguage_StillPopulatesResources()
     {
-        var sut = new SandboxSpecBuilder(new StubSandboxResourceResolver());
+        var sut = new SandboxSpecBuilder(new StubSandboxResourceResolver(), new StubAgentImageResolver());
 
         var spec = sut.Build(new ProjectConfig(), language: null);
 

--- a/tests/AgentSmith.Tests/Sandbox/StubAgentImageResolver.cs
+++ b/tests/AgentSmith.Tests/Sandbox/StubAgentImageResolver.cs
@@ -1,0 +1,12 @@
+using AgentSmith.Application.Services.Sandbox;
+using AgentSmith.Contracts.Models.Configuration;
+
+namespace AgentSmith.Tests.Sandbox;
+
+/// <summary>
+/// Test-fixture resolver that returns a fixed image string for any project.
+/// </summary>
+internal sealed class StubAgentImageResolver(string image = "agent-smith-sandbox-agent:test") : IAgentImageResolver
+{
+    public string Resolve(ProjectConfig projectConfig) => image;
+}

--- a/tests/AgentSmith.Tests/Services/PipelineExecutorLifecycleFailureTests.cs
+++ b/tests/AgentSmith.Tests/Services/PipelineExecutorLifecycleFailureTests.cs
@@ -44,7 +44,7 @@ public sealed class PipelineExecutorLifecycleFailureTests
             _ticketFactoryMock.Object,
             _coordinatorMock.Object,
             _sandboxFactoryMock.Object,
-            new SandboxSpecBuilder(new StubSandboxResourceResolver()),
+            new SandboxSpecBuilder(new StubSandboxResourceResolver(), new StubAgentImageResolver()),
             resolverMock.Object,
             _progressReporterMock.Object,
             new AgentSmith.Application.Services.Pipeline.PhaseDataFlowResolver(

--- a/tests/AgentSmith.Tests/Services/PipelineExecutorPersistGuardTests.cs
+++ b/tests/AgentSmith.Tests/Services/PipelineExecutorPersistGuardTests.cs
@@ -47,7 +47,7 @@ public sealed class PipelineExecutorPersistGuardTests
             _ticketFactoryMock.Object,
             _lifecycleMock.Object,
             _sandBoxFactory.Object,
-            new SandboxSpecBuilder(new StubSandboxResourceResolver()),
+            new SandboxSpecBuilder(new StubSandboxResourceResolver(), new StubAgentImageResolver()),
             resolverMock.Object,
             _progressReporterMock.Object,
             new AgentSmith.Application.Services.Pipeline.PhaseDataFlowResolver(

--- a/tests/AgentSmith.Tests/Services/PipelineExecutorSandboxResolutionTests.cs
+++ b/tests/AgentSmith.Tests/Services/PipelineExecutorSandboxResolutionTests.cs
@@ -87,7 +87,7 @@ public sealed class PipelineExecutorSandboxResolutionTests
             _ticketFactoryMock.Object,
             _coordinatorMock.Object,
             _sandboxFactoryMock.Object,
-            new SandboxSpecBuilder(new StubSandboxResourceResolver()),
+            new SandboxSpecBuilder(new StubSandboxResourceResolver(), new StubAgentImageResolver()),
             _resolverMock.Object,
             _progressReporterMock.Object,
             new AgentSmith.Application.Services.Pipeline.PhaseDataFlowResolver(

--- a/tests/AgentSmith.Tests/Services/PipelineExecutorTests.cs
+++ b/tests/AgentSmith.Tests/Services/PipelineExecutorTests.cs
@@ -38,7 +38,7 @@ public class PipelineExecutorTests
             _ticketFactoryMock.Object,
             _lifecycleMock.Object,
             _sandboxFactoryMock.Object,
-            new SandboxSpecBuilder(new StubSandboxResourceResolver()),
+            new SandboxSpecBuilder(new StubSandboxResourceResolver(), new StubAgentImageResolver()),
             resolverMock.Object,
             _progressReporterMock.Object,
             new AgentSmith.Application.Services.Pipeline.PhaseDataFlowResolver(


### PR DESCRIPTION
…mith.yml

ErrImagePull root-cause: SandboxSpec.AgentImage defaulted to the bare name 'agent-smith-sandbox-agent:latest', which K8s resolves through docker.io/library/ — a namespace reserved for official images. The image actually lives at holgerleichsenring/agent-smith-sandbox-agent:<tag>, but no override path existed.

The registry portion (operator-specific: holgerleichsenring vs corporate mirror) and the version tag (must be pinned in K8s production) are now loaded from agentsmith.yml — the project's existing operator-facing configuration surface — via two layers: a top-level `sandbox:` block for process-wide defaults and per-project `projects.<name>.sandbox:` for canary/rollback overrides. The image NAME stays a constant (AgentImageDefaults.SandboxAgentImageName) because it's the project's published identity, not an operator choice.

Resolution flows project.Sandbox.AgentRegistry/AgentVersion -> SandboxGlobalConfig.AgentRegistry/AgentVersion field-by-field. AgentVersion missing at both layers throws InvalidOperationException with a message naming the YAML key — caught at sandbox-create time instead of surfacing as a pod-level ErrImagePull. AgentRegistry can be empty (omits the registry prefix), supporting locally-built images in dev/docker-compose.

IAgentImageResolver registered as a singleton in Application's DI; IOptions<SandboxGlobalConfig> registered in Server via a factory that pulls from the loaded AgentSmithConfig at startup, and in Infrastructure.AddInProcessSandbox as a TryAdd-placeholder so CLI users (InProcessSandboxFactory ignores AgentImage entirely) don't have to set an unused version. SandboxSpecBuilder now requires the resolver and populates SandboxSpec.AgentImage explicitly on every Build call — no path bypasses the resolution chain.

Operator surface: agentsmith.yml gains a `sandbox:` top-level block; config/agentsmith.example.yml + the Rhenus 8-deployment-server.yaml ConfigMap demonstrate the canonical settings.

8 new tests (resolver x5 covering project override, global default, fail-loud on missing version, empty-registry prefix omission; YAML deserialisation x3). 1613 main + 62 sandbox tests passing.