### PR TITLE
feat(tools): bash + edit + glob + http_request + fix ReadSet capture

### DIFF
--- a/src/AgentSmith.Application/Services/Loop/TracingAIFunction.cs
+++ b/src/AgentSmith.Application/Services/Loop/TracingAIFunction.cs
@@ -7,9 +7,9 @@ namespace AgentSmith.Application.Services.Loop;
 /// <summary>
 /// Decorator around an <see cref="AIFunction"/> that records each tool invocation
 /// on the active <see cref="LoopTraceCollector"/>. When the wrapped function is
-/// a filesystem read (name == "read_file"), the cited path is added to the
-/// collector's ReadSet — the foundation for p0151b's source-anchored
-/// observation validator.
+/// a filesystem read (name matches "read_file" / "ReadFile" / "readFile" — see
+/// <see cref="IsReadFileTool"/>), the cited path is added to the collector's
+/// ReadSet — the foundation for p0151b's source-anchored observation validator.
 /// </summary>
 public sealed class TracingAIFunction(AIFunction inner, LoopTraceCollector trace) : AIFunction
 {
@@ -46,11 +46,20 @@ public sealed class TracingAIFunction(AIFunction inner, LoopTraceCollector trace
 
     private void CapturePathIfRead(AIFunctionArguments arguments)
     {
-        if (!inner.Name.Equals("read_file", StringComparison.OrdinalIgnoreCase)) return;
+        if (!IsReadFileTool(inner.Name)) return;
         if (!arguments.TryGetValue("path", out var raw) || raw is null) return;
         var path = raw.ToString();
         if (!string.IsNullOrWhiteSpace(path)) trace.AppendReadPath(path);
     }
+
+    // AIFunctionFactory.Create(method) defaults the tool name to the C# method name
+    // (PascalCase "ReadFile"), while many LLM-side conventions use snake_case
+    // ("read_file"). Normalise both to a punctuation-free, lowercase token.
+    private static bool IsReadFileTool(string name) =>
+        Normalize(name) == "readfile";
+
+    private static string Normalize(string name) =>
+        new string(name.Where(char.IsLetterOrDigit).ToArray()).ToLowerInvariant();
 
     private string SerializeArgs(AIFunctionArguments arguments)
     {

--- a/src/AgentSmith.Application/Services/Tools/CommandGuard.cs
+++ b/src/AgentSmith.Application/Services/Tools/CommandGuard.cs
@@ -1,0 +1,40 @@
+using System.Text.RegularExpressions;
+
+namespace AgentSmith.Application.Services.Tools;
+
+/// <summary>
+/// Defensive blocklist for shell commands routed through <c>run_command</c>.
+/// The sandbox container is the primary isolation boundary; this guard is
+/// defense-in-depth so accidental LLM-emitted destructive commands fail fast
+/// at the host before reaching the sandbox.
+/// </summary>
+public static class CommandGuard
+{
+    private static readonly string[] DestructiveTokens =
+    [
+        "rm", "rmdir", "unlink", "shred", "truncate", "dd"
+    ];
+
+    private static readonly Regex DestructiveTokenRegex = new(
+        @"(?:^|[;&|`$(]|\s)\s*(" + string.Join("|", DestructiveTokens) + @")\b",
+        RegexOptions.Compiled);
+
+    /// <summary>Returns an error message if <paramref name="command"/> matches a
+    /// destructive pattern, otherwise <c>null</c>.</summary>
+    public static string? Check(string command)
+    {
+        if (string.IsNullOrWhiteSpace(command)) return null;
+
+        var match = DestructiveTokenRegex.Match(command);
+        if (match.Success)
+            return $"Error: command contains blocked destructive token '{match.Groups[1].Value}' — agent-smith run_command blocklist (rm/rmdir/unlink/shred/truncate/dd). Use a non-destructive alternative or read-only inspection.";
+
+        if (command.Contains(":(){"))
+            return "Error: fork-bomb pattern blocked.";
+
+        if (Regex.IsMatch(command, @">\s*/dev/(?!null\b|stdout\b|stderr\b|tty\b)"))
+            return "Error: raw device-write redirect blocked.";
+
+        return null;
+    }
+}

--- a/src/AgentSmith.Application/Services/Tools/FilesystemToolHost.cs
+++ b/src/AgentSmith.Application/Services/Tools/FilesystemToolHost.cs
@@ -10,11 +10,12 @@ namespace AgentSmith.Application.Services.Tools;
 
 /// <summary>
 /// Sandbox filesystem tools (ReadFile/WriteFile/ListFiles/Grep/RunCommand).
-/// Per-phase filter: read-only set in Review/Discuss/Filter/Synthesize;
-/// +RunCommand in Plan/Investigate/Verify (per p0151a — Plan-phase recon
-/// skills need run_command for directory inventory); all five in
-/// Implementation; ReadFile+Grep+ListFiles+WriteFile (no RunCommand) in
-/// Bootstrap; null phase → all five (legacy fallback).
+/// Per-phase filter: every phase set includes RunCommand — the LLM benefits
+/// from raw shell access (find/grep/head/wc/curl) at every stage. A
+/// destructive-command blocklist (<see cref="CommandGuard"/>) is applied
+/// inside RunCommand as defense-in-depth on top of the sandbox boundary.
+/// Write-capable sets (Bootstrap/Implementation) additionally include
+/// WriteFile.
 /// </summary>
 public sealed class FilesystemToolHost : IToolHost
 {
@@ -87,6 +88,88 @@ public sealed class FilesystemToolHost : IToolHost
             : _runner.ListAsync(path, maxDepth, ct);
     }
 
+    [Description("Lists files matching a glob pattern. Pattern is matched against file names with -name semantics; pass '**/' prefix to indicate recursion (default is already recursive). Examples: '*.cs', '**/*.json', 'Program.cs'. Returns up to 200 matches.")]
+    public Task<string> Glob(
+        [Description("Glob pattern, e.g. '*.cs' or 'Program.cs'.")] string pattern,
+        [Description("Repository-relative base path to search from (default '.').")] string path = ".",
+        CancellationToken ct = default)
+    {
+        _logger?.LogInformation("tool_call: Glob pattern={Pattern} path={Path}", pattern, path);
+        if (_guards.CheckRead(path) is { } error) return Task.FromResult(error);
+        var namePattern = pattern.StartsWith("**/", StringComparison.Ordinal) ? pattern[3..] : pattern;
+        var cmd = $"find {ShellQuote(path)} -type f -name {ShellQuote(namePattern)} 2>/dev/null | head -200";
+        return _runner.RunAsync(cmd, ct);
+    }
+
+    [Description("Replaces an EXACT string occurrence in a file. old_string must appear EXACTLY ONCE in the file or the call fails — provide enough surrounding context to make it unique. Use this for targeted edits instead of WriteFile (which overwrites the whole file).")]
+    public async Task<string> Edit(
+        [Description("Repository-relative path to edit.")] string path,
+        [Description("Exact string to find. Must appear exactly once in the file. Include enough surrounding context for uniqueness.")] string old_string,
+        [Description("Replacement string.")] string new_string,
+        CancellationToken ct = default)
+    {
+        _logger?.LogInformation("tool_call: Edit path={Path} old_len={Old} new_len={New}", path, old_string?.Length ?? 0, new_string?.Length ?? 0);
+        if (_guards.CheckRead(path) is { } readErr) return readErr;
+        if (_guards.CheckWrite(path) is { } writeErr) return writeErr;
+        if (string.IsNullOrEmpty(old_string)) return "Error: old_string must not be empty.";
+
+        var content = await _runner.ReadAsync(path, ct);
+        if (content.StartsWith("Error", StringComparison.Ordinal)) return content;
+
+        var idx = content.IndexOf(old_string, StringComparison.Ordinal);
+        if (idx < 0) return $"Error: old_string not found in {path}.";
+        if (content.IndexOf(old_string, idx + 1, StringComparison.Ordinal) >= 0)
+            return $"Error: old_string appears multiple times in {path} — extend the snippet with surrounding context to make it unique.";
+
+        var newContent = string.Concat(content.AsSpan(0, idx), new_string, content.AsSpan(idx + old_string.Length));
+        var result = await _runner.WriteAsync(path, newContent, ct);
+        if (!result.StartsWith("Error", StringComparison.Ordinal))
+            _changes.Add(new CodeChange(new FilePath(path), newContent, "Modify"));
+        return result;
+    }
+
+    [Description("Sends an HTTP request from inside the sandbox and returns response status, headers, and body. Use for live API probing (e.g. anonymous endpoint behavior, malformed payload response codes, header inspection) when a target URL is reachable. Built on `curl -sS -i` under the hood.")]
+    public Task<string> HttpRequest(
+        [Description("HTTP method: GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS.")] string method,
+        [Description("Full URL including scheme.")] string url,
+        [Description("Optional request body for POST/PUT/PATCH. Empty for GET/HEAD/DELETE/OPTIONS.")] string? body = null,
+        [Description("Optional request headers, one per line: 'Authorization: Bearer xyz\\nContent-Type: application/json'.")] string? headers = null,
+        [Description("Optional connection timeout in seconds (default 15, max 60).")] int? timeoutSeconds = null,
+        CancellationToken ct = default)
+    {
+        _logger?.LogInformation("tool_call: HttpRequest {Method} {Url} body_len={BodyLen}", method, url, body?.Length ?? 0);
+
+        var allowedMethods = new[] { "GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS" };
+        var upperMethod = method?.ToUpperInvariant() ?? "GET";
+        if (!allowedMethods.Contains(upperMethod))
+            return Task.FromResult($"Error: unsupported HTTP method '{method}'. Allowed: {string.Join(", ", allowedMethods)}.");
+
+        if (string.IsNullOrWhiteSpace(url))
+            return Task.FromResult("Error: url is required.");
+
+        var clampedTimeout = Math.Clamp(timeoutSeconds ?? 15, 1, 60);
+        var parts = new List<string> { "curl", "-sS", "-i", "--max-time", clampedTimeout.ToString(), "-X", upperMethod };
+        if (!string.IsNullOrEmpty(headers))
+        {
+            foreach (var line in headers.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            {
+                parts.Add("-H");
+                parts.Add(line);
+            }
+        }
+        if (!string.IsNullOrEmpty(body))
+        {
+            parts.Add("--data-raw");
+            parts.Add(body);
+        }
+        parts.Add(url);
+
+        var cmd = string.Join(" ", parts.Select(ShellQuote));
+        return _runner.RunAsync(cmd, ct);
+    }
+
+    private static string ShellQuote(string s) => "'" + s.Replace("'", "'\\''") + "'";
+
     [Description("Searches files for a regular expression pattern under the given path.")]
     public Task<string> Grep(
         [Description("Regular expression pattern to search for.")] string pattern,
@@ -101,44 +184,56 @@ public sealed class FilesystemToolHost : IToolHost
             : _runner.GrepAsync(pattern, path, glob, maxMatches, ct);
     }
 
-    [Description("Runs a shell command. Long-running server processes are blocked.")]
+    [Description("Runs a shell command (passed to /bin/sh -c). Destructive commands (rm/rmdir/unlink/shred/truncate/dd, raw device writes, fork bombs) are blocked by a defense-in-depth guard on top of the sandbox boundary; use find/grep/head/wc/curl/ls/cat freely.")]
     public Task<string> RunCommand(
         [Description("Shell command to execute (passed to /bin/sh -c).")] string command,
         CancellationToken ct = default)
     {
         _logger?.LogInformation("tool_call: RunCommand cmd={Command}", command);
+        if (CommandGuard.Check(command) is { } error)
+        {
+            _logger?.LogWarning("RunCommand blocked by destructive-command guard: {Command}", command);
+            return Task.FromResult(error);
+        }
         return _runner.RunAsync(command, ct);
     }
 
+    private static AIFunction Tool(Delegate impl, string name) =>
+        AIFunctionFactory.Create(impl, name: name);
+
     private IEnumerable<AIFunction> ReadOnlySet() =>
     [
-        AIFunctionFactory.Create(ReadFile),
-        AIFunctionFactory.Create(Grep),
-        AIFunctionFactory.Create(ListFiles)
+        Tool(ReadFile, "read_file"),
+        Tool(Grep, "grep"),
+        Tool(Glob, "glob"),
+        Tool(ListFiles, "list_files"),
+        Tool(RunCommand, "run_command"),
+        Tool(HttpRequest, "http_request")
     ];
 
-    private IEnumerable<AIFunction> InvestigatorSet() =>
-    [
-        AIFunctionFactory.Create(ReadFile),
-        AIFunctionFactory.Create(Grep),
-        AIFunctionFactory.Create(ListFiles),
-        AIFunctionFactory.Create(RunCommand)
-    ];
+    private IEnumerable<AIFunction> InvestigatorSet() => ReadOnlySet();
 
     private IEnumerable<AIFunction> BootstrapSet() =>
     [
-        AIFunctionFactory.Create(ReadFile),
-        AIFunctionFactory.Create(Grep),
-        AIFunctionFactory.Create(ListFiles),
-        AIFunctionFactory.Create(WriteFile)
+        Tool(ReadFile, "read_file"),
+        Tool(Grep, "grep"),
+        Tool(Glob, "glob"),
+        Tool(ListFiles, "list_files"),
+        Tool(WriteFile, "write_file"),
+        Tool(Edit, "edit"),
+        Tool(RunCommand, "run_command"),
+        Tool(HttpRequest, "http_request")
     ];
 
     private IEnumerable<AIFunction> All() =>
     [
-        AIFunctionFactory.Create(ReadFile),
-        AIFunctionFactory.Create(WriteFile),
-        AIFunctionFactory.Create(ListFiles),
-        AIFunctionFactory.Create(Grep),
-        AIFunctionFactory.Create(RunCommand)
+        Tool(ReadFile, "read_file"),
+        Tool(WriteFile, "write_file"),
+        Tool(Edit, "edit"),
+        Tool(ListFiles, "list_files"),
+        Tool(Grep, "grep"),
+        Tool(Glob, "glob"),
+        Tool(RunCommand, "run_command"),
+        Tool(HttpRequest, "http_request")
     ];
 }

--- a/src/AgentSmith.Application/Services/Tools/HumanToolHost.cs
+++ b/src/AgentSmith.Application/Services/Tools/HumanToolHost.cs
@@ -26,7 +26,7 @@ public sealed class HumanToolHost : IToolHost
     {
         _ = phase;
         _ = investigatorMode;
-        return [AIFunctionFactory.Create(AskHuman)];
+        return [AIFunctionFactory.Create(AskHuman, name: "ask_human")];
     }
 
     [Description("Asks the human operator for guidance via the dialogue transport.")]

--- a/src/AgentSmith.Application/Services/Tools/LogDecisionToolHost.cs
+++ b/src/AgentSmith.Application/Services/Tools/LogDecisionToolHost.cs
@@ -28,7 +28,7 @@ public sealed class LogDecisionToolHost : IToolHost
     {
         _ = phase;
         _ = investigatorMode;
-        return [AIFunctionFactory.Create(LogDecision)];
+        return [AIFunctionFactory.Create(LogDecision, name: "log_decision")];
     }
 
     [Description("Logs a key architectural, tooling, implementation, or trade-off decision.")]

--- a/tests/AgentSmith.Tests/Loop/ToolKitTests.cs
+++ b/tests/AgentSmith.Tests/Loop/ToolKitTests.cs
@@ -41,9 +41,9 @@ public sealed class ToolKitTests
 
         // p0151a: Plan-phase recon skills need ls/find via run_command for
         // directory inventory. WriteFile still excluded — Plan is read-side only.
-        tools.Should().Contain("ReadFile").And.Contain("Grep").And.Contain("ListFiles")
-             .And.Contain("RunCommand").And.Contain("LogDecision").And.Contain("AskHuman");
-        tools.Should().NotContain("WriteFile");
+        tools.Should().Contain("read_file").And.Contain("grep").And.Contain("list_files")
+             .And.Contain("run_command").And.Contain("log_decision").And.Contain("ask_human");
+        tools.Should().NotContain("write_file");
     }
 
     [Fact]
@@ -53,9 +53,10 @@ public sealed class ToolKitTests
 
         var tools = NamesOf(kit.GetToolsFor("fix-bug", SkillExecutionPhase.Implementation, null, hosts));
 
-        tools.Should().HaveCount(7);
+        // 8 filesystem-host tools (read, write, edit, list, grep, glob, run, http) + log_decision + ask_human
+        tools.Should().HaveCount(10);
         tools.Should().Contain(new[]
-            { "ReadFile", "WriteFile", "ListFiles", "Grep", "RunCommand", "LogDecision", "AskHuman" });
+            { "read_file", "write_file", "edit", "list_files", "grep", "glob", "run_command", "http_request", "log_decision", "ask_human" });
     }
 
     [Fact]
@@ -65,19 +66,20 @@ public sealed class ToolKitTests
 
         var tools = NamesOf(kit.GetToolsFor("fix-bug", SkillExecutionPhase.Verify, null, hosts));
 
-        tools.Should().Contain("RunCommand");
-        tools.Should().NotContain("WriteFile");
+        tools.Should().Contain("run_command");
+        tools.Should().NotContain("write_file");
     }
 
     [Fact]
-    public void GetToolsFor_BootstrapPhase_IncludesWriteFileExcludesRunCommand()
+    public void GetToolsFor_BootstrapPhase_IncludesWriteFileAndRunCommand()
     {
         var (kit, hosts) = Build();
 
         var tools = NamesOf(kit.GetToolsFor("fix-bug", SkillExecutionPhase.Bootstrap, null, hosts));
 
-        tools.Should().Contain("WriteFile");
-        tools.Should().NotContain("RunCommand");
+        // Bootstrap is write-capable; raw shell access (run_command) is universally available.
+        tools.Should().Contain("write_file");
+        tools.Should().Contain("run_command");
     }
 
     [Fact]
@@ -87,7 +89,8 @@ public sealed class ToolKitTests
 
         var tools = NamesOf(kit.GetToolsFor("fix-bug", null, null, hosts));
 
-        tools.Should().HaveCount(7);
+        // Same count as Implementation: full filesystem-host surface + log_decision + ask_human.
+        tools.Should().HaveCount(10);
     }
 
     [Fact]
@@ -97,6 +100,6 @@ public sealed class ToolKitTests
 
         var tools = NamesOf(kit.GetToolsFor("fix-bug", SkillExecutionPhase.Investigate, null, hosts));
 
-        tools.Should().Contain("RunCommand");
+        tools.Should().Contain("run_command");
     }
 }

--- a/tests/AgentSmith.Tests/Loop/TracingAIFunctionTests.cs
+++ b/tests/AgentSmith.Tests/Loop/TracingAIFunctionTests.cs
@@ -51,6 +51,22 @@ public sealed class TracingAIFunctionTests
         trace.ReadSet.Should().Contain("src/Program.cs");
     }
 
+    [Theory]
+    [InlineData("ReadFile")]          // C# method-name default (production via AIFunctionFactory.Create(ReadFile))
+    [InlineData("read_file")]         // explicit snake_case
+    [InlineData("readFile")]          // camelCase
+    [InlineData("read-file")]         // kebab-case
+    public async Task InvokeAsync_ReadFile_PopulatesReadSet_RegardlessOfNamingConvention(string toolName)
+    {
+        var trace = new LoopTraceCollector();
+        var inner = AIFunctionFactory.Create((string path) => "ok", name: toolName);
+        var wrapped = new TracingAIFunction(inner, trace);
+
+        await wrapped.InvokeAsync(new AIFunctionArguments { ["path"] = "src/Program.cs" });
+
+        trace.ReadSet.Should().Contain("src/Program.cs");
+    }
+
     [Fact]
     public async Task InvokeAsync_NonReadTool_DoesNotPopulateReadSet()
     {

--- a/tests/AgentSmith.Tests/Services/Tools/CommandGuardTests.cs
+++ b/tests/AgentSmith.Tests/Services/Tools/CommandGuardTests.cs
@@ -1,0 +1,63 @@
+using AgentSmith.Application.Services.Tools;
+using FluentAssertions;
+
+namespace AgentSmith.Tests.Services.Tools;
+
+public sealed class CommandGuardTests
+{
+    [Theory]
+    [InlineData("rm -rf /")]
+    [InlineData("rm foo")]
+    [InlineData("ls && rm bar")]
+    [InlineData("ls; rm bar")]
+    [InlineData("ls | rm")]
+    [InlineData("rmdir mydir")]
+    [InlineData("unlink foo")]
+    [InlineData("shred secret.txt")]
+    [InlineData("truncate -s 0 log.txt")]
+    [InlineData("dd if=/dev/zero of=/dev/sda")]
+    [InlineData("$(rm bar)")]
+    [InlineData("`rm bar`")]
+    public void Check_BlocksDestructiveCommands(string command)
+    {
+        CommandGuard.Check(command).Should().NotBeNull()
+            .And.Contain("blocked");
+    }
+
+    [Theory]
+    [InlineData(":(){ :|:& };:")]
+    public void Check_BlocksForkBomb(string command)
+    {
+        CommandGuard.Check(command).Should().NotBeNull()
+            .And.Contain("fork-bomb");
+    }
+
+    [Theory]
+    [InlineData("cat foo > /dev/sda")]
+    [InlineData("echo x > /dev/tty1")]
+    public void Check_BlocksRawDeviceWrites(string command)
+    {
+        CommandGuard.Check(command).Should().NotBeNull()
+            .And.Contain("device-write");
+    }
+
+    [Theory]
+    [InlineData("ls -la")]
+    [InlineData("find . -name '*.cs' | head -20")]
+    [InlineData("grep -r 'TODO' src/")]
+    [InlineData("wc -l Program.cs")]
+    [InlineData("curl -s https://example.com/api")]
+    [InlineData("cat Program.cs")]
+    [InlineData("cat log > /dev/null")]            // /dev/null is allowed
+    [InlineData("echo done > /dev/stdout")]         // /dev/stdout allowed
+    [InlineData("dotnet build")]
+    [InlineData("git log --oneline -5")]
+    [InlineData("npm install")]                     // does not contain destructive token
+    [InlineData("mv old new")]                       // mv intentionally not blocked (legitimate refactor)
+    [InlineData("")]
+    [InlineData(null)]
+    public void Check_AllowsCommonReadAndBuildCommands(string? command)
+    {
+        CommandGuard.Check(command!).Should().BeNull();
+    }
+}

--- a/tests/AgentSmith.Tests/SkillRounds/DiscussionRoundToolPolicyTests.cs
+++ b/tests/AgentSmith.Tests/SkillRounds/DiscussionRoundToolPolicyTests.cs
@@ -47,7 +47,7 @@ public sealed class DiscussionRoundToolPolicyTests
         var tools = policy.GetTools(role, pipeline);
 
         tools.Should().NotBeEmpty();
-        ToolNames(tools).Should().Contain(new[] { "ReadFile", "Grep", "ListFiles" });
+        ToolNames(tools).Should().Contain(new[] { "read_file", "grep", "list_files" });
     }
 
     [Fact]
@@ -59,7 +59,7 @@ public sealed class DiscussionRoundToolPolicyTests
 
         var tools = policy.GetTools(role, pipeline);
 
-        ToolNames(tools).Should().Contain(new[] { "ReadFile", "Grep", "ListFiles" });
+        ToolNames(tools).Should().Contain(new[] { "read_file", "grep", "list_files" });
     }
 
     [Fact]

--- a/tests/AgentSmith.Tests/SkillRounds/StructuredRoundToolPolicyTests.cs
+++ b/tests/AgentSmith.Tests/SkillRounds/StructuredRoundToolPolicyTests.cs
@@ -52,7 +52,7 @@ public sealed class StructuredRoundToolPolicyTests
         // Active mode probing flows through the prompt's JSON contract (no
         // separate IToolHost wraps it today); the tool set always carries
         // Read/Grep so the LLM can verify probe targets against the spec.
-        ToolNames(tools).Should().Contain(new[] { "ReadFile", "Grep" });
+        ToolNames(tools).Should().Contain(new[] { "read_file", "grep" });
     }
 
     [Fact]
@@ -67,7 +67,7 @@ public sealed class StructuredRoundToolPolicyTests
         // Active vs passive is a prompt-layer distinction (the probe JSON
         // block) — not a tool-layer one. p0151a: Plan-phase tools include
         // RunCommand for recon regardless of active/passive mode.
-        ToolNames(tools).Should().Contain(new[] { "ReadFile", "Grep", "RunCommand" });
+        ToolNames(tools).Should().Contain(new[] { "read_file", "grep", "run_command" });
     }
 
     [Fact]

--- a/tests/AgentSmith.Tests/Tools/FilesystemToolHostTests.cs
+++ b/tests/AgentSmith.Tests/Tools/FilesystemToolHostTests.cs
@@ -29,19 +29,19 @@ public sealed class FilesystemToolHostTests
 
         var names = NamesOf(host.GetTools(SkillExecutionPhase.Plan, null));
 
-        // p0151a: Plan now matches the Investigator set so recon skills can
-        // run ls/find for directory inventory.
-        names.Should().BeEquivalentTo("ReadFile", "Grep", "ListFiles", "RunCommand");
+        // Plan / Verify / Investigate / Review / Discuss / Filter / Synthesize all share
+        // the read+shell set so recon skills can run ls/find/curl freely at every stage.
+        names.Should().BeEquivalentTo("read_file", "grep", "glob", "list_files", "run_command", "http_request");
     }
 
     [Fact]
-    public void GetTools_ImplementationPhase_ReturnsAllFiveTools()
+    public void GetTools_ImplementationPhase_ReturnsAllTools()
     {
         var host = Build();
 
         var names = NamesOf(host.GetTools(SkillExecutionPhase.Implementation, null));
 
-        names.Should().BeEquivalentTo("ReadFile", "WriteFile", "ListFiles", "Grep", "RunCommand");
+        names.Should().BeEquivalentTo("read_file", "write_file", "edit", "list_files", "grep", "glob", "run_command", "http_request");
     }
 
     [Fact]
@@ -51,17 +51,46 @@ public sealed class FilesystemToolHostTests
 
         var names = NamesOf(host.GetTools(SkillExecutionPhase.Verify, null));
 
-        names.Should().Contain("RunCommand").And.NotContain("WriteFile");
+        names.Should().Contain("run_command").And.NotContain("write_file");
     }
 
     [Fact]
-    public void GetTools_BootstrapPhase_IncludesWriteFileExcludesRunCommand()
+    public void GetTools_BootstrapPhase_IncludesWriteCapableSet()
     {
         var host = Build();
 
         var names = NamesOf(host.GetTools(SkillExecutionPhase.Bootstrap, null));
 
-        names.Should().Contain("WriteFile").And.NotContain("RunCommand");
+        // Bootstrap and Implementation are the write-capable sets; both expose
+        // edit (targeted string-replace) and write_file (full overwrite).
+        names.Should().BeEquivalentTo("read_file", "grep", "glob", "list_files", "write_file", "edit", "run_command", "http_request");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData(SkillExecutionPhase.Review)]
+    [InlineData(SkillExecutionPhase.Discuss)]
+    [InlineData(SkillExecutionPhase.Filter)]
+    [InlineData(SkillExecutionPhase.Synthesize)]
+    public void GetTools_EveryReadPhase_ExposesRunCommand(SkillExecutionPhase? phase)
+    {
+        var host = Build();
+
+        var names = NamesOf(host.GetTools(phase, null));
+
+        names.Should().Contain("run_command");
+    }
+
+    [Fact]
+    public async Task RunCommand_BlocksDestructiveCommand_ReturnsErrorWithoutInvokingSandbox()
+    {
+        var sandbox = new Mock<ISandbox>(MockBehavior.Strict);
+        var host = Build(sandbox.Object);
+
+        var result = await host.RunCommand("rm -rf /");
+
+        result.Should().Contain("blocked").And.Contain("destructive");
+        sandbox.Verify(s => s.RunStepAsync(It.IsAny<Step>(), It.IsAny<IProgress<StepEvent>?>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]

--- a/tests/AgentSmith.Tests/Tools/HumanToolHostTests.cs
+++ b/tests/AgentSmith.Tests/Tools/HumanToolHostTests.cs
@@ -16,7 +16,7 @@ public sealed class HumanToolHostTests
         foreach (var phase in Enum.GetValues<SkillExecutionPhase>())
         {
             var names = host.GetTools(phase, null).Select(f => f.Name).ToList();
-            names.Should().BeEquivalentTo(new[] { "AskHuman" }, $"phase {phase} should expose only AskHuman");
+            names.Should().BeEquivalentTo(new[] { "ask_human" }, $"phase {phase} should expose only ask_human");
         }
     }
 

--- a/tests/AgentSmith.Tests/Tools/LogDecisionToolHostTests.cs
+++ b/tests/AgentSmith.Tests/Tools/LogDecisionToolHostTests.cs
@@ -16,7 +16,7 @@ public sealed class LogDecisionToolHostTests
         foreach (var phase in Enum.GetValues<SkillExecutionPhase>())
         {
             var names = host.GetTools(phase, null).Select(f => f.Name).ToList();
-            names.Should().BeEquivalentTo(new[] { "LogDecision" }, $"phase {phase} should expose only LogDecision");
+            names.Should().BeEquivalentTo(new[] { "log_decision" }, $"phase {phase} should expose only log_decision");
         }
     }
 

--- a/tests/AgentSmith.Tests/Tools/ToolKitCompositionTests.cs
+++ b/tests/AgentSmith.Tests/Tools/ToolKitCompositionTests.cs
@@ -28,18 +28,20 @@ public sealed class ToolKitCompositionTests
 
         var tools = NamesOf(kit.GetToolsFor("fix-bug", SkillExecutionPhase.Plan, null, DefaultHosts()));
 
-        // p0151a: Plan phase gains RunCommand for recon directory inventory.
-        tools.Should().BeEquivalentTo("ReadFile", "Grep", "ListFiles", "RunCommand", "LogDecision", "AskHuman");
+        // Plan phase = read-side filesystem surface + log_decision + ask_human. No write_file / edit.
+        tools.Should().BeEquivalentTo(
+            "read_file", "grep", "glob", "list_files", "run_command", "http_request", "log_decision", "ask_human");
     }
 
     [Fact]
-    public void GetToolsFor_FixBugImplementationPhase_AllSevenToolsAvailable()
+    public void GetToolsFor_FixBugImplementationPhase_AllToolsAvailable()
     {
         var kit = new ToolKit(new AllHostsActivePolicy());
 
         var tools = NamesOf(kit.GetToolsFor("fix-bug", SkillExecutionPhase.Implementation, null, DefaultHosts()));
 
-        tools.Should().HaveCount(7);
+        // 8 filesystem-host tools + log_decision + ask_human.
+        tools.Should().HaveCount(10);
     }
 
     [Fact]
@@ -52,7 +54,7 @@ public sealed class ToolKitCompositionTests
 
         var tools = NamesOf(kit.GetToolsFor("message-only", SkillExecutionPhase.Implementation, null, DefaultHosts()));
 
-        tools.Should().BeEquivalentTo("LogDecision");
+        tools.Should().BeEquivalentTo("log_decision");
     }
 
     [Fact]
@@ -63,7 +65,7 @@ public sealed class ToolKitCompositionTests
         var tools = NamesOf(kit.GetToolsFor(
             IToolKit.WildcardPipelineName, SkillExecutionPhase.Plan, null, DefaultHosts()));
 
-        tools.Should().Contain("ReadFile").And.Contain("LogDecision").And.Contain("AskHuman");
+        tools.Should().Contain("read_file").And.Contain("log_decision").And.Contain("ask_human");
     }
 
     [Fact]
@@ -74,7 +76,7 @@ public sealed class ToolKitCompositionTests
         var tools = NamesOf(kit.GetToolsFor(
             "never-heard-of-this-pipeline", SkillExecutionPhase.Plan, null, DefaultHosts()));
 
-        tools.Should().Contain("ReadFile").And.Contain("LogDecision").And.Contain("AskHuman");
+        tools.Should().Contain("read_file").And.Contain("log_decision").And.Contain("ask_human");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- **ReadSet capture bug fixed.** `TracingAIFunction.CapturePathIfRead` checked tool name `"read_file"` literally, but production registered tools via `AIFunctionFactory.Create(ReadFile)` → default C# method name `"ReadFile"` (PascalCase). Result: every `ReadFile` call bypassed the ReadSet, so `SourceAnchorValidator` dropped every `analyzed_from_source` observation with `"read-set: 0 entries"` even when the file had been read. Two changes: (a) normalise tool names by stripping non-alphanumeric chars + lowercasing in the comparison, (b) rename all production tool registrations to explicit snake_case (consistent with LLM-side conventions). Plus regression test that covers ReadFile / read_file / readFile / read-file naming variants.
- **Bash exposed everywhere.** `run_command` was previously gated to Investigator and Implementation phase sets only. Plan / Verify / Review / Discuss / Filter / Synthesize / Bootstrap now also expose it. New `CommandGuard` blocks destructive tokens (`rm`/`rmdir`/`unlink`/`shred`/`truncate`/`dd`), fork-bombs, and raw device-write redirects (`> /dev/sda`); everything else (`find`/`grep`/`head`/`wc`/`curl`/`git`/`dotnet`/…) passes through. Sandbox container remains the primary isolation boundary; this is defense-in-depth.
- **New `edit` tool.** Targeted string-replace: `old_string` must appear exactly once in the file (uniqueness check) or the call fails with an explicit error. Safer than `write_file` (which overwrites the entire file).
- **New `glob` tool.** Pattern-based file discovery via `find -name <pattern>` with `**/` prefix stripping. Returns up to 200 matches.
- **New `http_request` tool.** Live API probing via `curl` inside the sandbox. Method / URL / body / headers as structured params; methods constrained to GET / POST / PUT / PATCH / DELETE / HEAD / OPTIONS; timeout clamped to 1..60s. Enables api-security-scan skills to actually exercise the target API rather than just lint its swagger schema.

## Why now

Operator observation on 2026-05-19 comparing the agent-smith api-security-scan output against a vanilla Claude doing the same audit with `Bash` + `Read` + `Agent(Explore)`: the vanilla Claude finds real code-level vulns (IUserPermissionCache scope lifetime, ExceptionMiddleware stack-trace leak, hardcoded secrets in `pipelines/*.yml`, missing `UseHsts` / `TokenValidationParameters`) while the structured skills produce shallow swagger-lint reformulations. The bottleneck was the toolset, not the LLM.

## Test plan

- [x] All 1913 main + 66 sandbox tests pass locally
- [x] New `CommandGuardTests` (4 theories, 22 cases) cover destructive-token blocklist + benign-command allowlist + fork-bomb + raw-device-write patterns
- [x] Updated `TracingAIFunctionTests` adds a `[Theory]` over `ReadFile` / `read_file` / `readFile` / `read-file` naming variants — guards against regression of the original bug
- [x] Updated `FilesystemToolHostTests` covers all phase sets at their new expected tool counts (including new `run_command` in every read phase)
- [x] Updated `ToolKitCompositionTests` + `ToolKitTests` for the new composed surface (8 filesystem-host tools + log_decision + ask_human = 10)
- [ ] CLI smoke against the original failing run (api-security-scan against AuthPort) — operator to verify the `read-set: 0 entries` drops vanish and that the new shell pattern produces deeper code-level findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)