### PR TITLE
fix: combine class-level [Route] with method [Http*] in .NET extractor (Drop 2)

### DIFF
--- a/src/AgentSmith.Infrastructure/Services/Security/Code/DotNetRouteExtractor.cs
+++ b/src/AgentSmith.Infrastructure/Services/Security/Code/DotNetRouteExtractor.cs
@@ -1,0 +1,146 @@
+using System.Text.RegularExpressions;
+
+namespace AgentSmith.Infrastructure.Services.Security.Code;
+
+/// <summary>
+/// Extracts ASP.NET controller routes by combining class-level <c>[Route("api/X")]</c>
+/// with method-level <c>[HttpGet("Y")]</c> or <c>[Route("Y")] [HttpGet]</c> pairings.
+/// Also resolves the <c>[controller]</c> token to the controller name (minus
+/// the "Controller" suffix). The single-regex approach in FrameworkRoutePatterns
+/// only catches inline paths on HTTP attributes, so most real-world controllers
+/// (those with a class-level Route prefix) were unmatched and downstream
+/// findings could not be correlated to source.
+/// </summary>
+internal static partial class DotNetRouteExtractor
+{
+    // Class-level [Route("path")] immediately preceding a controller class declaration.
+    // Intervening attributes ([ApiController], [Authorize], comments) are tolerated by
+    // the lazy [\s\S]*? gap. Anchored against the next `public ... class ...Controller`
+    // to avoid capturing a method-level [Route] as if it were class-level.
+    [GeneratedRegex(
+        """\[Route\(\s*"(?<prefix>[^"]+)"\s*\)\][\s\S]*?\bpublic\s+(?:partial\s+|sealed\s+|abstract\s+|static\s+)*class\s+(?<class>\w+Controller)\b""",
+        RegexOptions.Compiled)]
+    private static partial Regex ClassRouteRegex();
+
+    // Method-level HTTP attribute with optional inline path.
+    // - With path:    [HttpGet("user/{id}")]
+    // - Without path: [HttpGet]
+    // Captures the verb and an optional path; the brace style varies (() vs none).
+    [GeneratedRegex(
+        """\[Http(?<verb>Get|Post|Put|Delete|Patch|Head|Options)(?:\s*\(\s*"(?<path>[^"]*)"\s*(?:,[^)]*)?\))?\s*\]""",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase)]
+    private static partial Regex HttpAttrRegex();
+
+    // Method-level [Route("subpath")] — only relevant when paired with a verb-attribute
+    // that has no inline path. Same shape as the class-level Route but matched per-method.
+    [GeneratedRegex(
+        """\[Route\(\s*"(?<path>[^"]+)"\s*\)\]""",
+        RegexOptions.Compiled)]
+    private static partial Regex AnyRouteRegex();
+
+    public static IEnumerable<ExtractedRoute> Extract(string filePath, string text)
+    {
+        var classes = FindClassRoutes(text).ToList();
+        var classRoutePositions = ClassRouteRegex().Matches(text).Cast<Match>()
+            .Select(m => m.Index).ToHashSet();
+
+        foreach (var verbMatch in HttpAttrRegex().Matches(text).Cast<Match>())
+        {
+            var owner = FindOwningClass(classes, verbMatch.Index);
+            var prefix = owner?.Prefix ?? "";
+
+            var verb = verbMatch.Groups["verb"].Value.ToUpperInvariant();
+            var inlinePath = verbMatch.Groups["path"].Success ? verbMatch.Groups["path"].Value : null;
+            // Verb attribute without an inline path is paired with a nearby [Route("...")] —
+            // these can appear on either side of the HTTP verb (real-world ASP.NET allows both).
+            // The pairing window is bounded so a distant Route on a different method can't
+            // be misattributed.
+            var methodPath = inlinePath ?? FindAdjacentMethodRoute(text, verbMatch.Index, classRoutePositions);
+
+            var combined = Combine(prefix, methodPath);
+            yield return new ExtractedRoute(verb, combined, filePath, LineFromOffset(text, verbMatch.Index));
+        }
+    }
+
+    private static IEnumerable<ClassRoute> FindClassRoutes(string text)
+    {
+        foreach (var m in ClassRouteRegex().Matches(text).Cast<Match>())
+        {
+            var rawPrefix = m.Groups["prefix"].Value;
+            var className = m.Groups["class"].Value;
+            var resolved = ResolveControllerToken(rawPrefix, className);
+            yield return new ClassRoute(resolved, m.Index + m.Length);
+        }
+    }
+
+    private static ClassRoute? FindOwningClass(IReadOnlyList<ClassRoute> classes, int offset)
+    {
+        // Largest declaration offset that's still <= verbMatch position.
+        ClassRoute? owner = null;
+        foreach (var c in classes)
+            if (c.DeclarationOffset <= offset && (owner is null || c.DeclarationOffset > owner.DeclarationOffset))
+                owner = c;
+        return owner;
+    }
+
+    // Bidirectional scan around the verb attribute for a method-level [Route("path")].
+    // Pairings exist on either side in real ASP.NET ([Route] above OR below [HttpGet]).
+    // Window is bounded to a few hundred chars to avoid pairing with unrelated routes
+    // from neighboring methods. Skips Route matches that we already identified as
+    // class-level (their offsets are in classRoutePositions).
+    private static string? FindAdjacentMethodRoute(string text, int verbOffset, ISet<int> classRoutePositions)
+    {
+        const int Window = 200;
+        var start = Math.Max(0, verbOffset - Window);
+        var end = Math.Min(text.Length, verbOffset + Window);
+        var slice = text[start..end];
+
+        Match? closest = null;
+        var closestDistance = int.MaxValue;
+        foreach (var m in AnyRouteRegex().Matches(slice).Cast<Match>())
+        {
+            var absoluteOffset = start + m.Index;
+            if (classRoutePositions.Contains(absoluteOffset)) continue;
+            var distance = Math.Abs(absoluteOffset - verbOffset);
+            if (distance < closestDistance)
+            {
+                closest = m;
+                closestDistance = distance;
+            }
+        }
+        return closest?.Groups["path"].Value;
+    }
+
+    // [Route("api/[controller]")] → "api/auth" (when class is AuthController). Token
+    // replacement is case-insensitive; "Controller" suffix is stripped before
+    // substitution to match ASP.NET's default conventional binding.
+    private static string ResolveControllerToken(string template, string className)
+    {
+        var controllerName = className.EndsWith("Controller", StringComparison.Ordinal)
+            ? className[..^"Controller".Length]
+            : className;
+        return Regex.Replace(template, @"\[controller\]", controllerName, RegexOptions.IgnoreCase);
+    }
+
+    private static string Combine(string prefix, string? subpath)
+    {
+        var head = (prefix ?? "").Trim('/');
+        var tail = (subpath ?? "").Trim('/');
+        if (head.Length == 0 && tail.Length == 0) return "/";
+        if (head.Length == 0) return "/" + tail;
+        if (tail.Length == 0) return "/" + head;
+        return "/" + head + "/" + tail;
+    }
+
+    private static int LineFromOffset(string text, int offset)
+    {
+        var line = 1;
+        for (var i = 0; i < offset && i < text.Length; i++)
+            if (text[i] == '\n') line++;
+        return line;
+    }
+
+    private sealed record ClassRoute(string Prefix, int DeclarationOffset);
+}
+
+internal sealed record ExtractedRoute(string Verb, string Path, string File, int Line);

--- a/src/AgentSmith.Infrastructure/Services/Security/Code/FrameworkRoutePatterns.cs
+++ b/src/AgentSmith.Infrastructure/Services/Security/Code/FrameworkRoutePatterns.cs
@@ -14,13 +14,12 @@ internal static class FrameworkRoutePatterns
     private static readonly string[] PythonExt = [".py"];
     private static readonly string[] JavaKotlinExt = [".java", ".kt"];
 
+    // .NET controller routes (class-level [Route] + method-level [HttpVerb])
+    // are handled by DotNetRouteExtractor, which can combine prefix + path and
+    // resolve the [controller] token. The single-regex form below is kept only
+    // for minimal-API `app.MapGet(...)` declarations.
     public static readonly IReadOnlyList<FrameworkRoutePattern> All =
     [
-        new("dotnet", new Regex(
-            @"\[Http(Get|Post|Put|Delete|Patch)\s*\(\s*""(?<path>[^""]*)""",
-            RegexOptions.IgnoreCase | RegexOptions.Compiled),
-            DotNetExt),
-
         new("dotnet", new Regex(
             @"app\.Map(Get|Post|Put|Delete|Patch)\s*\(\s*""(?<path>[^""]+)""",
             RegexOptions.IgnoreCase | RegexOptions.Compiled),

--- a/src/AgentSmith.Infrastructure/Services/Security/Code/RouteMapper.cs
+++ b/src/AgentSmith.Infrastructure/Services/Security/Code/RouteMapper.cs
@@ -29,6 +29,10 @@ public sealed class RouteMapper(ILogger<RouteMapper> logger) : IRouteMapper
             try { text = File.ReadAllText(file); }
             catch { continue; }
 
+            if (file.EndsWith(".cs", StringComparison.OrdinalIgnoreCase))
+                foreach (var r in DotNetRouteExtractor.Extract(file, text))
+                    results.Add(new RouteDeclaration(r.Verb, r.Path, r.File, r.Line, "dotnet"));
+
             foreach (var pat in FrameworkRoutePatterns.All)
                 if (pat.AppliesTo(file))
                     AccumulateMatches(file, text, pat, results);

--- a/tests/AgentSmith.Tests/Services/RouteMapperTests.cs
+++ b/tests/AgentSmith.Tests/Services/RouteMapperTests.cs
@@ -82,4 +82,75 @@ public sealed class RouteMapperTests : IDisposable
         var routes = _mapper.MapRoutes([Endpoint("GET", "/api/users/{id}")], _temp);
         routes.Should().BeEmpty();
     }
+
+    // ASP.NET style: class-level [Route("api/masterdata")] + method-level [HttpGet("user")].
+    // Pre-DotNetRouteExtractor this was unmatched because the regex saw only "user" while
+    // swagger reported "/api/Masterdata/user" — the gap behind Drop 2 from the AuthPort run.
+    [Fact]
+    public void DotNet_CombinesClassRouteWithMethodRoute()
+    {
+        File.WriteAllText(Path.Combine(_temp, "MasterdataController.cs"), """
+            [Route("api/masterdata")]
+            [ApiController]
+            public class MasterdataController : ControllerBase
+            {
+                [HttpGet("user")]
+                public IActionResult Filter() => Ok();
+            }
+            """);
+        var routes = _mapper.MapRoutes([Endpoint("GET", "/api/masterdata/user")], _temp);
+        routes.Should().HaveCount(1);
+        routes[0].Framework.Should().Be("dotnet");
+        routes[0].Confidence.Should().Be(1.0);
+    }
+
+    // [Route("api/[controller]")] token replacement — the [controller] placeholder
+    // must resolve to the controller name minus the "Controller" suffix to match
+    // ASP.NET's conventional binding behavior.
+    [Fact]
+    public void DotNet_ResolvesControllerToken()
+    {
+        File.WriteAllText(Path.Combine(_temp, "TrafficTypeController.cs"), """
+            [Route("api/[controller]")]
+            public class TrafficTypeController : ControllerBase
+            {
+                [HttpGet("{id}")]
+                public IActionResult Get(int id) => Ok();
+            }
+            """);
+        var routes = _mapper.MapRoutes([Endpoint("GET", "/api/TrafficType/{id}")], _temp);
+        routes.Should().HaveCount(1);
+        routes[0].Framework.Should().Be("dotnet");
+        routes[0].Confidence.Should().Be(1.0);
+    }
+
+    // Method-level [Route("subpath")] paired with a verb-attribute that has no inline
+    // path. Both forms are real ASP.NET — the extractor pairs them by proximity.
+    [Fact]
+    public void DotNet_PairsMethodRouteWithVerbAttribute()
+    {
+        File.WriteAllText(Path.Combine(_temp, "UserAssignmentController.cs"), """
+            [Route("api/userassignment")]
+            public class UserAssignmentController : ControllerBase
+            {
+                [HttpGet]
+                [Route("user/{userId}")]
+                public IActionResult ByUser(string userId) => Ok();
+            }
+            """);
+        var routes = _mapper.MapRoutes([Endpoint("GET", "/api/userassignment/user/{userId}")], _temp);
+        routes.Should().HaveCount(1);
+        routes[0].Confidence.Should().Be(1.0);
+    }
+
+    // Minimal-API style still works alongside the controller-based extractor.
+    [Fact]
+    public void DotNet_MinimalApiMapStillWorks()
+    {
+        File.WriteAllText(Path.Combine(_temp, "Program.cs"),
+            "app.MapGet(\"/api/health\", () => \"ok\");");
+        var routes = _mapper.MapRoutes([Endpoint("GET", "/api/health")], _temp);
+        routes.Should().HaveCount(1);
+        routes[0].Framework.Should().Be("dotnet");
+    }
 }


### PR DESCRIPTION
## Summary

A recent api-security-scan against AuthPort logged `ApiCodeContext: 4 routes mapped (conf 5 %)` followed by `CorrelateFindings: 0/199 findings to handlers`. That means 78 of 82 endpoints had no source-code correlation, so downstream skills produced findings without any file:line evidence.

Root cause: the previous RouteMapper regex `\[Http(Get|Post|...)\("path"\)` only captured method-level inline paths. AuthPort controllers (and any real ASP.NET service) declare the prefix at class level:

```csharp
[Route("api/masterdata")]    // ← regex never saw this
public class MasterdataController : ControllerBase
{
    [HttpGet("user")]        // ← regex captured "user"
    public IActionResult Filter() ...
}
```

Swagger reports `/api/masterdata/user`. Mapper had `user`. No match.

## Changes

- **New `DotNetRouteExtractor`**: two-pass scan that captures every class-level `[Route]` immediately preceding a `public ... class XController`, resolves the `[controller]` token to the controller name (sans "Controller" suffix), and combines class prefix + method path. For `[HttpVerb]` without an inline path it scans a ±200-char window for an adjacent method-level `[Route]` (real ASP.NET allows both orderings).
- **`FrameworkRoutePatterns`**: dropped the standalone `[Http*("path")]` regex (superseded by the extractor). Kept the minimal-API `app.MapGet(...)` regex — that style has no class context to combine.
- **`RouteMapper.ScanDeclarations`**: dispatches `.cs` files through the new extractor in addition to the remaining regex patterns.

## Test plan

- [x] Four new RouteMapperTests fixtures cover (a) class-level Route + method HttpGet combo, (b) `[controller]` token replacement, (c) `[HttpGet]` + adjacent `[Route]` pairing in non-standard order, (d) minimal-API backward compatibility.
- [x] Five pre-existing tests still pass (single-attribute fixtures, Express, FastAPI, Spring).
- [x] Full suite green (1725 pass).
- [ ] **Operator verification**: re-run `api-scan` against AuthPort — should now report something like `~75-82/82 routes mapped (conf 90%+)` instead of `4/82 (5%)`, and `CorrelateFindings` should attach handlers to most findings.

## Out of scope

- `[Route("api/[area]/[controller]")]` with `[area]` token (rare; only matters in ASP.NET Areas).
- `[ApiVersion]` URL versioning prefix.
- AzureFunction `[HttpTrigger]`.
- Spring/FastAPI/Express two-level routing (class/router prefix + method). Same bug class as the .NET case, but separate work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)