### PR TITLE
fix(observations): downgrade mis-labeled analyzed_from_source observations instead of dropping

### DIFF
--- a/src/AgentSmith.Application/Services/Handlers/ISourceAnchorValidator.cs
+++ b/src/AgentSmith.Application/Services/Handlers/ISourceAnchorValidator.cs
@@ -4,18 +4,32 @@ using Microsoft.Extensions.Logging;
 namespace AgentSmith.Application.Services.Handlers;
 
 /// <summary>
-/// Rejects <see cref="SkillObservation"/>s whose <see cref="EvidenceMode.AnalyzedFromSource"/>
-/// claim is not backed by an actual file read in the current skill call.
-/// Implemented per p0151b: the validator reads the call's
-/// <c>ReadPaths</c> (populated by <c>LoopTraceCollector.ReadSet</c> in
-/// p0151a) and drops observations whose <c>File</c> is missing or not
-/// in the set. Observations with other evidence modes pass through —
-/// scanner/swagger/design findings are anchored by other fields, not by
-/// source reads.
+/// Enforces the source-anchor contract on <see cref="SkillObservation"/>s
+/// whose evidence mode is <see cref="EvidenceMode.AnalyzedFromSource"/>.
+///
+/// Originally (p0151b) this was a binary drop-or-keep gate, but operators
+/// observed valuable findings being silently lost when an LLM emitted
+/// <c>analyzed_from_source</c> with no file (or with a file outside the
+/// per-call ReadSet from p0151a). The signal in the description was often
+/// real even when the label was wrong — losing the entire observation was
+/// the wrong response.
+///
+/// The contract is therefore now: pass observations through unchanged when
+/// the anchor holds; <b>downgrade</b> mislabeled ones to
+/// <see cref="EvidenceMode.Potential"/> (clearing the unverified
+/// <c>File</c> claim) when it does not. Downgrades are logged at Warning
+/// so the operator still sees the prompt drift.
 /// </summary>
 public interface ISourceAnchorValidator
 {
-    bool IsAnchored(
+    /// <summary>
+    /// Returns the observation unchanged if its source anchor holds, or a
+    /// downgraded copy (evidence_mode → potential, file cleared) when the
+    /// <c>analyzed_from_source</c> claim cannot be verified against the
+    /// per-call ReadSet. Never returns null — the observation is always
+    /// kept in some form.
+    /// </summary>
+    SkillObservation EnforceAnchor(
         SkillObservation observation,
         IReadOnlyCollection<string>? readPaths,
         string role,

--- a/src/AgentSmith.Application/Services/Handlers/ObservationParser.cs
+++ b/src/AgentSmith.Application/Services/Handlers/ObservationParser.cs
@@ -105,7 +105,7 @@ public sealed class ObservationParser(
             var entry = element.Deserialize<RawObservation>(JsonOptions);
             if (entry is null || string.IsNullOrWhiteSpace(entry.Description)) return null;
             var observation = normalizer.Normalize(entry.ToFields(), role, id, perRunWarn, logger);
-            return sourceAnchorValidator.IsAnchored(observation, readPaths, role, logger) ? observation : null;
+            return sourceAnchorValidator.EnforceAnchor(observation, readPaths, role, logger);
         }
         catch (JsonException ex)
         {

--- a/src/AgentSmith.Application/Services/Handlers/SourceAnchorValidator.cs
+++ b/src/AgentSmith.Application/Services/Handlers/SourceAnchorValidator.cs
@@ -7,37 +7,42 @@ namespace AgentSmith.Application.Services.Handlers;
 /// Default <see cref="ISourceAnchorValidator"/>: passes through every
 /// observation whose evidence_mode is not <see cref="EvidenceMode.AnalyzedFromSource"/>
 /// (those are anchored by api_path / schema_name / scanner template_id),
-/// passes through every observation when no read-set is supplied (e.g.
-/// tests that bypass the runtime layer), and otherwise requires that
-/// <see cref="SkillObservation.File"/> appears in the read-set (case-
-/// insensitive). Failures are logged at Warning so operators see the
-/// drop without it being load-bearing.
+/// and every observation when no read-set is supplied (e.g. tests that
+/// bypass the runtime layer). For <c>analyzed_from_source</c> claims it
+/// requires that <see cref="SkillObservation.File"/> is set AND appears
+/// in the read-set (case-insensitive). Mislabeled observations are not
+/// dropped — they are downgraded to <see cref="EvidenceMode.Potential"/>
+/// with the unverified <c>File</c> cleared, and a warning is logged so
+/// the operator sees the prompt drift.
 /// </summary>
 public sealed class SourceAnchorValidator : ISourceAnchorValidator
 {
-    public bool IsAnchored(
+    public SkillObservation EnforceAnchor(
         SkillObservation observation,
         IReadOnlyCollection<string>? readPaths,
         string role,
         ILogger? logger)
     {
-        if (observation.EvidenceMode != EvidenceMode.AnalyzedFromSource) return true;
-        if (readPaths is null) return true;
+        if (observation.EvidenceMode != EvidenceMode.AnalyzedFromSource) return observation;
+        if (readPaths is null) return observation;
+
         if (string.IsNullOrWhiteSpace(observation.File))
         {
             logger?.LogWarning(
-                "Skill {Role}: dropping analyzed_from_source observation '{Description}' — no file cited.",
+                "Skill {Role}: downgrading analyzed_from_source observation '{Description}' to potential — no file cited.",
                 role, Preview(observation.Description));
-            return false;
+            return observation with { EvidenceMode = EvidenceMode.Potential, File = null };
         }
+
         if (!Contains(readPaths, observation.File))
         {
             logger?.LogWarning(
-                "Skill {Role}: dropping analyzed_from_source observation citing unread file '{File}' (read-set: {ReadCount} entries).",
+                "Skill {Role}: downgrading analyzed_from_source observation citing unread file '{File}' to potential (read-set: {ReadCount} entries).",
                 role, observation.File, readPaths.Count);
-            return false;
+            return observation with { EvidenceMode = EvidenceMode.Potential, File = null };
         }
-        return true;
+
+        return observation;
     }
 
     private static bool Contains(IReadOnlyCollection<string> readPaths, string file) =>

--- a/tests/AgentSmith.Tests/Handlers/SourceAnchorValidatorTests.cs
+++ b/tests/AgentSmith.Tests/Handlers/SourceAnchorValidatorTests.cs
@@ -18,75 +18,100 @@ public sealed class SourceAnchorValidatorTests
             EvidenceMode: mode, File: file);
 
     [Fact]
-    public void IsAnchored_AnalyzedFromSourceAndFileInReadSet_ReturnsTrue()
+    public void EnforceAnchor_AnalyzedFromSourceAndFileInReadSet_ReturnsUnchanged()
     {
         var observation = Make(file: "src/Program.cs");
         var readPaths = new[] { "src/Program.cs" };
 
-        _validator.IsAnchored(observation, readPaths, "judge", NullLogger.Instance).Should().BeTrue();
+        var result = _validator.EnforceAnchor(observation, readPaths, "judge", NullLogger.Instance);
+
+        result.EvidenceMode.Should().Be(EvidenceMode.AnalyzedFromSource);
+        result.File.Should().Be("src/Program.cs");
     }
 
     [Fact]
-    public void IsAnchored_AnalyzedFromSourceAndFileNotInReadSet_ReturnsFalse()
+    public void EnforceAnchor_AnalyzedFromSourceAndFileNotInReadSet_DowngradesToPotentialAndClearsFile()
     {
         var observation = Make(file: "src/Hallucination.cs");
         var readPaths = new[] { "src/Program.cs" };
 
-        _validator.IsAnchored(observation, readPaths, "judge", NullLogger.Instance).Should().BeFalse();
+        var result = _validator.EnforceAnchor(observation, readPaths, "judge", NullLogger.Instance);
+
+        result.EvidenceMode.Should().Be(EvidenceMode.Potential);
+        result.File.Should().BeNull();
+        result.Description.Should().Be("x");  // signal preserved
     }
 
     [Fact]
-    public void IsAnchored_AnalyzedFromSourceAndNoFile_ReturnsFalse()
+    public void EnforceAnchor_AnalyzedFromSourceAndNoFile_DowngradesToPotential()
     {
         var observation = Make(file: null);
         var readPaths = new[] { "src/Program.cs" };
 
-        _validator.IsAnchored(observation, readPaths, "judge", NullLogger.Instance).Should().BeFalse();
+        var result = _validator.EnforceAnchor(observation, readPaths, "judge", NullLogger.Instance);
+
+        result.EvidenceMode.Should().Be(EvidenceMode.Potential);
+        result.File.Should().BeNull();
+        result.Description.Should().Be("x");  // signal preserved
     }
 
     [Fact]
-    public void IsAnchored_AnalyzedFromSourceAndEmptyFile_ReturnsFalse()
+    public void EnforceAnchor_AnalyzedFromSourceAndEmptyFile_DowngradesToPotential()
     {
         var observation = Make(file: "");
         var readPaths = new[] { "src/Program.cs" };
 
-        _validator.IsAnchored(observation, readPaths, "judge", NullLogger.Instance).Should().BeFalse();
+        var result = _validator.EnforceAnchor(observation, readPaths, "judge", NullLogger.Instance);
+
+        result.EvidenceMode.Should().Be(EvidenceMode.Potential);
+        result.File.Should().BeNull();
     }
 
     [Fact]
-    public void IsAnchored_PotentialEvidence_ReturnsTrueRegardlessOfFile()
+    public void EnforceAnchor_PotentialEvidence_ReturnsUnchangedRegardlessOfFile()
     {
         var observation = Make(EvidenceMode.Potential, file: "src/anywhere.cs");
         var readPaths = Array.Empty<string>();
 
-        _validator.IsAnchored(observation, readPaths, "judge", NullLogger.Instance).Should().BeTrue();
+        var result = _validator.EnforceAnchor(observation, readPaths, "judge", NullLogger.Instance);
+
+        result.EvidenceMode.Should().Be(EvidenceMode.Potential);
+        result.File.Should().Be("src/anywhere.cs");
     }
 
     [Fact]
-    public void IsAnchored_ConfirmedEvidence_ReturnsTrueRegardlessOfFile()
+    public void EnforceAnchor_ConfirmedEvidence_ReturnsUnchangedRegardlessOfFile()
     {
         var observation = Make(EvidenceMode.Confirmed, file: null);
         var readPaths = Array.Empty<string>();
 
-        _validator.IsAnchored(observation, readPaths, "judge", NullLogger.Instance).Should().BeTrue();
+        var result = _validator.EnforceAnchor(observation, readPaths, "judge", NullLogger.Instance);
+
+        result.EvidenceMode.Should().Be(EvidenceMode.Confirmed);
     }
 
     [Fact]
-    public void IsAnchored_NoReadPathsProvided_PassesEvenForAnalyzedFromSource()
+    public void EnforceAnchor_NoReadPathsProvided_PassesEvenForAnalyzedFromSource()
     {
         // When the runtime layer does not provide readPaths (e.g. legacy tests
-        // that bypass the runtime), the validator does not enforce the rule.
+        // that bypass the runtime), the validator does not enforce the rule
+        // and returns the observation unchanged.
         var observation = Make(file: "src/Anything.cs");
 
-        _validator.IsAnchored(observation, readPaths: null, "judge", NullLogger.Instance).Should().BeTrue();
+        var result = _validator.EnforceAnchor(observation, readPaths: null, "judge", NullLogger.Instance);
+
+        result.EvidenceMode.Should().Be(EvidenceMode.AnalyzedFromSource);
+        result.File.Should().Be("src/Anything.cs");
     }
 
     [Fact]
-    public void IsAnchored_CaseInsensitiveFileMatch()
+    public void EnforceAnchor_CaseInsensitiveFileMatch()
     {
         var observation = Make(file: "SRC/PROGRAM.CS");
         var readPaths = new[] { "src/Program.cs" };
 
-        _validator.IsAnchored(observation, readPaths, "judge", NullLogger.Instance).Should().BeTrue();
+        var result = _validator.EnforceAnchor(observation, readPaths, "judge", NullLogger.Instance);
+
+        result.EvidenceMode.Should().Be(EvidenceMode.AnalyzedFromSource);
     }
 }


### PR DESCRIPTION
## Summary

Operator-observed in the 2026-05-19 22:55 api-security-scan run: the \`auth-config-reviewer\` skill produced 4 strong findings — missing JWT validation, no Strict-Transport-Security, AllowAnyOrigin CORS risk, missing security headers — that were all **silently dropped** by \`SourceAnchorValidator\` because the LLM had labeled them \`evidence_mode: analyzed_from_source\` without setting the \`file\` field. The label was wrong; the signal was real.

Change the contract from binary drop-or-keep to a transform:
- Pass through when the source-anchor claim holds.
- **Downgrade** \`analyzed_from_source\` → \`potential\` (and clear the unverified \`File\`) when (a) no file is cited or (b) file is cited but not in the per-call ReadSet.
- Either way, the observation — description, severity, confidence — survives. Operator sees the finding even when the LLM mis-labels its evidence strength.

Companion to the cross-repo PR in agent-smith-skills that adds the missing tool-usage + evidence_mode guidance to the Review-phase skill prompts (\`auth-config-reviewer\`, \`controller-implementation-reviewer\`, \`jwt-validation-judge\`, \`report-synthesizer\`) that PR #41 didn't cover.

## Test plan

- [x] \`SourceAnchorValidatorTests\` rewritten (9 cases) to assert downgrade + signal preservation, not binary drop
- [x] 1913 main + 66 sandbox tests pass locally
- [ ] Operator smoke: rerun api-security-scan against AuthPort; expect the 4 \`auth-config-reviewer\` findings to surface as MEDIUM/HIGH \`[potential]\` instead of being dropped

🤖 Generated with [Claude Code](https://claude.com/claude-code)