### PR TITLE
fix(triggers): drop DefaultPipeline fallback when pipeline_from_label is set

### DIFF
--- a/src/AgentSmith.Application/Services/Triggers/ProjectResolver.cs
+++ b/src/AgentSmith.Application/Services/Triggers/ProjectResolver.cs
@@ -33,13 +33,13 @@ public sealed class ProjectResolver(ILogger<ProjectResolver>? logger = null) : I
                 if (!Matches(trigger, project, envelope)) continue;
 
                 var pipeline = PipelineResolver.Resolve(
-                    trigger, envelope.Labels, config.PipelineTriggers, logger as ILogger)
-                    ?? trigger.DefaultPipeline;
+                    trigger, envelope.Labels, config.PipelineTriggers, logger as ILogger);
 
                 if (string.IsNullOrEmpty(pipeline))
                 {
-                    logger?.LogWarning(
-                        "ProjectResolver: project '{Project}' matched envelope on {Kind} but pipeline resolution returned null/empty; skipping.",
+                    // No DefaultPipeline fallback: when pipeline_from_label is set it acts as a strict filter; an unmatched ticket must be dropped.
+                    logger?.LogInformation(
+                        "ProjectResolver: project '{Project}' matched envelope on {Kind} but no pipeline_from_label entry matched; dropping.",
                         projectName, kind);
                     continue;
                 }

--- a/tests/AgentSmith.Tests/Triggers/ProjectResolverTests.cs
+++ b/tests/AgentSmith.Tests/Triggers/ProjectResolverTests.cs
@@ -97,6 +97,70 @@ public sealed class ProjectResolverTests
     }
 
     [Fact]
+    public void PipelineFromLabel_ConfiguredButNoLabelMatches_DropsMatch()
+    {
+        var trigger = TriggerWithTag("alpha");
+        trigger.PipelineFromLabel = new Dictionary<string, string>
+        {
+            ["agent-smith:bug"] = "fix-bug",
+            ["agent-smith:feature"] = "add-feature",
+        };
+        var config = ConfigWith(("alpha", new TrackerConnection { Name = "gh", Type = TrackerType.GitHub },
+            project => project with { GithubTrigger = trigger }));
+
+        var matches = _sut.Resolve(config, new IncomingTicketEnvelope { Labels = ["alpha"] });
+
+        matches.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void PipelineFromLabel_ConfiguredAndLabelMatches_ReturnsMappedPipeline()
+    {
+        var trigger = TriggerWithTag("alpha");
+        trigger.PipelineFromLabel = new Dictionary<string, string>
+        {
+            ["agent-smith:bug"] = "fix-bug",
+            ["agent-smith:feature"] = "add-feature",
+        };
+        var config = ConfigWith(("alpha", new TrackerConnection { Name = "gh", Type = TrackerType.GitHub },
+            project => project with { GithubTrigger = trigger }));
+
+        var matches = _sut.Resolve(config, new IncomingTicketEnvelope { Labels = ["alpha", "agent-smith:feature"] });
+
+        matches.Should().ContainSingle()
+            .Which.PipelineName.Should().Be("add-feature");
+    }
+
+    [Fact]
+    public void NoPipelineFromLabel_UsesDefaultPipeline()
+    {
+        var config = ConfigWith(("alpha", new TrackerConnection { Name = "gh", Type = TrackerType.GitHub },
+            project => project with { GithubTrigger = TriggerWithTag("alpha") }));
+
+        var matches = _sut.Resolve(config, new IncomingTicketEnvelope { Labels = ["alpha"] });
+
+        matches.Should().ContainSingle()
+            .Which.PipelineName.Should().Be("fix-bug");
+    }
+
+    [Fact]
+    public void GlobalPipelineTriggers_ConfiguredButNoLabelMatches_DropsMatch()
+    {
+        var globalTriggers = new PipelineTriggerMap(new Dictionary<string, string>
+        {
+            ["agent-smith:bug"] = "fix-bug",
+            ["agent-smith:feature"] = "add-feature",
+        });
+        var config = ConfigWith(globalTriggers,
+            ("alpha", new TrackerConnection { Name = "gh", Type = TrackerType.GitHub },
+                project => project with { GithubTrigger = TriggerWithTag("alpha") }));
+
+        var matches = _sut.Resolve(config, new IncomingTicketEnvelope { Labels = ["alpha"] });
+
+        matches.Should().BeEmpty();
+    }
+
+    [Fact]
     public void RepoStrategy_MatchesByRepoUrl()
     {
         var url = "https://github.com/acme/app.git";
@@ -115,6 +179,11 @@ public sealed class ProjectResolverTests
 
     private static AgentSmithConfig ConfigWith(
         params (string Name, TrackerConnection Tracker, Func<ResolvedProject, ResolvedProject> Shape)[] entries)
+        => ConfigWith(PipelineTriggerMap.Empty, entries);
+
+    private static AgentSmithConfig ConfigWith(
+        PipelineTriggerMap globalTriggers,
+        params (string Name, TrackerConnection Tracker, Func<ResolvedProject, ResolvedProject> Shape)[] entries)
     {
         var projects = new Dictionary<string, ResolvedProject>();
         foreach (var (name, tracker, shape) in entries)
@@ -127,7 +196,7 @@ public sealed class ProjectResolverTests
             };
             projects[name] = shape(project);
         }
-        return new AgentSmithConfig { Projects = projects };
+        return new AgentSmithConfig { Projects = projects, PipelineTriggers = globalTriggers };
     }
 
     private static WebhookTriggerConfig TriggerWithTag(string tag) =>


### PR DESCRIPTION
## Summary

- `pipeline_from_label` (and the global `pipeline_triggers` map) is documented as the operator's strict filter on action labels, but `ProjectResolver` rescued every label-map miss with `?? trigger.DefaultPipeline`.
- Effect: a ticket that only carried the project-routing tag (e.g. a Tag-strategy match like a target/customer label) ran the default pipeline regardless of which action labels were set — every tagged ticket was accepted.
- Fix: drop the rescue. When the map is configured and no label matches, the project match is dropped. `DefaultPipeline` still applies when no label-map is configured at all (handled inside `PipelineResolver`).

## Test plan

- [x] `dotnet test tests/AgentSmith.Tests/AgentSmith.Tests.csproj` — 1928/1928 green
- [x] New tests cover: strict-filter miss drops, strict-filter hit returns mapped pipeline, no-map config falls back to `DefaultPipeline`, global `pipeline_triggers` miss also drops
- [ ] Smoke test against a config with `pipeline_from_label` + tagged ticket without an action label (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)