### PR TITLE
fix(ado): render markdown comments as HTML before posting to System.History

### DIFF
--- a/src/AgentSmith.Infrastructure/AgentSmith.Infrastructure.csproj
+++ b/src/AgentSmith.Infrastructure/AgentSmith.Infrastructure.csproj
@@ -34,6 +34,11 @@
     <PackageReference Include="Octokit" Version="14.0.0" />
     <PackageReference Include="Polly" Version="8.*" />
     <PackageReference Include="YamlDotNet" Version="16.3.0" />
+    <!-- Markdown → HTML for Azure DevOps work-item comments. ADO's System.History
+         field renders HTML natively; the dedicated Comments REST API supports
+         a format=markdown query parameter but the bundled SDK (CommentCreate)
+         does not surface it, so we convert client-side before posting. -->
+    <PackageReference Include="Markdig" Version="1.2.0" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/AgentSmith.Infrastructure/Services/Providers/Tickets/AzureDevOpsTicketProvider.cs
+++ b/src/AgentSmith.Infrastructure/Services/Providers/Tickets/AzureDevOpsTicketProvider.cs
@@ -4,6 +4,7 @@ using AgentSmith.Contracts.Tickets;
 using AgentSmith.Domain.Entities;
 using AgentSmith.Domain.Exceptions;
 using AgentSmith.Domain.Models;
+using Markdig;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.Services.WebApi.Patch;
 using Microsoft.VisualStudio.Services.WebApi.Patch.Json;
@@ -88,11 +89,11 @@ public sealed class AzureDevOpsTicketProvider : ITicketProvider
             _attachmentLoader.DownloadAsync, cancellationToken);
 
     public Task UpdateStatusAsync(TicketId ticketId, string comment, CancellationToken cancellationToken)
-        => PatchAsync(ticketId, [Op("/fields/System.History", comment)], cancellationToken);
+        => PatchAsync(ticketId, [Op("/fields/System.History", ToHtml(comment))], cancellationToken);
 
     public Task CloseTicketAsync(TicketId ticketId, string resolution, CancellationToken cancellationToken)
         => PatchAsync(ticketId,
-            [Op("/fields/System.History", resolution), Op("/fields/System.State", _doneStatus)],
+            [Op("/fields/System.History", ToHtml(resolution)), Op("/fields/System.State", _doneStatus)],
             cancellationToken);
 
     public Task TransitionToAsync(TicketId ticketId, string statusName, CancellationToken cancellationToken)
@@ -106,6 +107,17 @@ public sealed class AzureDevOpsTicketProvider : ITicketProvider
 
     private static JsonPatchOperation Op(string path, string value) =>
         new() { Operation = Operation.Add, Path = path, Value = value };
+
+    // ADO's System.History field renders HTML natively; sending raw markdown
+    // produces plain-text-with-no-line-breaks in the UI. The dedicated Comments
+    // REST API accepts a `format=markdown` parameter but the bundled SDK does
+    // not surface it (CommentCreate exposes Text only). Converting client-side
+    // keeps the existing UpdateWorkItemAsync call path intact.
+    private static readonly MarkdownPipeline MarkdownPipeline =
+        new MarkdownPipelineBuilder().UseAdvancedExtensions().Build();
+
+    private static string ToHtml(string markdown) =>
+        string.IsNullOrEmpty(markdown) ? markdown : Markdown.ToHtml(markdown, MarkdownPipeline);
 
     private static string EscapeWiql(string s) => s.Replace("'", "''");
 }


### PR DESCRIPTION
## Summary

When agent-smith posts a status comment to an Azure DevOps work item, the markdown text appeared in the ADO web UI as plain text without line breaks — operator had to click into the comment and toggle the format dropdown to Markdown before it rendered.

The provider patches `System.History` which is an HTML-rendered field; the dedicated Comments REST API (\`POST /_apis/wit/workItems/{id}/comments?format=markdown\`) supports a format parameter but the bundled \`Microsoft.TeamFoundationServer.Client\` SDK's \`CommentCreate\` type exposes only \`Text\`. Rather than rip-and-replace to raw HttpClient, this PR converts markdown → HTML client-side via Markdig (the de-facto .NET markdown parser) and keeps the existing \`UpdateWorkItemAsync\` call path.

## Changes

- New dep: \`Markdig\` 1.2.0 in \`AgentSmith.Infrastructure.csproj\`
- \`AzureDevOpsTicketProvider.UpdateStatusAsync\` and \`CloseTicketAsync\`: comment text now passes through \`ToHtml()\` before being attached to the System.History patch
- \`UseAdvancedExtensions\` pipeline — tables, fenced code blocks, autolinks (matches GitHub-flavoured markdown rendering)
- Empty / null comments pass through unchanged

## Test plan

- [x] \`dotnet build\` — green
- [x] \`dotnet test --filter \"Category!=LiveLLM\"\` — 1920/1920 passed
- [ ] Run a fix-bug pipeline against a real ADO ticket; verify the work item discussion thread renders headings, lists, and code blocks correctly without the operator having to toggle format

🤖 Generated with [Claude Code](https://claude.com/claude-code)