### PR TITLE
chore: template docker-compose as example + gitignore the runnable copy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,8 @@ deploy/k8s/secret-local.yaml
 
 ## Local config (only *.example.* templates are tracked)
 config/agentsmith.yml
+deploy/docker-compose.yml
+deploy/docker-compose.override.yml
 
 ## Claude Code
 .claude/

--- a/deploy/docker-compose.example.yml
+++ b/deploy/docker-compose.example.yml
@@ -1,4 +1,8 @@
-# Run from repo root:
+# Template — copy to `docker-compose.yml` (gitignored) and adjust the
+# user-specific paths below for your local checkout. The committed file is
+# this template; the runnable file is your local copy.
+#
+# Run from repo root after copying + editing:
 #   docker compose -f deploy/docker-compose.yml up -d                        # server + redis
 #   docker compose -f deploy/docker-compose.yml run --rm agentsmith run --headless "fix #1 in my-project"
 #   docker compose -f deploy/docker-compose.yml run --rm agentsmith security-scan --repo /app/repo --output console
@@ -8,20 +12,24 @@
 #   - agentsmith-server (single long-running container: Slack/Teams chat,
 #     webhooks, polling, queue consumer, lifecycle reconcilers — all in one
 #     process via AgentSmith.Server.dll, since p0107)
+#
+# Two things to set before this template runs:
+#   1. The bind-mount target for /app/config below — replace the placeholder
+#      with the absolute path to the directory containing your agentsmith.yml.
+#   2. AGENTSMITH_VERSION / AGENT_VERSION in your .env (or shell) — pin to a
+#      released agent-smith tag (default below is the current release).
 
 services:
   agentsmith:
     build:
       context: ..
       dockerfile: src/AgentSmith.Cli/Dockerfile
-    # p0137d: pinned via env-var with safe default — set AGENTSMITH_VERSION in .env
-    # to track your deployment's release. Falling back to :latest is non-reproducible.
-    image: agentsmith-cli:${AGENTSMITH_VERSION:-0.48.0}
+    image: agentsmith-cli:${AGENTSMITH_VERSION:-0.50.0}
     restart: "no"
     env_file:
       - ../.env
     volumes:
-      - /Users/da5id/develop/source/rhenus/RHS.AuthPort.Server/config:/app/config
+      - /path/to/your/agentsmith/config:/app/config   # REPLACE — directory containing your agentsmith.yml
       - ${SSH_KEY_PATH:-~/.ssh}:/home/agentsmith/.ssh:ro
       - /var/run/docker.sock:/var/run/docker.sock    # for Nuclei/Spectral tool containers
 
@@ -33,15 +41,13 @@ services:
   #
   # Required before the first labelled ticket triggers a pipeline; without
   # the image present, DockerJobSpawner fails with DockerImageNotFoundException
-  # for `agent-smith-sandbox-agent:latest`. Not on Docker Hub — built locally
-  # from src/AgentSmith.Sandbox.Agent/Dockerfile.
+  # for `agent-smith-sandbox-agent:<tag>`. Pull from holgerleichsenring on
+  # Docker Hub or build locally from src/AgentSmith.Sandbox.Agent/Dockerfile.
   sandbox-agent:
     build:
       context: ..
       dockerfile: src/AgentSmith.Sandbox.Agent/Dockerfile
-    # p0137d: pinned via env-var with safe default — operators bump this in
-    # lockstep with sandbox.agent_version in agentsmith.yml.
-    image: agent-smith-sandbox-agent:${AGENT_VERSION:-0.48.0}
+    image: agent-smith-sandbox-agent:${AGENT_VERSION:-0.50.0}
     profiles: [build-only]
 
   redis:
@@ -74,12 +80,12 @@ services:
       - REDIS_URL=redis:6379
       - SPAWNER_TYPE=${SPAWNER_TYPE:-docker}
       - ASPNETCORE_ENVIRONMENT=${ASPNETCORE_ENVIRONMENT:-Production}
-      - AGENTSMITH_IMAGE=${AGENTSMITH_IMAGE:-agentsmith-cli:${AGENTSMITH_VERSION:-0.48.0}}
+      - AGENTSMITH_IMAGE=${AGENTSMITH_IMAGE:-agentsmith-cli:${AGENTSMITH_VERSION:-0.50.0}}
       - IMAGE_PULL_POLICY=${IMAGE_PULL_POLICY:-IfNotPresent}
     ports:
       - "${SERVER_PORT:-8081}:8081"
     volumes:
-      - /Users/da5id/develop/source/rhenus/RHS.AuthPort.Server/config:/app/config
+      - /path/to/your/agentsmith/config:/app/config   # REPLACE — same path as the agentsmith service above
       - /var/run/docker.sock:/var/run/docker.sock
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8081/health"]


### PR DESCRIPTION
The committed docker-compose.yml leaked operator-specific paths (/Users/.../rhenus/RHS.AuthPort.Server/config) into the source tree. Pattern from config/agentsmith.yml: template tracked, runnable copy gitignored.

- docker-compose.yml → docker-compose.example.yml (placeholder paths, default versions bumped 0.48.0 → 0.50.0 to match current release).
- .gitignore adds deploy/docker-compose.yml + deploy/docker-compose.override.yml.