### PR TITLE
feat(prompts): universal tool surface + evidence_mode contract in SourceAnchoringPreamble

### DIFF
--- a/src/AgentSmith.Application/Services/Prompts/SourceAnchoringPreamble.cs
+++ b/src/AgentSmith.Application/Services/Prompts/SourceAnchoringPreamble.cs
@@ -1,25 +1,38 @@
 namespace AgentSmith.Application.Services.Prompts;
 
 /// <summary>
-/// Produces the one-paragraph rule that every skill's system prompt opens with:
-/// every <c>analyzed_from_source</c> observation must cite a file actually read
-/// in this call. The runtime drops anything else. Centralized here so the rule
-/// lives in one place instead of in 50+ SKILL.md files — see p0151's
+/// Produces the universal preamble prepended to every skill's system prompt.
+/// Lists the sandbox tools available to investigators / producers / judges,
+/// states the evidence_mode rule, and clarifies that the runtime DOWNGRADES
+/// (no longer drops, post-PR #171) mis-labeled analyzed_from_source
+/// observations. Centralizing the rule here means SKILL.md authors don't
+/// need to repeat tool listings in every catalog entry — see p0151's
 /// "no new SKILL.md format" decision.
 /// </summary>
 public sealed class SourceAnchoringPreamble
 {
     public string Build() =>
-        "You have read-only inspection tools for source and shell (read_file, " +
-        "grep, list_files, run_command). Every observation you emit with " +
-        "evidence_mode: analyzed_from_source MUST cite a file you actually read " +
-        "in this call. The runtime drops any analyzed_from_source observation " +
-        "whose file is not in the trace ReadSet — claiming source analysis " +
-        "without a real read is wasted output. For findings backed by swagger, " +
-        "scanner output, or design analysis, use the matching evidence_mode " +
-        "(potential / confirmed) and the matching anchor (api_path, " +
-        "schema_name, scanner template_id) — those do not require a file read. " +
-        "When prior rounds have left observations on the bus, you may treat any " +
-        "observation with an anchor (file, api_path, schema_name) as a hint and " +
-        "confirm with your own tool calls; do not blindly restate prior findings.";
+        "You have these sandbox tools (always available; the framework " +
+        "filters by phase, but the tool surface is uniform across catalogs): " +
+        "read_file, grep, glob, list_files, edit, write_file, run_command " +
+        "(read-only bash; rm / rmdir / unlink / shred / truncate / dd are " +
+        "blocked), http_request (live HTTP probing). Plus log_decision and " +
+        "ask_human in pipelines that wire them up. Use them — broad recon " +
+        "first (glob / grep with a pipe to head / list_files), then targeted " +
+        "reads. A vanilla LLM with raw bash will out-perform you if you fall " +
+        "back to schema-only inference.\n\n" +
+        "evidence_mode contract: " +
+        "analyzed_from_source means you opened the cited file via read_file " +
+        "in THIS skill round (the runtime tracks a ReadSet and downgrades " +
+        "unverified claims to potential automatically — your description " +
+        "still surfaces, but the strong label is reserved for genuine reads). " +
+        "confirmed means you used http_request and observed the live behavior. " +
+        "potential covers schema / scanner / design inference and " +
+        "absence-of-thing findings (\"no UseHsts anywhere\"); these do NOT " +
+        "require a file anchor — set file to null. Pick the matching anchor " +
+        "field per evidence: file + start_line for source, api_path for " +
+        "endpoint behavior, schema_name for schema-only, template_id (in the " +
+        "description) for scanner-derived. When prior rounds left observations " +
+        "on the bus, treat any anchored prior observation as a hint to verify " +
+        "with your own tool calls; do not blindly restate.";
 }

--- a/tests/AgentSmith.Tests/Prompts/SourceAnchoringPreambleTests.cs
+++ b/tests/AgentSmith.Tests/Prompts/SourceAnchoringPreambleTests.cs
@@ -6,7 +6,7 @@ namespace AgentSmith.Tests.Prompts;
 public sealed class SourceAnchoringPreambleTests
 {
     [Fact]
-    public void Build_NamesTheAvailableTools()
+    public void Build_NamesTheFullToolSurface()
     {
         var preamble = new SourceAnchoringPreamble();
 
@@ -14,19 +14,26 @@ public sealed class SourceAnchoringPreambleTests
 
         text.Should().Contain("read_file")
             .And.Contain("grep")
+            .And.Contain("glob")
             .And.Contain("list_files")
-            .And.Contain("run_command");
+            .And.Contain("edit")
+            .And.Contain("write_file")
+            .And.Contain("run_command")
+            .And.Contain("http_request");
     }
 
     [Fact]
-    public void Build_StatesAnalyzedFromSourceRequirement()
+    public void Build_StatesDowngradeNotDropForAnalyzedFromSource()
     {
+        // Post-PR #171: validator downgrades, does NOT drop. The preamble must
+        // reflect the new contract so the LLM understands its safety net.
         var preamble = new SourceAnchoringPreamble();
 
         var text = preamble.Build();
 
         text.Should().Contain("analyzed_from_source")
-            .And.Contain("drops");
+            .And.Contain("downgrades");
+        text.Should().NotContain("drops any analyzed_from_source");
     }
 
     [Fact]
@@ -38,5 +45,18 @@ public sealed class SourceAnchoringPreambleTests
 
         text.Should().Contain("potential").And.Contain("confirmed");
         text.Should().Contain("api_path").And.Contain("template_id");
+    }
+
+    [Fact]
+    public void Build_AffirmsPotentialWithoutAnchorIsValid()
+    {
+        // Absence-of-config findings ("no UseHsts anywhere") must be a
+        // first-class evidence_mode=potential observation without a file anchor.
+        var preamble = new SourceAnchoringPreamble();
+
+        var text = preamble.Build();
+
+        text.Should().Contain("absence");
+        text.Should().Contain("file to null");
     }
 }


### PR DESCRIPTION
## Summary

Single-file change to \`SourceAnchoringPreamble.cs\` — the preamble prepended to every skill's system prompt across all catalogs (api-security, security, coding, autonomous, legal, mad, skill-manager: 83+ skills). Reflects two things that PRs #170 and #171 changed but never propagated to the preamble:

- **Full tool surface.** Names all eight sandbox tools (\`read_file\`, \`grep\`, \`glob\`, \`list_files\`, \`edit\`, \`write_file\`, \`run_command\`, \`http_request\`) plus the optional \`log_decision\` / \`ask_human\`. Old text named only four.
- **Downgrade, not drop.** Post-PR #171 the validator downgrades mis-labeled \`analyzed_from_source\` to \`potential\` instead of dropping. The preamble now says so, plus explicitly affirms that absence-of-config findings ("no UseHsts anywhere") are legitimate \`evidence_mode: "potential"\` observations without a file anchor.

## Why this matters

Operator-observed root cause: skills produced shallow, schema-lint-style output because the prompts gave no tool-use guidance and the existing preamble was both stale and brittle. Fixing this in 64+ SKILL.md files (the per-catalog approach) would be repetitive, hard to keep in sync, and embed framework concerns in domain content. One file in agent-smith propagates the correct universal rule to every skill that exists today AND every skill that gets added tomorrow.

The per-catalog Tools sections from PRs #41 / #42 (api-security) and a follow-up cross-repo PR for skills/security remain valuable for domain-specific recon hints (which grep patterns / globs to start with) — they're additive on top of this preamble, no longer load-bearing.

## Test plan

- [x] \`SourceAnchoringPreambleTests\` extended (4 cases now) — full tool surface, downgrade-not-drop wording, evidence-mode disambiguation, absence-finding affirmation
- [x] 1914 main + 66 sandbox tests pass locally
- [ ] Operator smoke: after merge + cross-repo PR, rerun api-security-scan and security-scan; expect (a) skills in all catalogs use tools more readily, (b) no \`unknown evidence_mode\` warns, (c) absence-findings ("no UseHsts") surface as \`[potential]\` rather than being silently lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)