### PR TITLE
fix(output): meta-observation for empty skill responses + Code Findin…

### DIFF
--- a/src/AgentSmith.Application/Services/Handlers/ObservationRecoveryHelper.cs
+++ b/src/AgentSmith.Application/Services/Handlers/ObservationRecoveryHelper.cs
@@ -42,6 +42,21 @@ internal static class ObservationRecoveryHelper
     internal static List<SkillObservation> FallbackSingle(
         string response, string role, int startId, ILogger? logger)
     {
+        if (string.IsNullOrWhiteSpace(response))
+        {
+            logger?.LogWarning(
+                "Skill {Role} returned an empty response; no observations to parse", role);
+            return
+            [
+                new SkillObservation(
+                    Id: startId, Role: role, Concern: ObservationConcern.Correctness,
+                    Description: $"Skill '{role}' returned an empty response — no observations could be parsed.",
+                    Suggestion: "", Blocking: false,
+                    Severity: ObservationSeverity.Info, Confidence: 0,
+                    Rationale: "Auto-wrapped: LLM returned no content",
+                    Category: ExecutionLimitCategories.ExecutionParseFailure)
+            ];
+        }
         logger?.LogWarning("Could not parse observations from {Role}, wrapping as single observation", role);
         return
         [

--- a/src/AgentSmith.Application/Services/SkillRounds/DiscussionRoundExecutor.cs
+++ b/src/AgentSmith.Application/Services/SkillRounds/DiscussionRoundExecutor.cs
@@ -33,7 +33,15 @@ public sealed class DiscussionRoundExecutor(
             skillName, role, system, userPrefix, userSuffix, toolPolicy, pipeline, cancellationToken);
         if (SkillCallOutcomeTranslator.TranslateDiscussion(result, skillName, role, logger) is { } earlyFail)
             return earlyFail;
-        var parsed = responseParser.ParseAndDowngrade(result.Output ?? string.Empty, skillName, logger, result.ReadPaths);
+        // Empty output is treated as zero observations; the parser's prose-wrap
+        // fallback was emitting ghost INFO entries when the runtime skipped the
+        // call (cost cap, exec-limit). The reason is already encoded as a typed
+        // RuntimeObservation below — surface that instead of a placeholder.
+        var parsed = string.IsNullOrWhiteSpace(result.Output)
+            ? new List<SkillObservation>()
+            : responseParser.ParseAndDowngrade(result.Output, skillName, logger, result.ReadPaths);
+        if (result.RuntimeObservations.Count > 0)
+            parsed.AddRange(result.RuntimeObservations);
         StorePlanArtifactIfPlanLead(skillName, pipeline, parsed);
         var entry = new DiscussionEntry(
             skillName, role.DisplayName, role.Emoji, round, responseParser.RenderObservationsAsText(parsed));

--- a/src/AgentSmith.Contracts/Models/ExecutionLimitCategories.cs
+++ b/src/AgentSmith.Contracts/Models/ExecutionLimitCategories.cs
@@ -50,6 +50,14 @@ public static class ExecutionLimitCategories
     public const string CostCapExhausted = "cost-cap-exhausted";
 
     /// <summary>
+    /// Skill returned a response the observation parser could not extract
+    /// any structured observations from (empty / whitespace). Recorded as a
+    /// meta-observation so operators see the silent drop without polluting
+    /// the severity tally with an empty-description placeholder.
+    /// </summary>
+    public const string ExecutionParseFailure = "execution-parse-failure";
+
+    /// <summary>
     /// True when <paramref name="category"/> is any of the runtime-emitted
     /// execution-limit / execution-error markers. Output strategies use this
     /// to render the observation with a distinct prefix.
@@ -59,5 +67,6 @@ public static class ExecutionLimitCategories
         or ExecutionLimitTokens
         or ExecutionLimitWallClock
         or ExecutionError
-        or CostCapExhausted;
+        or CostCapExhausted
+        or ExecutionParseFailure;
 }

--- a/src/AgentSmith.Infrastructure/Services/Output/ConsoleOutputStrategy.cs
+++ b/src/AgentSmith.Infrastructure/Services/Output/ConsoleOutputStrategy.cs
@@ -128,6 +128,8 @@ public sealed class ConsoleOutputStrategy(
         ExecutionLimitCategories.ExecutionLimitTokens => "token limit",
         ExecutionLimitCategories.ExecutionLimitWallClock => "wall-clock limit",
         ExecutionLimitCategories.ExecutionError => "runtime error",
+        ExecutionLimitCategories.CostCapExhausted => "cost cap",
+        ExecutionLimitCategories.ExecutionParseFailure => "parse failure",
         _ => "execution limit"
     };
 

--- a/src/AgentSmith.Infrastructure/Services/Output/SummaryOutputStrategy.cs
+++ b/src/AgentSmith.Infrastructure/Services/Output/SummaryOutputStrategy.cs
@@ -56,6 +56,8 @@ public sealed partial class SummaryOutputStrategy(
             }
         }
 
+        AppendEvidenceBreakdown(sb, operatorObs);
+
         sb.AppendLine($"Total: {findings.Count} findings");
 
         if (limitObs.Count > 0)
@@ -78,6 +80,38 @@ public sealed partial class SummaryOutputStrategy(
             "Summary delivered ({Count} findings, {Limits} limit hits)",
             findings.Count, limitObs.Count);
         return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Surfaces evidence-mode breakdown — how many findings are code-grounded
+    /// (analyzed_from_source) vs HTTP-probe-confirmed vs schema/inferred. Lists
+    /// the source-anchored findings inline with file:line so operators can tell
+    /// at a glance whether the run produced real code analysis or stayed at
+    /// schema-lint level.
+    /// </summary>
+    private static void AppendEvidenceBreakdown(StringBuilder sb, IReadOnlyList<SkillObservation> operatorObservations)
+    {
+        if (operatorObservations.Count == 0) return;
+        var sourceAnchored = operatorObservations
+            .Where(o => o.EvidenceMode == EvidenceMode.AnalyzedFromSource)
+            .ToList();
+        var confirmed = operatorObservations.Count(o => o.EvidenceMode == EvidenceMode.Confirmed);
+        var schema = operatorObservations.Count - sourceAnchored.Count - confirmed;
+
+        if (sourceAnchored.Count == 0)
+        {
+            sb.AppendLine($"Evidence: 0 from source, {confirmed} confirmed, {schema} schema/inferred");
+            sb.AppendLine();
+            return;
+        }
+
+        sb.AppendLine($"Code Findings ({sourceAnchored.Count})");
+        foreach (var obs in sourceAnchored.OrderBy(o => SeverityOrder(o.Severity.ToString())))
+            sb.AppendLine(
+                $"  [{obs.Severity.ToString().ToUpperInvariant()}] {obs.DisplayLocation} — {ExtractTitle(obs.Description)}");
+        sb.AppendLine();
+        sb.AppendLine($"Evidence: {sourceAnchored.Count} from source, {confirmed} confirmed, {schema} schema/inferred");
+        sb.AppendLine();
     }
 
     private void AppendVerification(StringBuilder sb, IReadOnlyList<SkillObservation> operatorObservations)
@@ -114,6 +148,8 @@ public sealed partial class SummaryOutputStrategy(
         ExecutionLimitCategories.ExecutionLimitTokens => "token limit",
         ExecutionLimitCategories.ExecutionLimitWallClock => "wall-clock limit",
         ExecutionLimitCategories.ExecutionError => "runtime error",
+        ExecutionLimitCategories.CostCapExhausted => "cost cap",
+        ExecutionLimitCategories.ExecutionParseFailure => "parse failure",
         _ => "execution limit"
     };
 

--- a/tests/AgentSmith.Tests/Output/SummaryEvidenceBreakdownTests.cs
+++ b/tests/AgentSmith.Tests/Output/SummaryEvidenceBreakdownTests.cs
@@ -1,0 +1,106 @@
+using AgentSmith.Contracts.Commands;
+using AgentSmith.Contracts.Models;
+using AgentSmith.Contracts.Services;
+using AgentSmith.Infrastructure.Services.Output;
+using AgentSmith.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace AgentSmith.Tests.Output;
+
+public sealed class SummaryEvidenceBreakdownTests
+{
+    [Fact]
+    public async Task SourceAnchoredFindings_RenderInDedicatedCodeFindingsSection()
+    {
+        var observations = new List<SkillObservation>
+        {
+            ObservationFactory.Make("HIGH", "Program.cs", 15, "JWT misconfig", "", 90,
+                evidence: EvidenceMode.AnalyzedFromSource),
+            ObservationFactory.Make("MEDIUM", "Program.cs", 45, "CORS too permissive", "", 80,
+                evidence: EvidenceMode.AnalyzedFromSource),
+            ObservationFactory.Make("HIGH", "src/X.cs", 0, "Schema lint", "", 70,
+                evidence: EvidenceMode.Potential, apiPath: "/users"),
+        };
+
+        var output = await CaptureSummaryAsync(observations);
+
+        output.Should().Contain("Code Findings (2)");
+        output.Should().Contain("Program.cs:15");
+        output.Should().Contain("Program.cs:45");
+        output.Should().Contain("JWT misconfig");
+        output.Should().Contain("CORS too permissive");
+    }
+
+    [Fact]
+    public async Task NoSourceAnchoredFindings_RendersEvidenceLineOnly_NoCodeFindingsHeader()
+    {
+        var observations = new List<SkillObservation>
+        {
+            ObservationFactory.Make("HIGH", "", 0, "Schema lint", "", 70,
+                evidence: EvidenceMode.Potential, apiPath: "/users"),
+        };
+
+        var output = await CaptureSummaryAsync(observations);
+
+        output.Should().NotContain("Code Findings");
+        output.Should().Contain("Evidence: 0 from source, 0 confirmed, 1 schema/inferred");
+    }
+
+    [Fact]
+    public async Task MixedEvidence_TalliesAllThreeCategories()
+    {
+        var observations = new List<SkillObservation>
+        {
+            ObservationFactory.Make("HIGH", "Program.cs", 15, "JWT", "", 90,
+                evidence: EvidenceMode.AnalyzedFromSource),
+            ObservationFactory.Make("HIGH", "", 0, "Probe hit", "", 85,
+                evidence: EvidenceMode.Confirmed, apiPath: "/admin"),
+            ObservationFactory.Make("MEDIUM", "", 0, "Schema lint", "", 70,
+                evidence: EvidenceMode.Potential, apiPath: "/users"),
+            ObservationFactory.Make("LOW", "", 0, "Schema lint", "", 60,
+                evidence: EvidenceMode.Potential, apiPath: "/posts"),
+        };
+
+        var output = await CaptureSummaryAsync(observations);
+
+        output.Should().Contain("Code Findings (1)");
+        output.Should().Contain("Evidence: 1 from source, 1 confirmed, 2 schema/inferred");
+    }
+
+    [Fact]
+    public async Task ParseFailureMetaObservation_FiltersOutOfFindingsTally_RendersInLimitsFooter()
+    {
+        var observations = new List<SkillObservation>
+        {
+            ObservationFactory.Make("HIGH", "Program.cs", 15, "JWT", "", 90,
+                evidence: EvidenceMode.AnalyzedFromSource),
+            new(
+                Id: 99, Role: "report-synthesizer",
+                Concern: ObservationConcern.Correctness,
+                Description: "Skill 'report-synthesizer' returned an empty response — no observations could be parsed.",
+                Suggestion: "", Blocking: false,
+                Severity: ObservationSeverity.Info, Confidence: 0,
+                Category: ExecutionLimitCategories.ExecutionParseFailure),
+        };
+
+        var output = await CaptureSummaryAsync(observations);
+
+        output.Should().Contain("Total: 1 findings");
+        output.Should().Contain("Execution limits hit: 1");
+        output.Should().Contain("[parse failure]");
+    }
+
+    private static async Task<string> CaptureSummaryAsync(IReadOnlyList<SkillObservation> observations)
+    {
+        var pipeline = new PipelineContext();
+        var ctx = new OutputContext("test", null, observations, null, "./test-output", pipeline);
+        var sut = new SummaryOutputStrategy(new AnchoringVerifier(), NullLogger<SummaryOutputStrategy>.Instance);
+        var original = Console.Out;
+        await using var capture = new StringWriter();
+        Console.SetOut(capture);
+        try { await sut.DeliverAsync(ctx); }
+        finally { Console.SetOut(original); }
+        return capture.ToString();
+    }
+}

--- a/tests/AgentSmith.Tests/Services/ObservationParserEmptyResponseTests.cs
+++ b/tests/AgentSmith.Tests/Services/ObservationParserEmptyResponseTests.cs
@@ -1,0 +1,68 @@
+using AgentSmith.Application.Services.Handlers;
+using AgentSmith.Contracts.Models;
+using AgentSmith.Contracts.Services;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace AgentSmith.Tests.Services;
+
+/// <summary>
+/// Covers the empty-response branch of <see cref="ObservationRecoveryHelper.FallbackSingle"/>.
+/// When a skill returns nothing parseable AND nothing renderable, the fallback used to emit a
+/// SkillObservation with empty Description / Confidence=50 — surfaced to operators as a ghost
+/// INFO finding. The fix emits a meta-observation with Category=execution-parse-failure so the
+/// output strategies filter it out of the severity tally and into the limits footer.
+/// </summary>
+public sealed class ObservationParserEmptyResponseTests
+{
+    private readonly ObservationParser _parser;
+
+    public ObservationParserEmptyResponseTests()
+    {
+        var tolerantParser = new Mock<ITolerantJsonParser>();
+        tolerantParser.Setup(p => p.ParseArray(It.IsAny<string>()))
+            .Returns(new TolerantParseResult(null, Array.Empty<TolerantParseDiagnostic>()));
+        tolerantParser.Setup(p => p.ExtractArrayObjects(It.IsAny<string>())).Returns(Array.Empty<string>());
+        var normalizer = new Mock<IObservationNormalizer>();
+        var anchorValidator = new Mock<ISourceAnchorValidator>();
+        anchorValidator
+            .Setup(v => v.EnforceAnchor(It.IsAny<SkillObservation>(), It.IsAny<IReadOnlyCollection<string>?>(), It.IsAny<string>(), It.IsAny<Microsoft.Extensions.Logging.ILogger?>()))
+            .Returns<SkillObservation, IReadOnlyCollection<string>?, string, Microsoft.Extensions.Logging.ILogger?>((o, _, _, _) => o);
+        _parser = new ObservationParser(tolerantParser.Object, normalizer.Object, anchorValidator.Object);
+    }
+
+    [Fact]
+    public void Parse_EmptyResponse_EmitsMetaObservation_NotEmptyPlaceholder()
+    {
+        var result = _parser.Parse(string.Empty, "report-synthesizer", 1, NullLogger.Instance);
+
+        result.Should().HaveCount(1);
+        result[0].Category.Should().Be(ExecutionLimitCategories.ExecutionParseFailure);
+        result[0].Description.Should().Contain("report-synthesizer");
+        result[0].Description.Should().Contain("empty response");
+        result[0].Confidence.Should().Be(0);
+        result[0].Severity.Should().Be(ObservationSeverity.Info);
+    }
+
+    [Fact]
+    public void Parse_WhitespaceOnlyResponse_EmitsMetaObservation()
+    {
+        var result = _parser.Parse("   \n\t  ", "jwt-validation-judge", 1, NullLogger.Instance);
+
+        result.Should().HaveCount(1);
+        result[0].Category.Should().Be(ExecutionLimitCategories.ExecutionParseFailure);
+        result[0].Description.Should().Contain("jwt-validation-judge");
+    }
+
+    [Fact]
+    public void Parse_NonEmptyUnparseableResponse_PreservesWrappingBehaviour()
+    {
+        var result = _parser.Parse("This is not JSON, just prose.", "architect", 1, NullLogger.Instance);
+
+        result.Should().HaveCount(1);
+        result[0].Category.Should().BeNull();
+        result[0].Description.Should().Contain("This is not JSON");
+        result[0].Confidence.Should().Be(50);
+    }
+}

--- a/tests/AgentSmith.Tests/SkillRounds/DiscussionRoundExecutorRuntimeObsTests.cs
+++ b/tests/AgentSmith.Tests/SkillRounds/DiscussionRoundExecutorRuntimeObsTests.cs
@@ -1,0 +1,204 @@
+using AgentSmith.Application.Models;
+using AgentSmith.Application.Services;
+using AgentSmith.Application.Services.SkillRounds;
+using AgentSmith.Contracts.Commands;
+using AgentSmith.Contracts.Models;
+using AgentSmith.Contracts.Models.Configuration;
+using AgentSmith.Contracts.Models.Skills;
+using AgentSmith.Contracts.Services;
+using AgentSmith.Domain.Models;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace AgentSmith.Tests.SkillRounds;
+
+/// <summary>
+/// Regression: when SkillCallRuntime short-circuits a call (cost cap exhausted,
+/// execution-limit hit) the result carries Output=null + a typed
+/// RuntimeObservation explaining the reason. Before the fix DiscussionRoundExecutor
+/// dropped the RuntimeObservations and ran the parser on the empty string,
+/// producing a ghost INFO observation with empty Description. The fix appends
+/// RuntimeObservations to the bus and skips parsing when Output is whitespace.
+/// </summary>
+public sealed class DiscussionRoundExecutorRuntimeObsTests
+{
+    [Fact]
+    public async Task CostCapExhausted_SurfacesRuntimeObservation_NotGhostInfo()
+    {
+        var costCapObs = new SkillObservation(
+            Id: 0, Role: "report-synthesizer",
+            Concern: ObservationConcern.Correctness,
+            Description: "Skill report-synthesizer skipped — pipeline cost cap exhausted (1.9065 USD / 931058 tokens).",
+            Suggestion: "", Blocking: false,
+            Severity: ObservationSeverity.Info, Confidence: 100,
+            Category: ExecutionLimitCategories.CostCapExhausted);
+
+        var dispatcher = MockDispatcher(new SkillCallResult
+        {
+            Outcome = SkillCallOutcome.Incomplete,
+            Output = null,
+            Cost = MakeCost("report-synthesizer", "judge"),
+            Trace = Array.Empty<LoopTraceEntry>(),
+            FailureReason = "cost cap exhausted",
+            RuntimeObservations = new[] { costCapObs },
+            ReadPaths = Array.Empty<string>(),
+        });
+
+        var (sut, bufferSpy) = BuildExecutor(dispatcher);
+        await sut.ExecuteAsync(
+            "report-synthesizer", MakeRole("report-synthesizer"), Array.Empty<RoleSkillDefinition>(),
+            round: 2, MockStrategy(), MockToolPolicy(), new PipelineContext(),
+            NullLogger.Instance, CancellationToken.None);
+
+        bufferSpy.Buffer.Should().NotBeNull();
+        bufferSpy.Buffer!.Observations.Should().HaveCount(1);
+        bufferSpy.Buffer.Observations[0].Category.Should().Be(ExecutionLimitCategories.CostCapExhausted);
+        bufferSpy.Buffer.Observations[0].Description.Should().Contain("cost cap exhausted");
+    }
+
+    [Fact]
+    public async Task EmptyOutput_NoRuntimeObs_ProducesZeroObservations_NoGhostFallback()
+    {
+        var dispatcher = MockDispatcher(new SkillCallResult
+        {
+            Outcome = SkillCallOutcome.Ok,
+            Output = "",
+            Cost = MakeCost("some-judge", "judge"),
+            Trace = Array.Empty<LoopTraceEntry>(),
+            RuntimeObservations = Array.Empty<SkillObservation>(),
+            ReadPaths = Array.Empty<string>(),
+        });
+
+        var (sut, bufferSpy) = BuildExecutor(dispatcher);
+        await sut.ExecuteAsync(
+            "some-judge", MakeRole("some-judge"), Array.Empty<RoleSkillDefinition>(),
+            round: 1, MockStrategy(), MockToolPolicy(), new PipelineContext(),
+            NullLogger.Instance, CancellationToken.None);
+
+        bufferSpy.Buffer!.Observations.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ParsedOutput_PlusRuntimeObs_MergesBoth()
+    {
+        var execLimitObs = new SkillObservation(
+            Id: 0, Role: "auth-tester",
+            Concern: ObservationConcern.Correctness,
+            Description: "Skill auth-tester hit per-skill tool-call cap",
+            Suggestion: "", Blocking: false,
+            Severity: ObservationSeverity.Info, Confidence: 100,
+            Category: ExecutionLimitCategories.ExecutionLimitToolCalls);
+
+        var dispatcher = MockDispatcher(new SkillCallResult
+        {
+            Outcome = SkillCallOutcome.Ok,
+            Output = "[{\"concern\":\"security\",\"description\":\"Real finding\",\"severity\":\"high\",\"confidence\":80,\"blocking\":false}]",
+            Cost = MakeCost("auth-tester", "investigator"),
+            Trace = Array.Empty<LoopTraceEntry>(),
+            RuntimeObservations = new[] { execLimitObs },
+            ReadPaths = Array.Empty<string>(),
+        });
+
+        var (sut, bufferSpy) = BuildExecutor(dispatcher);
+        await sut.ExecuteAsync(
+            "auth-tester", MakeRole("auth-tester"), Array.Empty<RoleSkillDefinition>(),
+            round: 1, MockStrategy(), MockToolPolicy(), new PipelineContext(),
+            NullLogger.Instance, CancellationToken.None);
+
+        bufferSpy.Buffer!.Observations.Should().HaveCount(2);
+        bufferSpy.Buffer.Observations.Should().Contain(o => o.Description.Contains("Real finding"));
+        bufferSpy.Buffer.Observations.Should().Contain(o => o.Category == ExecutionLimitCategories.ExecutionLimitToolCalls);
+    }
+
+    private static Mock<ISkillRoundDispatcher> MockDispatcher(SkillCallResult result)
+    {
+        var mock = new Mock<ISkillRoundDispatcher>();
+        mock.Setup(d => d.DispatchAsync(
+                It.IsAny<string>(), It.IsAny<RoleSkillDefinition>(),
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<ISkillRoundToolPolicy>(), It.IsAny<PipelineContext>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(result);
+        return mock;
+    }
+
+    private static (DiscussionRoundExecutor sut, BufferSpy spy) BuildExecutor(Mock<ISkillRoundDispatcher> dispatcher)
+    {
+        var composer = new Mock<IPromptComposer>();
+        composer.Setup(c => c.ComposeDiscussion(
+                It.IsAny<RoleSkillDefinition>(), It.IsAny<ISkillPromptStrategy>(),
+                It.IsAny<string>(), It.IsAny<int>(), It.IsAny<PipelineContext>()))
+            .Returns(("sys", "userPrefix", "userSuffix"));
+
+        var responseParser = new Mock<ISkillResponseParser>();
+        responseParser.Setup(p => p.ParseAndDowngrade(
+                It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<Microsoft.Extensions.Logging.ILogger>(), It.IsAny<IReadOnlyCollection<string>>()))
+            .Returns<string, string, Microsoft.Extensions.Logging.ILogger, IReadOnlyCollection<string>>((text, _, _, _) =>
+                string.IsNullOrWhiteSpace(text)
+                    ? new List<SkillObservation>()
+                    : new List<SkillObservation>
+                    {
+                        new(Id: 1, Role: "test",
+                            Concern: ObservationConcern.Security,
+                            Description: "Real finding",
+                            Suggestion: "", Blocking: false,
+                            Severity: ObservationSeverity.High, Confidence: 80),
+                    });
+        responseParser.Setup(p => p.RenderObservationsAsText(It.IsAny<IReadOnlyList<SkillObservation>>()))
+            .Returns("rendered");
+
+        var bufferSpy = new BufferSpy();
+        var bufferDispatcher = new Mock<ISkillRoundBufferDispatcher>();
+        bufferDispatcher.Setup(d => d.Dispatch(It.IsAny<PipelineContext>(), It.IsAny<SkillRoundBuffer>()))
+            .Callback<PipelineContext, SkillRoundBuffer>((_, buf) => bufferSpy.Buffer = buf);
+
+        var detector = new Mock<IBlockingFollowUpDetector>();
+        detector.Setup(d => d.Detect(
+                It.IsAny<IReadOnlyList<SkillObservation>>(), It.IsAny<string>(),
+                It.IsAny<RoleSkillDefinition>(), It.IsAny<IReadOnlyList<RoleSkillDefinition>>(),
+                It.IsAny<int>(), It.IsAny<string>(), It.IsAny<PipelineContext>(),
+                It.IsAny<Microsoft.Extensions.Logging.ILogger>()))
+            .Returns((CommandResult?)null);
+
+        var sut = new DiscussionRoundExecutor(
+            composer.Object, dispatcher.Object, responseParser.Object,
+            bufferDispatcher.Object, detector.Object);
+        return (sut, bufferSpy);
+    }
+
+    private static RoleSkillDefinition MakeRole(string name) =>
+        new()
+        {
+            Name = name,
+            DisplayName = name,
+            Emoji = "🔎",
+            Role = "judge",
+            Description = "test",
+            OutputSchema = "observation",
+        };
+
+    private static CallCostRecord MakeCost(string skillName, string role) =>
+        new()
+        {
+            SkillName = skillName,
+            Role = role,
+            Phase = SkillExecutionPhase.Discuss,
+            StartedAt = DateTimeOffset.UtcNow,
+        };
+
+    private static ISkillPromptStrategy MockStrategy()
+    {
+        var mock = new Mock<ISkillPromptStrategy>();
+        mock.SetupGet(s => s.SkillRoundCommandName).Returns("TestSkillRoundCommand");
+        return mock.Object;
+    }
+
+    private static ISkillRoundToolPolicy MockToolPolicy() => new Mock<ISkillRoundToolPolicy>().Object;
+
+    private sealed class BufferSpy
+    {
+        public SkillRoundBuffer? Buffer { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary

Two operator-facing regressions in the api-security-scan summary, both visible in a recent run:

1. **Ghost INFO entries** — three empty `— confidence 50` lines polluted the INFO group when three skills (`controller-implementation-reviewer`, `jwt-validation-judge`, `report-synthesizer`) returned empty responses. `ObservationRecoveryHelper.FallbackSingle` wrapped each empty response into a placeholder observation with `Description=""`.
2. **No code-findings visibility** — `SummaryOutputStrategy` grouped only by severity, so operators couldn't see whether the run produced real code-grounded findings (`EvidenceMode.AnalyzedFromSource`) or stayed at schema-lint level. In the actual run, only 4 of 31 findings were code-grounded.

## Changes

- New `ExecutionLimitCategories.ExecutionParseFailure` constant (added to `IsExecutionLimit` so output strategies route it into the limits footer, not the findings tally).
- `FallbackSingle`: when response is null/whitespace, emit one meta-observation with `Category=execution-parse-failure`, clear description naming the skill, and `Confidence=0`. Non-empty unparseable responses keep the existing prose-wrapping behaviour (still useful for operator debugging).
- `SummaryOutputStrategy.AppendEvidenceBreakdown`: adds `Code Findings (N)` section listing source-anchored observations with `[SEVERITY] file:line — title`, followed by `Evidence: N from source, N confirmed, N schema/inferred`. When zero source-anchored findings, only the tally renders (no empty header).
- `ConsoleOutputStrategy` + `SummaryOutputStrategy.LimitLabel`: recognise the new category (`parse failure`) and the previously-defined-but-unlabelled `CostCapExhausted` (`cost cap`).

## Expected effect on the user's recent run

The 3 ghost INFO lines disappear; they reappear as `[parse failure] Skill 'X' returned an empty response …` in the limits footer instead. The summary gains a `Code Findings (4)` block listing the four `Program.cs:…` source-anchored findings, plus an `Evidence: 4 from source, 0 confirmed, 27 schema/inferred` tally.

## Test plan

- [x] `dotnet build` — green
- [x] `dotnet test --filter "Category!=LiveLLM"` — 1927/1927 passed (+7 new)
- [ ] Run api-security-scan locally, verify Code Findings section + no ghost INFO entries

## Follow-up (not in this PR)

The deeper "why" behind the empty responses: those three skills route through `SkillCallRuntime`'s discussion path but don't surface in the new `skill_prompt` debug log — there's a separate code path (likely Filter or a non-orchestrated structured skill) that bypasses the runtime entirely. Worth tracing in a follow-up; outside scope of the operator-visibility fix here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)