### PR TITLE
fix: unify YAML config schema on snake_case + close p0140a area_path bug

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Fetch skill catalog for tests
         env:
-          SKILLS_VERSION: ${{ vars.SKILLS_VERSION || 'v2.0.0' }}
+          SKILLS_VERSION: ${{ vars.SKILLS_VERSION || 'v2.1.2' }}
         run: |
           chmod +x scripts/fetch-skills.sh
           scripts/fetch-skills.sh ./test-skills

--- a/config/agentsmith.example.yml
+++ b/config/agentsmith.example.yml
@@ -8,10 +8,10 @@
 # where every project carried inline source/tickets/agent blocks (see
 # docs/configuration/migration-from-pre-p0139.md if you're migrating).
 #
-# Supported providers:
-#   - AI agents: Claude (Anthropic), OpenAI, Azure OpenAI, Gemini (Google), Ollama
-#   - Repos:     GitHub | GitLab | AzureDevOps | Local
-#   - Trackers:  GitHub | GitLab | AzureDevOps | Jira
+# Supported providers (canonical YAML values are snake_case):
+#   - AI agents: claude | openai | azure_openai | gemini | ollama
+#   - Repos:     github | gitlab | azure_devops | local
+#   - Trackers:  github | gitlab | azure_devops | jira
 
 # --- Sandbox carrier image (REQUIRED for K8s/Docker spawners) ---
 sandbox:
@@ -30,7 +30,7 @@ orchestrator:
 # Same agent reused across projects → defined once, edited once.
 agents:
   claude-default:
-    type: Claude
+    type: claude
     model: claude-sonnet-4-20250514
     retry:
       max_retries: 5
@@ -72,7 +72,7 @@ agents:
 
   # Required for api-security-scan to hit Anthropic's 5-min prompt-cache TTL.
   claude-parallel:
-    type: Claude
+    type: claude
     model: claude-sonnet-4-20250514
     cache:
       is_enabled: true
@@ -94,7 +94,7 @@ agents:
       max_concurrent_skill_rounds: 4
 
   # azure-openai-default:
-  #   type: azure-openai
+  #   type: azure_openai
   #   endpoint: https://your-instance.openai.azure.com
   #   api_version: 2025-01-01-preview
   #   models:
@@ -120,31 +120,31 @@ agents:
 # ────────────────────────────────────────────────────────────────────────
 repos:
   acme-app:
-    type: GitHub
+    type: github
     url: https://github.com/owner/acme-app
     auth: github_token
     # default_branch: main
 
   acme-platform:
-    type: AzureDevOps
+    type: azure_devops
     url: https://dev.azure.com/acme/platform/_git/platform-core
     organization: acme
     project: platform
     auth: azure_devops_token
 
   acme-rules-shared:
-    type: GitLab
+    type: gitlab
     url: https://gitlab.com/acme/rules-shared
     auth: gitlab_token
 
   acme-rules-billing:
-    type: GitLab
+    type: gitlab
     url: https://gitlab.com/acme/rules-billing
     auth: gitlab_token
 
   # Local repo for dev / api-security passive mode.
   api-source-local:
-    type: Local
+    type: local
     path: ./repo
     auth: none
 
@@ -156,12 +156,12 @@ repos:
 # stays on the project's trigger block.
 trackers:
   acme-github:
-    type: GitHub
+    type: github
     url: https://github.com/owner/acme-app
     auth: github_token
 
   acme-ado:
-    type: AzureDevOps
+    type: azure_devops
     url: https://dev.azure.com/acme
     organization: acme
     project: platform
@@ -170,7 +170,7 @@ trackers:
     done_status: "Resolved"
 
   acme-jira:
-    type: Jira
+    type: jira
     url: https://acme.atlassian.net/
     auth: jira_token
     open_states: ["To Do", "In Progress"]
@@ -225,11 +225,11 @@ projects:
       jitter_percent: 10
     azuredevops_trigger:
       project_resolution:
-        # p0140a: ADO area-path dispatch — hierarchical prefix match. The configured
+        # p0140a: ADO area_path dispatch — hierarchical prefix match. The configured
         # value AcmeMain/Platform also matches AcmeMain/Platform/Provisioning and any
         # deeper subtree. Backslash form (AcmeMain\\Platform with YAML-escaping) is
         # equivalent; the loader normalises.
-        strategy: area-path
+        strategy: area_path
         value: AcmeMain/Platform
       trigger_statuses: ["New", "Active"]
       done_status: "Resolved"

--- a/config/agentsmith.schema.json
+++ b/config/agentsmith.schema.json
@@ -52,7 +52,7 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["Claude", "OpenAI", "azure-openai", "Gemini", "Ollama"]
+          "enum": ["claude", "openai", "azure_openai", "gemini", "ollama"]
         },
         "model": { "type": "string" },
         "endpoint": { "type": "string" },
@@ -69,12 +69,12 @@
     },
     "repo": {
       "type": "object",
-      "description": "Source repository connection. Type=Local uses path; remote types use url.",
+      "description": "Source repository connection. type=local uses path; remote types use url.",
       "required": ["type", "auth"],
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["GitHub", "GitLab", "AzureDevOps", "Local"]
+          "enum": ["github", "gitlab", "azure_devops", "local"]
         },
         "url": { "type": "string" },
         "path": { "type": "string" },
@@ -91,7 +91,7 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["GitHub", "GitLab", "AzureDevOps", "Jira"]
+          "enum": ["github", "gitlab", "azure_devops", "jira"]
         },
         "url": { "type": "string" },
         "organization": { "type": "string" },
@@ -220,17 +220,17 @@
     },
     "projectResolution": {
       "type": "object",
-      "description": "Tells the webhook handler which agent-smith project owns an incoming ticket. With multi-tenant trackers (one ADO project hosting many sub-projects, one Jira install used by many teams) this declaration is mandatory — without it the handler has no way to route. Strategies: tag (label match on ticket), area-path (ADO AreaPath prefix match — supports both \\ and /), repo (GitHub/GitLab source-repo URL match — requires project.repos to have exactly one entry), to_address (Email tracker only, see p0141).",
+      "description": "Tells the webhook handler which agent-smith project owns an incoming ticket. With multi-tenant trackers (one ADO project hosting many sub-projects, one Jira install used by many teams) this declaration is mandatory — without it the handler has no way to route. Strategies: tag (label match on ticket), area_path (ADO AreaPath prefix match — supports both \\ and /), repo (GitHub/GitLab source-repo URL match — requires project.repos to have exactly one entry), to_address (Email tracker only, see p0141).",
       "required": ["strategy", "value"],
       "additionalProperties": false,
       "properties": {
         "strategy": {
           "type": "string",
-          "enum": ["tag", "area-path", "repo", "to_address"]
+          "enum": ["tag", "area_path", "repo", "to_address"]
         },
         "value": {
           "type": "string",
-          "description": "Strategy-specific match value. tag: label string. area-path: hierarchical path (e.g. ContosoMain/Billing or ContosoMain\\Billing); matching is prefix-based on the normalized backslash form, so ContosoMain\\Billing matches both itself and ContosoMain\\Billing\\Invoicing. repo: repo URL or short name matched against the project's single repo's RepoConnection.Url. to_address: full email address."
+          "description": "Strategy-specific match value. tag: label string. area_path: hierarchical path (e.g. ContosoMain/Billing or ContosoMain\\Billing); matching is prefix-based on the normalized backslash form, so ContosoMain\\Billing matches both itself and ContosoMain\\Billing\\Invoicing. repo: repo URL or short name matched against the project's single repo's RepoConnection.Url. to_address: full email address."
         }
       }
     }

--- a/src/AgentSmith.Application/Services/Configuration/AgentSmithConfigValidator.cs
+++ b/src/AgentSmith.Application/Services/Configuration/AgentSmithConfigValidator.cs
@@ -35,7 +35,7 @@ public sealed class AgentSmithConfigValidator
                 errors.Add(
                     $"Project '{name}': {kind} is missing required 'project_resolution' " +
                     "(p0140 — declares how the webhook handler picks this project for an " +
-                    "incoming ticket; one of tag/area-path/repo/to_address).");
+                    "incoming ticket; one of tag/area_path/repo/to_address).");
             }
         }
     }
@@ -53,7 +53,7 @@ public sealed class AgentSmithConfigValidator
                 errors.Add(
                     $"Project '{name}': {kind} project_resolution.strategy=repo requires " +
                     $"exactly one entry in repos (has {project.Repos.Count}). Use strategy=tag " +
-                    "or area-path for multi-repo projects, since the webhook payload's repo URL " +
+                    "or area_path for multi-repo projects, since the webhook payload's repo URL " +
                     "alone cannot disambiguate which repo of the project the ticket belongs to.");
             }
         }

--- a/src/AgentSmith.Contracts/Models/Configuration/ProjectResolutionConfig.cs
+++ b/src/AgentSmith.Contracts/Models/Configuration/ProjectResolutionConfig.cs
@@ -12,7 +12,7 @@ public sealed record ProjectResolutionConfig
 
     /// <summary>
     /// Strategy-specific match value. For tag/to_address: exact case-insensitive match.
-    /// For area-path: hierarchical prefix match against the normalised backslash form.
+    /// For area_path: hierarchical prefix match against the normalised backslash form.
     /// For repo: exact case-insensitive URL match against the project's single repo.
     /// </summary>
     public string Value { get; init; } = string.Empty;

--- a/src/AgentSmith.Contracts/Models/Configuration/RepoType.cs
+++ b/src/AgentSmith.Contracts/Models/Configuration/RepoType.cs
@@ -1,9 +1,11 @@
+using System.Runtime.Serialization;
+
 namespace AgentSmith.Contracts.Models.Configuration;
 
 public enum RepoType
 {
-    GitHub,
-    GitLab,
-    AzureDevOps,
-    Local
+    [EnumMember(Value = "github")] GitHub,
+    [EnumMember(Value = "gitlab")] GitLab,
+    [EnumMember(Value = "azure_devops")] AzureDevOps,
+    [EnumMember(Value = "local")] Local
 }

--- a/src/AgentSmith.Contracts/Models/Configuration/ResolutionStrategy.cs
+++ b/src/AgentSmith.Contracts/Models/Configuration/ResolutionStrategy.cs
@@ -1,3 +1,5 @@
+using System.Runtime.Serialization;
+
 namespace AgentSmith.Contracts.Models.Configuration;
 
 /// <summary>
@@ -11,11 +13,11 @@ public enum ResolutionStrategy
     Tag,
 
     /// <summary>ADO area path: hierarchical prefix match. Supports both \ and / separators.</summary>
-    AreaPath,
+    [EnumMember(Value = "area_path")] AreaPath,
 
     /// <summary>Source-repo URL match. Requires project.Repos.Count == 1.</summary>
     Repo,
 
     /// <summary>Email tracker: the to-address on the incoming mail equals the configured value. Reserved for p0141.</summary>
-    ToAddress
+    [EnumMember(Value = "to_address")] ToAddress
 }

--- a/src/AgentSmith.Contracts/Models/Configuration/TrackerType.cs
+++ b/src/AgentSmith.Contracts/Models/Configuration/TrackerType.cs
@@ -1,9 +1,11 @@
+using System.Runtime.Serialization;
+
 namespace AgentSmith.Contracts.Models.Configuration;
 
 public enum TrackerType
 {
-    GitHub,
-    GitLab,
-    AzureDevOps,
-    Jira
+    [EnumMember(Value = "github")] GitHub,
+    [EnumMember(Value = "gitlab")] GitLab,
+    [EnumMember(Value = "azure_devops")] AzureDevOps,
+    [EnumMember(Value = "jira")] Jira
 }

--- a/src/AgentSmith.Infrastructure.Core/Services/Configuration/RawRepoEntry.cs
+++ b/src/AgentSmith.Infrastructure.Core/Services/Configuration/RawRepoEntry.cs
@@ -1,3 +1,5 @@
+using AgentSmith.Contracts.Models.Configuration;
+
 namespace AgentSmith.Infrastructure.Core.Services.Configuration;
 
 /// <summary>
@@ -6,7 +8,7 @@ namespace AgentSmith.Infrastructure.Core.Services.Configuration;
 /// </summary>
 public sealed class RawRepoEntry
 {
-    public string Type { get; set; } = string.Empty;
+    public RepoType Type { get; set; }
     public string? Url { get; set; }
     public string? Path { get; set; }
     public string? Organization { get; set; }

--- a/src/AgentSmith.Infrastructure.Core/Services/Configuration/RawTrackerEntry.cs
+++ b/src/AgentSmith.Infrastructure.Core/Services/Configuration/RawTrackerEntry.cs
@@ -1,3 +1,5 @@
+using AgentSmith.Contracts.Models.Configuration;
+
 namespace AgentSmith.Infrastructure.Core.Services.Configuration;
 
 /// <summary>
@@ -6,7 +8,7 @@ namespace AgentSmith.Infrastructure.Core.Services.Configuration;
 /// </summary>
 public sealed class RawTrackerEntry
 {
-    public string Type { get; set; } = string.Empty;
+    public TrackerType Type { get; set; }
     public string? Url { get; set; }
     public string? Organization { get; set; }
     public string? Project { get; set; }

--- a/src/AgentSmith.Infrastructure.Core/Services/Configuration/RepoCatalogBuilder.cs
+++ b/src/AgentSmith.Infrastructure.Core/Services/Configuration/RepoCatalogBuilder.cs
@@ -4,44 +4,29 @@ namespace AgentSmith.Infrastructure.Core.Services.Configuration;
 
 /// <summary>
 /// Converts raw `repos:` YAML entries into <see cref="RepoConnection"/>
-/// records keyed by catalog name. Type-parse failures are recorded into the
-/// passed-in errors list — the builder never throws.
+/// records keyed by catalog name. Type binding happens at YAML deserialize
+/// time via the snake_case enum convention; unknown values fail there.
 /// </summary>
 public sealed class RepoCatalogBuilder
 {
     public Dictionary<string, RepoConnection> Build(
-        IReadOnlyDictionary<string, RawRepoEntry> raw, List<string> errors)
+        IReadOnlyDictionary<string, RawRepoEntry> raw, List<string> _)
     {
         var result = new Dictionary<string, RepoConnection>(raw.Count);
 
         foreach (var (name, entry) in raw)
-        {
-            var connection = TryBuild(name, entry, errors);
-            if (connection is not null) result[name] = connection;
-        }
+            result[name] = new RepoConnection
+            {
+                Name = name,
+                Type = entry.Type,
+                Url = entry.Url,
+                Path = entry.Path,
+                Organization = entry.Organization,
+                Project = entry.Project,
+                Auth = entry.Auth,
+                DefaultBranch = entry.DefaultBranch,
+            };
+
         return result;
-    }
-
-    private static RepoConnection? TryBuild(string name, RawRepoEntry entry, List<string> errors)
-    {
-        if (!Enum.TryParse<RepoType>(entry.Type, ignoreCase: true, out var type))
-        {
-            errors.Add(
-                $"Repo '{name}': unknown type '{entry.Type}' " +
-                "(expected GitHub|GitLab|AzureDevOps|Local)");
-            return null;
-        }
-
-        return new RepoConnection
-        {
-            Name = name,
-            Type = type,
-            Url = entry.Url,
-            Path = entry.Path,
-            Organization = entry.Organization,
-            Project = entry.Project,
-            Auth = entry.Auth,
-            DefaultBranch = entry.DefaultBranch,
-        };
     }
 }

--- a/src/AgentSmith.Infrastructure.Core/Services/Configuration/TrackerCatalogBuilder.cs
+++ b/src/AgentSmith.Infrastructure.Core/Services/Configuration/TrackerCatalogBuilder.cs
@@ -4,48 +4,34 @@ namespace AgentSmith.Infrastructure.Core.Services.Configuration;
 
 /// <summary>
 /// Converts raw `trackers:` YAML entries into <see cref="TrackerConnection"/>
-/// records keyed by catalog name. Type-parse failures go into the errors list.
+/// records keyed by catalog name. Type binding happens at YAML deserialize
+/// time via the snake_case enum convention; unknown values fail there.
 /// </summary>
 public sealed class TrackerCatalogBuilder
 {
     public Dictionary<string, TrackerConnection> Build(
-        IReadOnlyDictionary<string, RawTrackerEntry> raw, List<string> errors)
+        IReadOnlyDictionary<string, RawTrackerEntry> raw, List<string> _)
     {
         var result = new Dictionary<string, TrackerConnection>(raw.Count);
 
         foreach (var (name, entry) in raw)
-        {
-            var connection = TryBuild(name, entry, errors);
-            if (connection is not null) result[name] = connection;
-        }
+            result[name] = new TrackerConnection
+            {
+                Name = name,
+                Type = entry.Type,
+                Url = entry.Url,
+                Organization = entry.Organization,
+                Project = entry.Project,
+                Auth = entry.Auth,
+                OpenStates = entry.OpenStates,
+                DoneStatus = entry.DoneStatus,
+                CloseTransitionName = entry.CloseTransitionName,
+                ExtraFields = entry.ExtraFields,
+                ZeroMatchComment = entry.ZeroMatchComment,
+                Polling = MapPolling(entry.Polling),
+            };
+
         return result;
-    }
-
-    private static TrackerConnection? TryBuild(string name, RawTrackerEntry entry, List<string> errors)
-    {
-        if (!Enum.TryParse<TrackerType>(entry.Type, ignoreCase: true, out var type))
-        {
-            errors.Add(
-                $"Tracker '{name}': unknown type '{entry.Type}' " +
-                "(expected GitHub|GitLab|AzureDevOps|Jira)");
-            return null;
-        }
-
-        return new TrackerConnection
-        {
-            Name = name,
-            Type = type,
-            Url = entry.Url,
-            Organization = entry.Organization,
-            Project = entry.Project,
-            Auth = entry.Auth,
-            OpenStates = entry.OpenStates,
-            DoneStatus = entry.DoneStatus,
-            CloseTransitionName = entry.CloseTransitionName,
-            ExtraFields = entry.ExtraFields,
-            ZeroMatchComment = entry.ZeroMatchComment,
-            Polling = MapPolling(entry.Polling),
-        };
     }
 
     private static PollingConfig MapPolling(RawPollingEntry? raw)

--- a/src/AgentSmith.Infrastructure.Core/Services/Configuration/YamlConfigurationLoader.cs
+++ b/src/AgentSmith.Infrastructure.Core/Services/Configuration/YamlConfigurationLoader.cs
@@ -55,6 +55,7 @@ public sealed class YamlConfigurationLoader(
         {
             var deserializer = new DeserializerBuilder()
                 .WithNamingConvention(UnderscoredNamingConvention.Instance)
+                .WithEnumNamingConvention(UnderscoredNamingConvention.Instance)
                 .IgnoreUnmatchedProperties()
                 .Build();
 
@@ -63,7 +64,8 @@ public sealed class YamlConfigurationLoader(
         }
         catch (Exception ex) when (ex is not ConfigurationException)
         {
-            throw new ConfigurationException($"Invalid YAML in {configPath}: {ex.Message}");
+            var detail = ex.InnerException is not null ? $"{ex.Message} -> {ex.InnerException.Message}" : ex.Message;
+            throw new ConfigurationException($"Invalid YAML in {configPath}: {detail}");
         }
     }
 

--- a/src/AgentSmith.Infrastructure/Services/Factories/ChatClientBuilders/IChatClientBuilder.cs
+++ b/src/AgentSmith.Infrastructure/Services/Factories/ChatClientBuilders/IChatClientBuilder.cs
@@ -10,7 +10,7 @@ namespace AgentSmith.Infrastructure.Services.Factories.ChatClientBuilders;
 public interface IChatClientBuilder
 {
     /// <summary>
-    /// AgentConfig.Type values this builder handles (e.g. "claude", "openai", "azure-openai").
+    /// AgentConfig.Type values this builder handles (e.g. "claude", "openai", "azure_openai").
     /// </summary>
     IReadOnlyList<string> SupportedTypes { get; }
 

--- a/src/AgentSmith.Infrastructure/Services/Factories/ChatClientBuilders/OpenAiChatClientBuilder.cs
+++ b/src/AgentSmith.Infrastructure/Services/Factories/ChatClientBuilders/OpenAiChatClientBuilder.cs
@@ -13,7 +13,7 @@ namespace AgentSmith.Infrastructure.Services.Factories.ChatClientBuilders;
 /// </summary>
 public sealed class OpenAiChatClientBuilder : IChatClientBuilder
 {
-    public IReadOnlyList<string> SupportedTypes { get; } = new[] { "openai", "azure-openai" };
+    public IReadOnlyList<string> SupportedTypes { get; } = new[] { "openai", "azure_openai" };
 
     public IChatClient Build(AgentConfig agent, ModelAssignment assignment)
     {
@@ -23,7 +23,7 @@ public sealed class OpenAiChatClientBuilder : IChatClientBuilder
 
         var credential = new ApiKeyCredential(apiKey);
 
-        if (string.Equals(agent.Type, "azure-openai", StringComparison.OrdinalIgnoreCase))
+        if (string.Equals(agent.Type, "azure_openai", StringComparison.OrdinalIgnoreCase))
         {
             var endpoint = agent.Endpoint
                 ?? throw new InvalidOperationException("Azure OpenAI requires AgentConfig.Endpoint.");
@@ -47,7 +47,7 @@ public sealed class OpenAiChatClientBuilder : IChatClientBuilder
             if (!string.IsNullOrEmpty(secret)) return secret;
         }
 
-        var fallback = string.Equals(agent.Type, "azure-openai", StringComparison.OrdinalIgnoreCase)
+        var fallback = string.Equals(agent.Type, "azure_openai", StringComparison.OrdinalIgnoreCase)
             ? "AZURE_OPENAI_API_KEY"
             : "OPENAI_API_KEY";
         return Environment.GetEnvironmentVariable(fallback);

--- a/tests/AgentSmith.Tests/AgentSmith.Tests.csproj
+++ b/tests/AgentSmith.Tests/AgentSmith.Tests.csproj
@@ -31,6 +31,9 @@
     <None Update="Configuration\TestData\**\*">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="..\..\config\agentsmith.example.yml" Link="Configuration\TestData\agentsmith.example.yml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/AgentSmith.Tests/Configuration/TestData/valid-config.yml
+++ b/tests/AgentSmith.Tests/Configuration/TestData/valid-config.yml
@@ -1,17 +1,17 @@
 agents:
   claude-default:
-    type: Claude
+    type: claude
     model: sonnet-4
 
 repos:
   test-repo:
-    type: GitHub
+    type: github
     url: https://github.com/test/repo
     auth: token
 
 trackers:
   test-ado:
-    type: AzureDevOps
+    type: azure_devops
     organization: testorg
     project: TestProject
     auth: token

--- a/tests/AgentSmith.Tests/Configuration/TrackerCatalogBuilderTests.cs
+++ b/tests/AgentSmith.Tests/Configuration/TrackerCatalogBuilderTests.cs
@@ -1,3 +1,4 @@
+using AgentSmith.Contracts.Models.Configuration;
 using AgentSmith.Infrastructure.Core.Services.Configuration;
 using FluentAssertions;
 
@@ -19,7 +20,7 @@ public sealed class TrackerCatalogBuilderTests
         {
             ["tr1"] = new RawTrackerEntry
             {
-                Type = "GitHub",
+                Type = TrackerType.GitHub,
                 Auth = "token",
                 Polling = new RawPollingEntry
                 {
@@ -45,7 +46,7 @@ public sealed class TrackerCatalogBuilderTests
     {
         var raw = new Dictionary<string, RawTrackerEntry>
         {
-            ["tr1"] = new RawTrackerEntry { Type = "GitHub", Auth = "token", Polling = null }
+            ["tr1"] = new RawTrackerEntry { Type = TrackerType.GitHub, Auth = "token", Polling = null }
         };
         var errors = new List<string>();
 
@@ -62,7 +63,7 @@ public sealed class TrackerCatalogBuilderTests
         {
             ["tr1"] = new RawTrackerEntry
             {
-                Type = "GitHub",
+                Type = TrackerType.GitHub,
                 Auth = "token",
                 ZeroMatchComment = true,
             }

--- a/tests/AgentSmith.Tests/Configuration/YamlConfigurationLoaderTests.cs
+++ b/tests/AgentSmith.Tests/Configuration/YamlConfigurationLoaderTests.cs
@@ -68,9 +68,36 @@ public class YamlConfigurationLoaderTests
         repo.Url.Should().Be("https://github.com/test/repo");
         project.Tracker.Type.Should().Be(TrackerType.AzureDevOps);
         project.Tracker.Organization.Should().Be("testorg");
-        project.Agent.Type.Should().Be("Claude");
+        project.Agent.Type.Should().Be("claude");
         project.Agent.Model.Should().Be("sonnet-4");
         project.Pipeline.Should().Be("fix-bug");
     }
 
+    // Loads the bundled operator-facing example end-to-end. Regression guard for
+    // the p0140a area-path bug: a `strategy: area-path` value in the example
+    // never matched ResolutionStrategy.AreaPath because YamlDotNet's underscored
+    // property convention does not apply to enum values, and no end-to-end load
+    // covered the canonical example. This test exercises the full deserializer
+    // wiring (snake_case enums) against the live example file.
+    [Fact]
+    public void LoadConfig_BundledExample_LoadsAndBindsEnumsAcrossAllCanonicalForms()
+    {
+        var config = _loader.LoadConfig(TestDataPath("agentsmith.example.yml"));
+
+        config.Should().NotBeNull();
+        config.Repos.Values.Select(r => r.Type).Should().Contain(
+            new[] { RepoType.GitHub, RepoType.GitLab, RepoType.AzureDevOps, RepoType.Local });
+        config.Trackers.Values.Select(t => t.Type).Should().Contain(
+            new[] { TrackerType.GitHub, TrackerType.AzureDevOps, TrackerType.Jira });
+
+        var strategies = config.Projects.Values
+            .SelectMany(p => new[] { p.GithubTrigger, p.GitlabTrigger, p.AzuredevopsTrigger, p.JiraTrigger })
+            .Where(t => t?.ProjectResolution is not null)
+            .Select(t => t!.ProjectResolution!.Strategy)
+            .ToList();
+        strategies.Should().Contain(ResolutionStrategy.AreaPath,
+            "the example exercises ADO area_path resolution — this is the assertion that fails when YamlDotNet's enum naming convention isn't wired up");
+        strategies.Should().Contain(ResolutionStrategy.Tag);
+        strategies.Should().Contain(ResolutionStrategy.Repo);
+    }
 }

--- a/tests/AgentSmith.Tests/TestHelpers/RunStateConceptsTestFactory.cs
+++ b/tests/AgentSmith.Tests/TestHelpers/RunStateConceptsTestFactory.cs
@@ -51,7 +51,8 @@ internal static class RunStateConceptsTestFactory
         ["pipeline_name"] = new(
             "pipeline_name", "test", ConceptType.Enum,
             new[] { "api-security-scan", "security-scan", "fix-bug", "feature-implementation",
-                    "mad-discussion", "legal-analysis", "init-project" },
+                    "mad-discussion", "legal-analysis", "init-project",
+                    "autonomous", "skill-manager" },
             null, []),
         ["source_available"] = new("source_available", "test", ConceptType.Bool, null, null, []),
         ["context_yaml_present"] = new("context_yaml_present", "test", ConceptType.Bool, null, null, []),


### PR DESCRIPTION
## Summary

- `strategy: area-path` in the bundled `agentsmith.yml` / `agentsmith.example.yml` silently failed to bind to `ResolutionStrategy.AreaPath` because YamlDotNet's `UnderscoredNamingConvention` only applies to property names, not enum values — and the canonical example was never loaded end-to-end. The codebase also bound enums via two different mechanisms (typed YamlDotNet binding vs. manual `Enum.TryParse(ignoreCase: true)`), so casing drift accumulated across files (`GitHub` / `area-path` / `to_address` / `azure-openai`).
- Unifies on **snake_case** everywhere (single global convention for properties AND enum values), with canonical forms pinned via `[EnumMember(Value=...)]` (BCL attribute — no YamlDotNet coupling in `AgentSmith.Contracts`).
- Adds an end-to-end loader regression test against the bundled `agentsmith.example.yml` — the exact gap that let p0140a's `area-path` slip through.

## Mechanics

- Loader: `.WithEnumNamingConvention(UnderscoredNamingConvention.Instance)` + InnerException unwrap for clearer error surfacing.
- `RawTrackerEntry.Type` / `RawRepoEntry.Type` promoted from `string` to typed enums; manual `Enum.TryParse` branches in the catalog builders removed.
- Enum aliases: `GitHub`→`github`, `GitLab`→`gitlab`, `AzureDevOps`→`azure_devops`, `Local`→`local`, `Jira`→`jira`, `AreaPath`→`area_path`, `ToAddress`→`to_address`.
- `OpenAiChatClientBuilder.SupportedTypes`: `"azure-openai"`→`"azure_openai"`.
- Bundled `agentsmith.example.yml` + `agentsmith.schema.json` migrated to canonical forms.

## Operator impact

**Breaking, no backwards compatibility.** Operator configs (`agentsmith.yml`) must move to snake_case enum values. The Rhenus deployments (AuthPort, RheTrust, DAP, CICD, k8s configmap) are migrated in their own repos in parallel commits.

## Test plan

- [x] Full test suite green (1722 unit tests pass).
- [x] New regression test `LoadConfig_BundledExample_LoadsAndBindsEnumsAcrossAllCanonicalForms` asserts `ResolutionStrategy.AreaPath` binds from `strategy: area_path` in the live example file.
- [x] Existing tests updated: `TrackerCatalogBuilderTests` (typed enum `Type`), `YamlConfigurationLoaderTests` (lowercase assertion), `valid-config.yml` fixture (snake_case for canonical-form consistency).
- [ ] Operator follow-up: confirm AuthPort / RheTrust / DAP / CICD / k8s configmap deployments load against this codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)