### PR TITLE
fix(prompts): pull preamble toward tool use via identity + concrete targets

### DIFF
--- a/src/AgentSmith.Application/Services/Prompts/SourceAnchoringPreamble.cs
+++ b/src/AgentSmith.Application/Services/Prompts/SourceAnchoringPreamble.cs
@@ -2,37 +2,46 @@ namespace AgentSmith.Application.Services.Prompts;
 
 /// <summary>
 /// Produces the universal preamble prepended to every skill's system prompt.
-/// Lists the sandbox tools available to investigators / producers / judges,
-/// states the evidence_mode rule, and clarifies that the runtime DOWNGRADES
-/// (no longer drops, post-PR #171) mis-labeled analyzed_from_source
-/// observations. Centralizing the rule here means SKILL.md authors don't
-/// need to repeat tool listings in every catalog entry — see p0151's
-/// "no new SKILL.md format" decision.
+/// Tells the skill it is an investigator (or producer / judge) whose job
+/// is to read the files and ground its findings, lists the sandbox tools,
+/// and clarifies when each evidence_mode is appropriate. Centralized here
+/// so SKILL.md authors don't repeat themselves across 80+ catalogs.
+///
+/// History: an earlier permissive revision led to LLMs emitting potential-only
+/// observations with 0 tool calls when source was available, because the
+/// safety-net wording ("validator will downgrade automatically") was
+/// interpreted as license to skip reading. This revision pulls the LLM
+/// toward tool use via identity + concrete targets, not via threat.
 /// </summary>
 public sealed class SourceAnchoringPreamble
 {
     public string Build() =>
-        "You have these sandbox tools (always available; the framework " +
-        "filters by phase, but the tool surface is uniform across catalogs): " +
-        "read_file, grep, glob, list_files, edit, write_file, run_command " +
-        "(read-only bash; rm / rmdir / unlink / shred / truncate / dd are " +
-        "blocked), http_request (live HTTP probing). Plus log_decision and " +
-        "ask_human in pipelines that wire them up. Use them — broad recon " +
-        "first (glob / grep with a pipe to head / list_files), then targeted " +
-        "reads. A vanilla LLM with raw bash will out-perform you if you fall " +
-        "back to schema-only inference.\n\n" +
-        "evidence_mode contract: " +
-        "analyzed_from_source means you opened the cited file via read_file " +
-        "in THIS skill round (the runtime tracks a ReadSet and downgrades " +
-        "unverified claims to potential automatically — your description " +
-        "still surfaces, but the strong label is reserved for genuine reads). " +
-        "confirmed means you used http_request and observed the live behavior. " +
-        "potential covers schema / scanner / design inference and " +
-        "absence-of-thing findings (\"no UseHsts anywhere\"); these do NOT " +
-        "require a file anchor — set file to null. Pick the matching anchor " +
-        "field per evidence: file + start_line for source, api_path for " +
-        "endpoint behavior, schema_name for schema-only, template_id (in the " +
-        "description) for scanner-derived. When prior rounds left observations " +
-        "on the bus, treat any anchored prior observation as a hint to verify " +
-        "with your own tool calls; do not blindly restate.";
+        "You are an investigator. Your job, when source is available, is to " +
+        "read the files, get context, then judge.\n\n" +
+        "Tools available in this round (the framework filters by phase, but " +
+        "the surface is uniform): read_file, grep, glob, list_files, edit, " +
+        "write_file, run_command (read-only bash; rm / rmdir / unlink / " +
+        "shred / truncate / dd are blocked), http_request (live HTTP " +
+        "probing). Plus log_decision and ask_human where wired up.\n\n" +
+        "Recon flow that produces strong findings: glob or list_files for " +
+        "the layout, grep for the security-relevant symbols, then read_file " +
+        "the 2-5 files that actually matter. A finding grounded in a file " +
+        "you opened carries evidence_mode: analyzed_from_source and cites " +
+        "the file + start_line. That is your primary deliverable.\n\n" +
+        "evidence_mode: potential is the right label for: (a) absence " +
+        "findings (\"no UseHsts registration anywhere in the codebase\"), " +
+        "(b) pure schema or scanner-output inference where no code applies, " +
+        "(c) genuine pattern-only hits you have not yet read. These are " +
+        "valid observations; leave file null. Potential is not a shortcut " +
+        "for skipping the read — when source is available, expect the " +
+        "majority of your findings to be analyzed_from_source.\n\n" +
+        "evidence_mode: confirmed is only legitimate after a real " +
+        "http_request call in this round. The framework records every tool " +
+        "call; do not claim confirmed without a matching probe.\n\n" +
+        "When prior rounds left observations on the bus, treat anchored " +
+        "ones as hints to verify with your own tool calls; do not blindly " +
+        "restate. A round of investigation that makes zero tool calls when " +
+        "source is available will produce shallow output the operator does " +
+        "not act on. Your strongest finding names a file, a line, and the " +
+        "offending statement.";
 }

--- a/tests/AgentSmith.Tests/Prompts/SourceAnchoringPreambleTests.cs
+++ b/tests/AgentSmith.Tests/Prompts/SourceAnchoringPreambleTests.cs
@@ -23,28 +23,49 @@ public sealed class SourceAnchoringPreambleTests
     }
 
     [Fact]
-    public void Build_StatesDowngradeNotDropForAnalyzedFromSource()
+    public void Build_PullsTowardToolUseViaIdentityAndConcreteTargets()
     {
-        // Post-PR #171: validator downgrades, does NOT drop. The preamble must
-        // reflect the new contract so the LLM understands its safety net.
+        // Post-PR #173-followup: earlier permissive wording produced 0-tool-call
+        // rounds. The preamble must pull toward investigation via identity +
+        // a concrete recon flow + a numeric target, not via threat.
         var preamble = new SourceAnchoringPreamble();
 
         var text = preamble.Build();
 
-        text.Should().Contain("analyzed_from_source")
-            .And.Contain("downgrades");
-        text.Should().NotContain("drops any analyzed_from_source");
+        text.Should().Contain("investigator");
+        text.Should().Contain("read the files");
+        text.Should().Contain("2-5 files");
+        text.Should().Contain("primary deliverable");
+    }
+
+    [Fact]
+    public void Build_DiscourageZeroToolCallShortcut()
+    {
+        var preamble = new SourceAnchoringPreamble();
+
+        var text = preamble.Build();
+
+        // The wording must NOT lean on "the framework will downgrade automatically"
+        // as the only deterrent — that was the regression.
+        text.Should().NotContain("downgrades unverified claims to potential automatically");
+        // The wording MUST explicitly name the failure mode.
+        text.Should().Contain("zero tool calls");
+        text.Should().Contain("shallow");
     }
 
     [Fact]
     public void Build_AcknowledgesOtherEvidenceModesAreLegitimate()
     {
+        // The preamble names the three evidence_modes; concrete anchor types
+        // (api_path / schema_name / template_id) are catalog-specific and live
+        // in per-skill SKILL.md guidance, not in this universal text.
         var preamble = new SourceAnchoringPreamble();
 
         var text = preamble.Build();
 
-        text.Should().Contain("potential").And.Contain("confirmed");
-        text.Should().Contain("api_path").And.Contain("template_id");
+        text.Should().Contain("potential")
+            .And.Contain("confirmed")
+            .And.Contain("analyzed_from_source");
     }
 
     [Fact]
@@ -57,6 +78,17 @@ public sealed class SourceAnchoringPreambleTests
         var text = preamble.Build();
 
         text.Should().Contain("absence");
-        text.Should().Contain("file to null");
+        text.Should().Contain("file null");
+    }
+
+    [Fact]
+    public void Build_RequiresHttpRequestForConfirmedEvidence()
+    {
+        var preamble = new SourceAnchoringPreamble();
+
+        var text = preamble.Build();
+
+        text.Should().Contain("confirmed");
+        text.Should().Contain("http_request");
     }
 }


### PR DESCRIPTION
## Summary

PR #173 softened the preamble for the post-PR #171 validator (downgrade instead of drop). The wording "validator will downgrade automatically" + "your description still surfaces" was read by LLMs as license to skip the work — the **23:25 operator run produced 7 findings, all `evidence_mode: potential`, 0/7 anchored, 0 tool calls across every review-phase skill**. Two findings claimed `confirmed` without any `http_request` call.

Rewrite the preamble to pull toward tool use via **identity + concrete recon flow + numeric target**, not via threat:

- Identity opener: *"You are an investigator. Your job ... is to read the files, get context, then judge."*
- Concrete recon flow: glob/list_files → grep → read_file the **2-5 files** that actually matter.
- \`analyzed_from_source\` framed as "primary deliverable", not strict contract.
- \`potential\` framed positively as the right label for absence findings, schema/scanner inference, not-yet-read pattern hits — and explicitly called out as **"not a shortcut for skipping the read"**.
- \`confirmed\` requires an actual \`http_request\` call (drops the wording that let LLMs claim confirmed without probing).
- Success picture at the end: *"Your strongest finding names a file, a line, and the offending statement."*

## Test plan

- [x] \`SourceAnchoringPreambleTests\` updated: 6 cases assert pull-direction wording (identity, 2-5 files, primary deliverable, http_request gate, zero-tool-call failure naming, no "downgrade-automatically" wording)
- [x] 1916 main + 66 sandbox tests pass locally
- [ ] Operator smoke after merge + new agent-smith-skills release: expect tool_calls > 0 on review-phase skills again, anchor rate > 50%, no lying-confirmed labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)