### PR TITLE
fix: raise triage rationale cap 500 → 1000 chars (api-security-scan)

### DIFF
--- a/src/AgentSmith.Application/Prompts/Resources/triage-structured-system.md
+++ b/src/AgentSmith.Application/Prompts/Resources/triage-structured-system.md
@@ -69,7 +69,7 @@ rejected).
 
 - Both `<skill>` AND `<key>` are mandatory in every token — the parser
   drops malformed tokens silently. Do not emit `lead=foo;` without a key.
-- Max 500 chars total. No newlines inside the JSON.
+- Max 1000 chars total. No newlines inside the JSON.
 - Every `<key>` MUST come from the concept-vocabulary list shown verbatim
   in the user message under `## Available Rationale Keys (Concept
   Vocabulary)`. Invented keys are rejected by the framework.

--- a/src/AgentSmith.Application/Services/Triage/TriageOutputValidator.cs
+++ b/src/AgentSmith.Application/Services/Triage/TriageOutputValidator.cs
@@ -15,7 +15,12 @@ namespace AgentSmith.Application.Services.Triage;
 /// </summary>
 public sealed class TriageOutputValidator(TriageRationaleParser rationaleParser)
 {
-    private const int MaxRationaleChars = 500;
+    // 1000 (raised from 500) gives the LLM headroom for security-scan / api-security-scan
+    // catalogs (15-20 skills) where each phase slot carries its own positive justification
+    // and the rejected-candidate negative entries add another bracket of tokens. Observed
+    // overshoots on the 500-cap clustered around 600-800 chars — 1000 covers them with
+    // margin while still keeping the JSON rationale field operator-readable on one screen.
+    private const int MaxRationaleChars = 1000;
 
     public TriageValidationResult Validate(
         TriageOutput output,

--- a/tests/AgentSmith.Tests/Triage/TriageOutputValidatorTests.cs
+++ b/tests/AgentSmith.Tests/Triage/TriageOutputValidatorTests.cs
@@ -68,13 +68,28 @@ public sealed class TriageOutputValidatorTests
     public void Validate_RationaleExceedsMaxLength_Rejects()
     {
         var skills = Array.Empty<SkillIndexEntry>();
-        var huge = new string('x', 501);
+        var huge = new string('x', 1001);
         var output = new TriageOutput(new Dictionary<PipelinePhase, PhaseAssignment>(), 85, huge);
 
         var result = _sut.Validate(output, skills);
 
         result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.Contains("500 chars"));
+        result.Errors.Should().Contain(e => e.Contains("1000 chars"));
+    }
+
+    [Fact]
+    public void Validate_RationaleAt800Chars_PassesBetween500and1000Cap()
+    {
+        // p0138-followup: cap raised from 500 to 1000 — rationales in the 500-800 band
+        // (typical for api-security-scan / security-scan catalogs with 15-20 skills)
+        // are now legal where they previously failed validation.
+        var skills = Array.Empty<SkillIndexEntry>();
+        var mid = new string('x', 800);
+        var output = new TriageOutput(new Dictionary<PipelinePhase, PhaseAssignment>(), 85, mid);
+
+        var result = _sut.Validate(output, skills);
+
+        result.Errors.Should().NotContain(e => e.Contains("chars"));
     }
 
     [Fact]


### PR DESCRIPTION
api-security-scan run via CLI surfaced consistent 600-800 char rationales on first attempt — beyond the 500 cap. The LLM's response shape with 15-20 skills (typical for security catalogs) naturally produces more justification tokens than the small 3-5-skill code-flow catalogs the 500 cap was tuned for. Retry under the STRICT REPROMPT compressed the text but also degraded skill choice (investigator dropped into Reviewer slot — wrong role for the slot).

Raised cap matches the catalog scale. Prompt's documented cap synced to keep LLM and validator on the same number — prompt says 1000 chars now too, so the LLM does not over-trim and lose information.

Tests:
- Existing TriageOutputValidatorTests.Validate_RationaleExceedsMaxLength_Rejects bumped to 1001-char input + asserts "1000 chars" in error message.
- New Validate_RationaleAt800Chars_PassesBetween500and1000Cap covers the 500-1000 band that previously failed.

1655 main + 62 sandbox tests passing.