### PR TITLE
fix(tools): deduplicate CodeChange recording by path

### DIFF
--- a/src/AgentSmith.Application/Services/Tools/FilesystemToolHost.cs
+++ b/src/AgentSmith.Application/Services/Tools/FilesystemToolHost.cs
@@ -38,6 +38,16 @@ public sealed class FilesystemToolHost : IToolHost
 
     public IReadOnlyList<CodeChange> GetChanges() => _changes.AsReadOnly();
 
+    // Dedup by path: the LLM frequently makes several edits to the same file in one run.
+    // Downstream consumers (commit comment, run-result, log "N files changed") expect a per-file set.
+    private void RecordChange(string path, string content)
+    {
+        var change = new CodeChange(new FilePath(path), content, "Modify");
+        var idx = _changes.FindIndex(c => c.Path.Value == path);
+        if (idx >= 0) _changes[idx] = change;
+        else _changes.Add(change);
+    }
+
     public IEnumerable<AIFunction> GetTools(SkillExecutionPhase? phase, string? investigatorMode)
     {
         _ = investigatorMode;
@@ -72,7 +82,7 @@ public sealed class FilesystemToolHost : IToolHost
         if (_guards.CheckWrite(path) is { } error) return error;
         var result = await _runner.WriteAsync(path, content, ct);
         if (!result.StartsWith("Error", StringComparison.Ordinal))
-            _changes.Add(new CodeChange(new FilePath(path), content, "Modify"));
+            RecordChange(path, content);
         return result;
     }
 
@@ -124,7 +134,7 @@ public sealed class FilesystemToolHost : IToolHost
         var newContent = string.Concat(content.AsSpan(0, idx), new_string, content.AsSpan(idx + old_string.Length));
         var result = await _runner.WriteAsync(path, newContent, ct);
         if (!result.StartsWith("Error", StringComparison.Ordinal))
-            _changes.Add(new CodeChange(new FilePath(path), newContent, "Modify"));
+            RecordChange(path, newContent);
         return result;
     }
 

--- a/src/AgentSmith.Infrastructure/Services/Providers/Agent/FileToolHandler.cs
+++ b/src/AgentSmith.Infrastructure/Services/Providers/Agent/FileToolHandler.cs
@@ -22,6 +22,21 @@ internal sealed class FileToolHandler(
 
     public IReadOnlyList<CodeChange> GetChanges() => _changes.AsReadOnly();
 
+    private void RecordChange(string path, string content, string changeType)
+    {
+        var idx = _changes.FindIndex(c => c.Path.Value == path);
+        if (idx >= 0)
+        {
+            // Preserve original "Create" — a file created and later modified in the same run is still a Create.
+            var effectiveType = _changes[idx].ChangeType == "Create" ? "Create" : changeType;
+            _changes[idx] = new CodeChange(_changes[idx].Path, content, effectiveType);
+        }
+        else
+        {
+            _changes.Add(new CodeChange(new FilePath(path), content, changeType));
+        }
+    }
+
     public string ReadFile(JsonNode? input)
     {
         var path = ToolParams.GetString(input, "path");
@@ -71,7 +86,7 @@ internal sealed class FileToolHandler(
             Directory.CreateDirectory(directory);
 
         File.WriteAllText(fullPath, content);
-        _changes.Add(new CodeChange(new FilePath(path), content, changeType));
+        RecordChange(path, content, changeType);
         fileReadTracker?.InvalidateRead(path);
 
         logger.LogDebug("Wrote file {Path} ({ChangeType})", path, changeType);

--- a/tests/AgentSmith.Tests/Tools/FilesystemToolHostTests.cs
+++ b/tests/AgentSmith.Tests/Tools/FilesystemToolHostTests.cs
@@ -130,6 +130,43 @@ public sealed class FilesystemToolHostTests
     }
 
     [Fact]
+    public async Task GetChanges_TwoWritesSamePath_DedupedToLatestContent()
+    {
+        var sandbox = new Mock<ISandbox>();
+        sandbox.Setup(s => s.RunStepAsync(
+                It.Is<Step>(st => st.Kind == StepKind.WriteFile),
+                It.IsAny<IProgress<StepEvent>?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new StepResult(1, Guid.NewGuid(), 0, false, 0.1, null));
+        var host = Build(sandbox.Object);
+
+        await host.WriteFile("src/x.cs", "v1");
+        await host.WriteFile("src/x.cs", "v2");
+
+        var changes = host.GetChanges();
+        changes.Should().ContainSingle();
+        changes[0].Path.Value.Should().Be("src/x.cs");
+        changes[0].Content.Should().Be("v2");
+    }
+
+    [Fact]
+    public async Task GetChanges_WritesToTwoDifferentPaths_KeepsBoth()
+    {
+        var sandbox = new Mock<ISandbox>();
+        sandbox.Setup(s => s.RunStepAsync(
+                It.Is<Step>(st => st.Kind == StepKind.WriteFile),
+                It.IsAny<IProgress<StepEvent>?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new StepResult(1, Guid.NewGuid(), 0, false, 0.1, null));
+        var host = Build(sandbox.Object);
+
+        await host.WriteFile("src/a.cs", "a");
+        await host.WriteFile("src/b.cs", "b");
+
+        host.GetChanges().Select(c => c.Path.Value).Should().BeEquivalentTo(new[] { "src/a.cs", "src/b.cs" });
+    }
+
+    [Fact]
     public async Task RunCommand_DelegatesToSandbox()
     {
         var sandbox = new Mock<ISandbox>();


### PR DESCRIPTION
## Summary

- `FilesystemToolHost.WriteFile`/`Edit` and `FileToolHandler.WriteFile` appended a new `CodeChange` entry per call, so a single file edited twice in one run produced two entries.
- Downstream drift: the ticket-completion comment listed the same file twice (see the screenshot user reported), the run-result log claimed `N files changed` where N > actual file count, and `RunResultFormatter` / `GenerateDocsHandler` had the same off-by-edit issue.
- Now both recorders replace any existing entry for the same path. `FileToolHandler` preserves the original `Create` changeType when a file is created and later modified in the same run.

## Test plan

- [x] `dotnet test tests/AgentSmith.Tests/AgentSmith.Tests.csproj` — 1940/1940 green
- [x] New tests: two writes to same path → single deduped entry with latest content; writes to two different paths → both kept

🤖 Generated with [Claude Code](https://claude.com/claude-code)