### PR TITLE
feat(p0146d): drop ObservationParser regex-fishing, skills emit typed location fields

### DIFF
--- a/.agentsmith/decisions/p0146d-observation-fields.md
+++ b/.agentsmith/decisions/p0146d-observation-fields.md
@@ -1,0 +1,8 @@
+## p0146d: Observation Explicit Location Fields
+
+- [Architecture] Skills emit typed location fields (`file`, `start_line`, `end_line`, `api_path`, `schema_name`) directly as separate JSON properties — the C# parser no longer fishes locations out of `description` prose via regex.
+- [Implementation] Deleted `FileLineRegex`, `HttpEndpointRegex`, `SchemaNameRegex` and `ApplyLocationMigration` from `ObservationParser.cs`. Removed the legacy `Location` property from the private `RawObservation` DTO. JSON parses once; if the LLM omits the typed fields they stay null/0.
+- [Implementation] Set `JsonNamingPolicy.SnakeCaseLower` on the parser's `JsonSerializerOptions` so snake-cased JSON keys (`start_line`, `api_path`, `schema_name`, `evidence_mode`, `review_status`) bind to the PascalCase C# properties. Single-word fields keep working because `PropertyNameCaseInsensitive` was already on.
+- [TradeOff] Dropped backward compatibility with skills that still emit a legacy `"location"` string field. Per spec: skills are framework code, fix at the prompt level. The fallback hid under-specified prompts behind a regex that could mis-extract (paths with colons, multi-line descriptions). New explicit test `Parse_LegacyLocationStringIsIgnored_StructuredFieldsStayNull` documents the change.
+- [Fix] Cross-repo: updated `agent-smith-skills/skills/observation-schema.md` and ~11 SKILL.md prompts that instructed skills to embed `file:line` in `description` or use a `"location"` JSON field. They now instruct skills to populate the typed fields directly. Paired PR in `agent-smith-skills` repo.
+- [Implementation] Output strategies already read from the structured fields (`SkillObservation.DisplayLocation` + SARIF's `artifactLocation` from `obs.File`). No changes needed there.

--- a/.agentsmith/phases/done/p0146d-observation-explicit-location-fields.yaml
+++ b/.agentsmith/phases/done/p0146d-observation-explicit-location-fields.yaml
@@ -1,0 +1,73 @@
+# yaml-language-server: $schema=../../phase-spec.schema.json
+phase: p0146d
+goal: "ObservationParser regex-fishes `file:line` substrings and HttpEndpoint
+  patterns out of the LLM-emitted `description` text. Skills already have
+  structured `file` / `start_line` / `api_path` fields on the SkillObservation
+  record (audit) — the regex post-pass is patching for skills that didn't
+  populate them. Lift the contract: skills must emit those fields directly,
+  drop the regex post-extraction."
+
+requires: ["p0146"]
+
+scope:
+  in: |
+    (1) Audit SkillObservation record fields and the structured-output JSON
+        schema. Confirm `file`, `start_line`, `end_line`, `api_path`,
+        `schema_name` are all on the record (they are, per the SkillObservation
+        definition in Contracts).
+
+    (2) ObservationParser.cs: drop FileLineRegex + HttpEndpointRegex + their
+        post-parse usage. JSON is parsed once; if the LLM didn't populate
+        file/line/api_path the values stay null. No regex-fishing on description.
+
+    (3) Cross-repo (agent-smith-skills): SKILL.md prompts that currently embed
+        `file:line` in description text (audit by grep) get instructions to
+        populate the structured fields directly. Schema doc already names the
+        fields; just enforce the contract.
+
+    (4) Output strategies (Markdown / SARIF / Summary): confirm they read from
+        the structured fields, not from description. Update any that fall back
+        to description-parsing.
+
+  out: |
+    Adding new fields to SkillObservation. Existing fields suffice.
+
+    Other regex-extraction sites (Convergence / Comment / Intent — p0146c,
+    p0146e, p0146b).
+
+decisions:
+  - key: |
+      Drop the regex fallback even if some skills currently don't populate the
+      structured fields. Reason: skills are framework code, easy to fix at the
+      prompt level. The C# fallback hides under-specified prompts behind a
+      best-effort regex that may extract wrong tuples (file path with a colon
+      in it, multi-line descriptions, etc.). -- alternatives: keep fallback
+      (rejected: same bug class).
+
+steps:
+  - id: audit-skill-prompts
+    action: "Grep agent-smith-skills SKILL.md files for description templates that embed `file:line` or URLs. List skills that need their prompts updated to emit structured fields."
+    modify:
+      - "(populate after audit) — likely candidates: api-vuln-analyst-investigator, dast-analyst, response-analyst, false-positive-filter, anonymous-attacker, low-privilege-attacker."
+
+  - id: lift-contract-in-skills
+    action: "Update each identified SKILL.md output section: 'set file / start_line / api_path / schema_name as separate JSON fields; description is the human-readable headline only, no embedded location.'"
+
+  - id: drop-regex-in-parser
+    action: "ObservationParser.cs: delete FileLineRegex + HttpEndpointRegex + their post-parse usage."
+    modify:
+      - "src/AgentSmith.Application/Services/Handlers/ObservationParser.cs: lines ~24-26 + their callers — delete."
+
+  - id: verify-output-strategies
+    action: "Confirm Console / Markdown / SARIF / Summary output strategies read from structured fields. Update any reads of description that should use file / api_path."
+
+tests:
+  - "ObservationParser test pack: skill emits JSON with structured file/line/api_path → record has them. JSON with empty structured fields → record has nulls (no regex fallback)."
+  - "SARIF output strategy renders artifactLocation from observation.File, not from a description regex."
+  - "Skill prompt smoke (agent-smith-skills): per-skill round emits JSON with structured fields populated where applicable."
+
+done:
+  - "ObservationParser has zero Regex usage."
+  - "All skills audited; prompts populate structured fields directly."
+  - "Output strategies confirmed reading structured fields."
+  - "Full test suite green."

--- a/src/AgentSmith.Application/Prompts/Resources/observation-schema.md
+++ b/src/AgentSmith.Application/Prompts/Resources/observation-schema.md
@@ -48,7 +48,7 @@ Over-cap fields are truncated, not rejected — the observation always survives,
 
 When you have multi-paragraph context, put the headline in `description` and the body in `details`. Skipping `details` is fine — Markdown then just renders `description`.
 
-**Location fields:** prefer the typed fields (`file` + `start_line` for source code, `api_path` for HTTP endpoints, `schema_name` for OpenAPI schemas). Legacy `location` string is still accepted and parsed into the typed fields when the typed fields are absent.
+**Location fields:** use the typed fields directly — `file` + `start_line` (+ `end_line`) for source code, `api_path` for HTTP endpoints, `schema_name` for OpenAPI schemas. Do NOT embed `file:line` or method+path inside `description` — the framework no longer extracts it from prose (p0146d). If a finding has no clean location, leave the typed fields null.
 
 **`category` vs `concern`:** `concern` is a coarse structural axis (security/correctness/etc.) that drives skill orchestration. `category` is a fine-grained domain tag for SARIF rule grouping. Don't duplicate (`concern: security` + `category: "security"` is redundant — pick a finer category like `"secrets"` or `"injection"`).
 
@@ -118,7 +118,7 @@ A routine HIGH-severity finding — NOT blocking, just report it:
     "severity": "high",
     "confidence": 95,
     "rationale": "OWASP A2:2021 — passwords in URLs are a well-documented vulnerability.",
-    "location": "POST /api/auth/login",
+    "api_path": "POST /api/auth/login",
     "effort": "small"
   }
 ]
@@ -134,8 +134,7 @@ A genuinely blocking case — analysis cannot proceed without peer input:
     "suggestion": "Load baselines/api-headers.yaml from the skill catalog or supply a project override.",
     "blocking": true,
     "severity": "info",
-    "confidence": 100,
-    "location": "baseline:api-headers"
+    "confidence": 100
   }
 ]
 ```

--- a/src/AgentSmith.Application/Services/Handlers/ObservationParser.cs
+++ b/src/AgentSmith.Application/Services/Handlers/ObservationParser.cs
@@ -1,6 +1,5 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using System.Text.RegularExpressions;
 using AgentSmith.Contracts.Models;
 using Microsoft.Extensions.Logging;
 
@@ -9,24 +8,25 @@ namespace AgentSmith.Application.Services.Handlers;
 /// <summary>
 /// Parses LLM JSON responses into SkillObservation lists.
 /// Element-wise: bad observations are skipped with a warning, valid ones survive.
-/// Migration helpers: legacy Location string is split into structured fields;
-/// 1-10 confidence values are auto-upgraded to 0-100; Category that duplicates
-/// Concern is dropped with a warning.
+/// Skills are contracted to populate `file` / `start_line` / `api_path` /
+/// `schema_name` directly as structured JSON fields (p0146d): no regex-fishing
+/// over the description text. 1-10 confidence values are auto-upgraded to 0-100;
+/// Category that duplicates Concern is dropped with a warning.
 /// </summary>
 internal static class ObservationParser
 {
+    // Snake-case naming so JSON `start_line` / `api_path` / `schema_name` /
+    // `evidence_mode` / `review_status` bind directly to RawObservation properties
+    // — single-word fields (description, concern, …) still match because case is
+    // insensitive. p0146d: skills are contracted to emit the typed location
+    // fields directly, so there is no fallback path that fishes them out of
+    // `description` prose.
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
         PropertyNameCaseInsensitive = true,
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
         Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) }
     };
-
-    private static readonly Regex FileLineRegex =
-        new(@"^(?<file>[^\s].*?):(?<line>\d+)$", RegexOptions.Compiled);
-    private static readonly Regex HttpEndpointRegex =
-        new(@"^(GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS)\s+/.+", RegexOptions.Compiled);
-    private static readonly Regex SchemaNameRegex =
-        new(@"^[A-Z][A-Za-z0-9_]*$", RegexOptions.Compiled);
 
     private static readonly HashSet<string> WarnedSeverityValues = new(StringComparer.OrdinalIgnoreCase);
 
@@ -162,7 +162,6 @@ internal static class ObservationParser
             if (entry is null || string.IsNullOrWhiteSpace(entry.Description))
                 return null;
 
-            ApplyLocationMigration(entry);
             var confidence = ApplyConfidenceMigration(entry, role, perRunWarn, logger);
             var category = ApplyCategoryDriftCheck(entry, role, perRunWarn, logger);
 
@@ -190,26 +189,6 @@ internal static class ObservationParser
                 index, role, ex.Message, preview);
             return null;
         }
-    }
-
-    private static void ApplyLocationMigration(RawObservation entry)
-    {
-        if (string.IsNullOrWhiteSpace(entry.Location)) return;
-        if (!string.IsNullOrEmpty(entry.File)
-            || !string.IsNullOrEmpty(entry.ApiPath)
-            || !string.IsNullOrEmpty(entry.SchemaName)) return;
-
-        var loc = entry.Location.Trim();
-        var fileLineMatch = FileLineRegex.Match(loc);
-        if (fileLineMatch.Success && int.TryParse(fileLineMatch.Groups["line"].Value, out var line))
-        {
-            entry.File = fileLineMatch.Groups["file"].Value;
-            entry.StartLine = line;
-            return;
-        }
-        if (HttpEndpointRegex.IsMatch(loc)) { entry.ApiPath = loc; return; }
-        if (SchemaNameRegex.IsMatch(loc)) { entry.SchemaName = loc; return; }
-        entry.File = loc;
     }
 
     private static int ApplyConfidenceMigration(
@@ -302,9 +281,10 @@ internal static class ObservationParser
     }
 
     /// <summary>
-    /// DTO matching the LLM's JSON output. Includes legacy Location for backward
-    /// compatibility and all new typed fields. Mutable so the migration helpers
-    /// can fill File/StartLine/etc. from the legacy Location before construction.
+    /// DTO matching the LLM's JSON output. Skills emit typed location fields
+    /// (`file`, `start_line`, `end_line`, `api_path`, `schema_name`) directly
+    /// per the observation schema contract; no legacy `location` string is
+    /// parsed (p0146d).
     /// </summary>
     private sealed class RawObservation
     {
@@ -315,7 +295,6 @@ internal static class ObservationParser
         public ObservationSeverity Severity { get; set; }
         public int Confidence { get; set; }
         public string? Rationale { get; set; }
-        public string? Location { get; set; }
         public ObservationEffort? Effort { get; set; }
         public string? File { get; set; }
         public int StartLine { get; set; }

--- a/tests/AgentSmith.Tests/Commands/ObservationParserTests.cs
+++ b/tests/AgentSmith.Tests/Commands/ObservationParserTests.cs
@@ -31,6 +31,7 @@ public sealed class ObservationParserTests
     [Fact]
     public void Parse_ValidJsonObservations_StoresAllFields()
     {
+        // Skills emit typed location fields directly (p0146d) — no regex post-pass.
         var json = """
             [
               {
@@ -41,7 +42,7 @@ public sealed class ObservationParserTests
                 "severity": "high",
                 "confidence": 95,
                 "rationale": "OWASP A2:2021",
-                "location": "POST /api/auth/login",
+                "api_path": "POST /api/auth/login",
                 "effort": "small"
               }
             ]
@@ -62,6 +63,50 @@ public sealed class ObservationParserTests
         obs.Rationale.Should().Be("OWASP A2:2021");
         obs.ApiPath.Should().Be("POST /api/auth/login");
         obs.Effort.Should().Be(ObservationEffort.Small);
+    }
+
+    [Fact]
+    public void Parse_LegacyLocationStringIsIgnored_StructuredFieldsStayNull()
+    {
+        // p0146d: regex post-pass is gone. A legacy "location" field is ignored —
+        // skills must populate the typed fields (file/start_line/api_path/schema_name)
+        // directly. If they don't, the structured fields stay null instead of being
+        // best-effort-guessed from prose.
+        var json = """
+            [
+              { "concern": "security", "description": "Issue", "suggestion": "Fix",
+                "blocking": false, "severity": "low", "confidence": 60,
+                "location": "src/Foo.cs:42" }
+            ]
+            """;
+
+        var result = ObservationParser.Parse(json, "reviewer", 1, Logger);
+
+        result.Should().HaveCount(1);
+        result[0].File.Should().BeNull();
+        result[0].StartLine.Should().Be(0);
+        result[0].ApiPath.Should().BeNull();
+        result[0].SchemaName.Should().BeNull();
+    }
+
+    [Fact]
+    public void Parse_StructuredFileAndStartLine_StoredDirectly()
+    {
+        var json = """
+            [
+              { "concern": "correctness", "description": "Off-by-one",
+                "suggestion": "Use Length-1", "blocking": false,
+                "severity": "medium", "confidence": 80,
+                "file": "src/Foo.cs", "start_line": 42, "end_line": 48 }
+            ]
+            """;
+
+        var result = ObservationParser.Parse(json, "reviewer", 1, Logger);
+
+        result.Should().HaveCount(1);
+        result[0].File.Should().Be("src/Foo.cs");
+        result[0].StartLine.Should().Be(42);
+        result[0].EndLine.Should().Be(48);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- `ObservationParser` previously regex-fished `file:line` and HTTP endpoint substrings out of the LLM-emitted `description` text as a fallback for skills that didn't populate the structured fields. Skills are framework code — fix the contract at the prompt level instead.
- Deleted `FileLineRegex`, `HttpEndpointRegex`, `SchemaNameRegex` and `ApplyLocationMigration` from `ObservationParser.cs`. Removed the legacy `Location` property from the private `RawObservation` DTO. JSON parses once; if the LLM omits the typed fields they stay null/0.
- Added `PropertyNamingPolicy = SnakeCaseLower` on the parser's `JsonSerializerOptions` so snake-cased keys (`start_line`, `api_path`, `schema_name`, `evidence_mode`, `review_status`) bind to the PascalCase C# properties.
- Updated `observation-schema.md` prompt resource: dropped the legacy `location` JSON field from the shape + examples; explicit "no regex-fishing on description" note.
- Tests: replaced the one test that exercised the legacy `location` regex; added explicit tests covering the new contract (typed fields stored directly; legacy `"location"` is ignored).

Output strategies (Console / Markdown / SARIF / Summary) already read from the typed fields (`SkillObservation.DisplayLocation`; SARIF `artifactLocation` from `obs.File`) — no changes needed there.

Paired PR in `agent-smith-skills` updates the SKILL.md prompts to instruct skills to populate the typed fields directly instead of embedding `file:line` or method+path in `description`.

## Test plan

- [x] `dotnet build` green
- [x] `dotnet test` green: 1691 + 66 passing
- [x] `ObservationParser.Parse` with `file` / `start_line` / `api_path` / `schema_name` populates the corresponding record fields
- [x] `ObservationParser.Parse` with legacy `"location"` JSON field leaves all typed fields null (no regex fallback)
- [x] No `Regex` usage remains in `ObservationParser.cs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)