### PR TITLE
fix(sandbox): GrepStepHandler accepts file paths, not just directories

### DIFF
--- a/src/AgentSmith.Sandbox.Agent/Services/GrepStepHandler.cs
+++ b/src/AgentSmith.Sandbox.Agent/Services/GrepStepHandler.cs
@@ -96,7 +96,7 @@ internal sealed class GrepStepHandler(IProcessRunner runner, ILogger<GrepStepHan
                 if (path is null || lineText is null) continue;
                 matches.Add(new JsonObject
                 {
-                    ["path"] = System.IO.Path.GetRelativePath(root, path),
+                    ["path"] = RelativeFromRoot(root, path),
                     ["line"] = lineNumber,
                     ["text"] = TruncateLine(lineText)
                 });
@@ -131,7 +131,7 @@ internal sealed class GrepStepHandler(IProcessRunner runner, ILogger<GrepStepHan
             var info = new FileInfo(file);
             if (info.Length > MaxFileSizeBytes) return false;
             var lines = File.ReadAllLines(file);
-            var rel = System.IO.Path.GetRelativePath(root, file);
+            var rel = RelativeFromRoot(root, file);
             for (var i = 0; i < lines.Length; i++)
             {
                 if (matches.Count >= maxMatches) return true;
@@ -146,8 +146,25 @@ internal sealed class GrepStepHandler(IProcessRunner runner, ILogger<GrepStepHan
         return false;
     }
 
+    // Path.GetRelativePath returns "." when root == file, which is useless as a
+    // match-record path. When the caller targeted a single file, surface the
+    // filename instead so consumers (LLM, JSON consumers) get a meaningful anchor.
+    private static string RelativeFromRoot(string root, string file) =>
+        string.Equals(root, file, StringComparison.OrdinalIgnoreCase)
+            ? System.IO.Path.GetFileName(file)
+            : System.IO.Path.GetRelativePath(root, file);
+
     private static IEnumerable<string> EnumerateFiles(string root, string? glob)
     {
+        // Skills routinely pass a specific file path (e.g. a controller cited
+        // in an upstream observation) instead of a directory. Directory.EnumerateFiles
+        // throws DirectoryNotFoundException on a file path, masking the real
+        // intent. Handle the file case explicitly; ignore glob when targeting
+        // a single file.
+        if (File.Exists(root))
+            return new[] { root };
+        if (!Directory.Exists(root))
+            return Array.Empty<string>();
         if (string.IsNullOrEmpty(glob) || glob == "**/*")
             return Directory.EnumerateFiles(root, "*", SearchOption.AllDirectories).Where(f => !IsExcluded(f));
         var pattern = NormalizeGlobToRegex(glob);

--- a/tests/AgentSmith.Sandbox.Agent.Tests/Services/GrepStepHandlerTests.cs
+++ b/tests/AgentSmith.Sandbox.Agent.Tests/Services/GrepStepHandlerTests.cs
@@ -84,6 +84,41 @@ public sealed class GrepStepHandlerTests : IDisposable
         matches.Should().HaveCount(1, "the >1MB binary file is skipped by the managed fallback");
     }
 
+    [Fact]
+    public async Task HandleAsync_PathIsSpecificFile_ScansThatFileOnly()
+    {
+        // Skills routinely call grep with a specific file (cited from an upstream
+        // observation), not a directory. The managed fallback used to throw
+        // DirectoryNotFoundException because Directory.EnumerateFiles requires a
+        // directory; the fix detects File.Exists and scans the file directly.
+        var filePath = Path.Combine(_root, "Controller.cs");
+        File.WriteAllText(filePath, "namespace X;\npublic Result CreateApplication() { return Ok(result); }\n");
+        var handler = BuildHandlerNoRipgrep();
+        var step = new Step(1, Guid.NewGuid(), StepKind.Grep, Path: filePath, Pattern: "CreateApplication|return Ok\\(");
+
+        var result = await handler.HandleAsync(step, _ => Task.CompletedTask, CancellationToken.None);
+
+        result.ExitCode.Should().Be(0);
+        var matches = JsonSerializer.Deserialize<List<JsonElement>>(result.OutputContent!)!;
+        matches.Should().HaveCount(1);
+        matches[0].GetProperty("line").GetInt32().Should().Be(2);
+        matches[0].GetProperty("path").GetString().Should().Be("Controller.cs");
+    }
+
+    [Fact]
+    public async Task HandleAsync_PathDoesNotExist_ReturnsEmptyArray_NoException()
+    {
+        var missing = Path.Combine(_root, "does-not-exist", "ghost.cs");
+        var handler = BuildHandlerNoRipgrep();
+        var step = new Step(1, Guid.NewGuid(), StepKind.Grep, Path: missing, Pattern: "anything");
+
+        var result = await handler.HandleAsync(step, _ => Task.CompletedTask, CancellationToken.None);
+
+        result.ExitCode.Should().Be(0, "missing path is a zero-match result, not a fatal error");
+        var matches = JsonSerializer.Deserialize<List<JsonElement>>(result.OutputContent!)!;
+        matches.Should().BeEmpty();
+    }
+
     private static GrepStepHandler BuildHandlerNoRipgrep()
     {
         var runnerMock = new Mock<IProcessRunner>();


### PR DESCRIPTION
## Summary

The managed-fallback path of \`GrepStepHandler\` threw \`DirectoryNotFoundException\` when a skill called grep with a specific file path (e.g. \`RHS.AuthPort.API/Controllers/ApplicationController.cs\`) instead of a directory. Skills routinely cite a specific file from an upstream observation, so this was a common production failure mode whenever ripgrep wasn't installed in the toolchain image.

\`\`\`
warn: GrepStepHandler[0]
      Grep failed for path=RHS.AuthPort.API/Controllers/ApplicationController.cs pattern=CreateApplication|...
      System.IO.DirectoryNotFoundException: Could not find a part of the path '/work/RHS.AuthPort.API/Controllers/ApplicationController.cs'.
         at System.IO.Enumeration.FileSystemEnumerator\`1.CreateDirectoryHandle(...)
         at AgentSmith.Sandbox.Agent.Services.GrepStepHandler.EnumerateFiles(String root, String glob)
\`\`\`

The ripgrep path handled both file and directory inputs transparently — only the managed fallback broke.

## Changes

- \`EnumerateFiles\`: detect \`File.Exists(root)\` first and scan just that file (glob is ignored when targeting a single file). Non-existent paths now return an empty enumeration instead of throwing
- New helper \`RelativeFromRoot\`: \`Path.GetRelativePath\` returns \".\" when root == file, which is a useless anchor in match records. The helper returns the filename in the single-file case; the directory branch keeps existing relative-path output. Applied to both managed and ripgrep parse paths

## Tests

- \`HandleAsync_PathIsSpecificFile_ScansThatFileOnly\` — reproduces the bug from the production log
- \`HandleAsync_PathDoesNotExist_ReturnsEmptyArray_NoException\` — defence-in-depth for the missing-path case
- 68/68 sandbox-agent tests + 1930/1930 main tests pass

## Out of scope

Whether the grep tool surface should be split (file-grep vs directory-grep) for clearer LLM intent — separate discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)