### PR TITLE
feat(tools): split overloaded grep/glob/list_files into explicit primitives

### DIFF
--- a/src/AgentSmith.Application/Services/Tools/FilesystemToolHost.cs
+++ b/src/AgentSmith.Application/Services/Tools/FilesystemToolHost.cs
@@ -76,28 +76,28 @@ public sealed class FilesystemToolHost : IToolHost
         return result;
     }
 
-    [Description("Lists files and folders under the given path.")]
-    public Task<string> ListFiles(
-        [Description("Repository-relative path to list. Use '.' for the repo root.")] string path = ".",
-        [Description("Optional max depth to recurse.")] int? maxDepth = null,
+    [Description("Lists the immediate contents (files + subdirectories) of a directory. Pass depth>1 for recursive listing. Use this to discover the shape of an unfamiliar directory; use find_files when you already know a name pattern.")]
+    public Task<string> ListDirectory(
+        [Description("Repository-relative directory path. Use '.' for the repo root.")] string path = ".",
+        [Description("Recursion depth (1 = direct children only). Omit for full recursion — use sparingly on large trees.")] int? depth = null,
         CancellationToken ct = default)
     {
-        _logger?.LogInformation("tool_call: ListFiles path={Path} maxDepth={MaxDepth}", path, maxDepth);
+        _logger?.LogInformation("tool_call: ListDirectory path={Path} depth={Depth}", path, depth);
         return _guards.CheckRead(path) is { } error
             ? Task.FromResult(error)
-            : _runner.ListAsync(path, maxDepth, ct);
+            : _runner.ListAsync(path, depth, ct);
     }
 
-    [Description("Lists files matching a glob pattern. Pattern is matched against file names with -name semantics; pass '**/' prefix to indicate recursion (default is already recursive). Examples: '*.cs', '**/*.json', 'Program.cs'. Returns up to 200 matches.")]
-    public Task<string> Glob(
-        [Description("Glob pattern, e.g. '*.cs' or 'Program.cs'.")] string pattern,
-        [Description("Repository-relative base path to search from (default '.').")] string path = ".",
+    [Description("Finds files whose names match a glob pattern, tree-recursive under the given root. Use when you know the file-name shape ('*.cs', 'Program.cs', '**/Controller.cs'). For directory-shape exploration use list_directory.")]
+    public Task<string> FindFiles(
+        [Description("Glob pattern matched against file names, e.g. '*.cs' or '**/Controller.cs'.")] string pattern,
+        [Description("Repository-relative directory to search under (default '.').")] string root = ".",
         CancellationToken ct = default)
     {
-        _logger?.LogInformation("tool_call: Glob pattern={Pattern} path={Path}", pattern, path);
-        if (_guards.CheckRead(path) is { } error) return Task.FromResult(error);
+        _logger?.LogInformation("tool_call: FindFiles pattern={Pattern} root={Root}", pattern, root);
+        if (_guards.CheckRead(root) is { } error) return Task.FromResult(error);
         var namePattern = pattern.StartsWith("**/", StringComparison.Ordinal) ? pattern[3..] : pattern;
-        var cmd = $"find {ShellQuote(path)} -type f -name {ShellQuote(namePattern)} 2>/dev/null | head -200";
+        var cmd = $"find {ShellQuote(root)} -type f -name {ShellQuote(namePattern)} 2>/dev/null | head -200";
         return _runner.RunAsync(cmd, ct);
     }
 
@@ -170,19 +170,62 @@ public sealed class FilesystemToolHost : IToolHost
 
     private static string ShellQuote(string s) => "'" + s.Replace("'", "'\\''") + "'";
 
-    [Description("Searches files for a regular expression pattern under the given path.")]
-    public Task<string> Grep(
+    [Description("Searches a single file for lines matching a regular expression. Use when you already know the file path (e.g. cited in an upstream observation). For searching across a directory tree, use grep_in_tree.")]
+    public Task<string> GrepInFile(
+        [Description("Repository-relative path to a specific file.")] string path,
         [Description("Regular expression pattern to search for.")] string pattern,
-        [Description("Repository-relative path to search under.")] string path = ".",
-        [Description("Optional glob filter (e.g. '*.cs').")] string? glob = null,
         [Description("Maximum number of matches to return (default 200).")] int? maxMatches = null,
         CancellationToken ct = default)
     {
-        _logger?.LogInformation("tool_call: Grep pattern={Pattern} path={Path} glob={Glob}", pattern, path, glob);
+        _logger?.LogInformation("tool_call: GrepInFile path={Path} pattern={Pattern}", path, pattern);
+        return _guards.CheckRead(path) is { } error
+            ? Task.FromResult(error)
+            : _runner.GrepAsync(pattern, path, glob: null, maxMatches, ct);
+    }
+
+    [Description("Searches all files under a directory tree for lines matching a regular expression. Use a glob filter (e.g. '*.cs') to narrow file types. For a single known file, use grep_in_file.")]
+    public Task<string> GrepInTree(
+        [Description("Regular expression pattern to search for.")] string pattern,
+        [Description("Repository-relative directory to search under (default '.').")] string root = ".",
+        [Description("Optional glob filter for file names (e.g. '*.cs', '**/*.json').")] string? glob = null,
+        [Description("Maximum number of matches to return (default 200).")] int? maxMatches = null,
+        CancellationToken ct = default)
+    {
+        _logger?.LogInformation("tool_call: GrepInTree pattern={Pattern} root={Root} glob={Glob}", pattern, root, glob);
+        return _guards.CheckRead(root) is { } error
+            ? Task.FromResult(error)
+            : _runner.GrepAsync(pattern, root, glob, maxMatches, ct);
+    }
+
+    // Deprecated aliases — kept to preserve the contract that v2.5.1 SKILL.md
+    // files reference (`grep`, `glob`, `list_files`). The next agent-smith-skills
+    // release migrates the prompts to the new names; once a release or two has
+    // shipped with the renamed prompts, these aliases come out.
+    [Description("[DEPRECATED — use grep_in_file or grep_in_tree.] Searches files for a regular expression. Forwards to grep_in_tree when path is a directory, grep_in_file when path is a file.")]
+    public Task<string> Grep(
+        [Description("Regular expression pattern to search for.")] string pattern,
+        [Description("Repository-relative path to search under (file or directory).")] string path = ".",
+        [Description("Optional glob filter (e.g. '*.cs') — only meaningful when path is a directory.")] string? glob = null,
+        [Description("Maximum number of matches to return (default 200).")] int? maxMatches = null,
+        CancellationToken ct = default)
+    {
+        _logger?.LogInformation("tool_call: Grep [deprecated] pattern={Pattern} path={Path} glob={Glob}", pattern, path, glob);
         return _guards.CheckRead(path) is { } error
             ? Task.FromResult(error)
             : _runner.GrepAsync(pattern, path, glob, maxMatches, ct);
     }
+
+    [Description("[DEPRECATED — use find_files.] Lists files matching a glob pattern. Forwards to find_files.")]
+    public Task<string> Glob(
+        [Description("Glob pattern, e.g. '*.cs' or 'Program.cs'.")] string pattern,
+        [Description("Repository-relative base path to search from (default '.').")] string path = ".",
+        CancellationToken ct = default) => FindFiles(pattern, path, ct);
+
+    [Description("[DEPRECATED — use list_directory.] Lists files and folders under the given path. Forwards to list_directory.")]
+    public Task<string> ListFiles(
+        [Description("Repository-relative path to list. Use '.' for the repo root.")] string path = ".",
+        [Description("Optional max depth to recurse.")] int? maxDepth = null,
+        CancellationToken ct = default) => ListDirectory(path, maxDepth, ct);
 
     [Description("Runs a shell command (passed to /bin/sh -c). Destructive commands (rm/rmdir/unlink/shred/truncate/dd, raw device writes, fork bombs) are blocked by a defense-in-depth guard on top of the sandbox boundary; use find/grep/head/wc/curl/ls/cat freely.")]
     public Task<string> RunCommand(
@@ -204,11 +247,16 @@ public sealed class FilesystemToolHost : IToolHost
     private IEnumerable<AIFunction> ReadOnlySet() =>
     [
         Tool(ReadFile, "read_file"),
+        Tool(GrepInFile, "grep_in_file"),
+        Tool(GrepInTree, "grep_in_tree"),
+        Tool(FindFiles, "find_files"),
+        Tool(ListDirectory, "list_directory"),
+        Tool(RunCommand, "run_command"),
+        Tool(HttpRequest, "http_request"),
+        // Deprecated aliases — kept until agent-smith-skills migrates its prompts.
         Tool(Grep, "grep"),
         Tool(Glob, "glob"),
-        Tool(ListFiles, "list_files"),
-        Tool(RunCommand, "run_command"),
-        Tool(HttpRequest, "http_request")
+        Tool(ListFiles, "list_files")
     ];
 
     private IEnumerable<AIFunction> InvestigatorSet() => ReadOnlySet();
@@ -216,13 +264,18 @@ public sealed class FilesystemToolHost : IToolHost
     private IEnumerable<AIFunction> BootstrapSet() =>
     [
         Tool(ReadFile, "read_file"),
-        Tool(Grep, "grep"),
-        Tool(Glob, "glob"),
-        Tool(ListFiles, "list_files"),
         Tool(WriteFile, "write_file"),
         Tool(Edit, "edit"),
+        Tool(GrepInFile, "grep_in_file"),
+        Tool(GrepInTree, "grep_in_tree"),
+        Tool(FindFiles, "find_files"),
+        Tool(ListDirectory, "list_directory"),
         Tool(RunCommand, "run_command"),
-        Tool(HttpRequest, "http_request")
+        Tool(HttpRequest, "http_request"),
+        // Deprecated aliases — kept until agent-smith-skills migrates its prompts.
+        Tool(Grep, "grep"),
+        Tool(Glob, "glob"),
+        Tool(ListFiles, "list_files")
     ];
 
     private IEnumerable<AIFunction> All() =>
@@ -230,10 +283,15 @@ public sealed class FilesystemToolHost : IToolHost
         Tool(ReadFile, "read_file"),
         Tool(WriteFile, "write_file"),
         Tool(Edit, "edit"),
-        Tool(ListFiles, "list_files"),
+        Tool(ListDirectory, "list_directory"),
+        Tool(FindFiles, "find_files"),
+        Tool(GrepInFile, "grep_in_file"),
+        Tool(GrepInTree, "grep_in_tree"),
+        Tool(RunCommand, "run_command"),
+        Tool(HttpRequest, "http_request"),
+        // Deprecated aliases — kept until agent-smith-skills migrates its prompts.
         Tool(Grep, "grep"),
         Tool(Glob, "glob"),
-        Tool(RunCommand, "run_command"),
-        Tool(HttpRequest, "http_request")
+        Tool(ListFiles, "list_files")
     ];
 }

--- a/src/AgentSmith.Sandbox.Agent/Services/GrepStepHandler.cs
+++ b/src/AgentSmith.Sandbox.Agent/Services/GrepStepHandler.cs
@@ -96,7 +96,7 @@ internal sealed class GrepStepHandler(IProcessRunner runner, ILogger<GrepStepHan
                 if (path is null || lineText is null) continue;
                 matches.Add(new JsonObject
                 {
-                    ["path"] = System.IO.Path.GetRelativePath(root, path),
+                    ["path"] = RelativeFromRoot(root, path),
                     ["line"] = lineNumber,
                     ["text"] = TruncateLine(lineText)
                 });
@@ -131,7 +131,7 @@ internal sealed class GrepStepHandler(IProcessRunner runner, ILogger<GrepStepHan
             var info = new FileInfo(file);
             if (info.Length > MaxFileSizeBytes) return false;
             var lines = File.ReadAllLines(file);
-            var rel = System.IO.Path.GetRelativePath(root, file);
+            var rel = RelativeFromRoot(root, file);
             for (var i = 0; i < lines.Length; i++)
             {
                 if (matches.Count >= maxMatches) return true;
@@ -146,8 +146,25 @@ internal sealed class GrepStepHandler(IProcessRunner runner, ILogger<GrepStepHan
         return false;
     }
 
+    // Path.GetRelativePath returns "." when root == file, which is useless as a
+    // match-record path. When the caller targeted a single file, surface the
+    // filename instead so consumers (LLM, JSON consumers) get a meaningful anchor.
+    private static string RelativeFromRoot(string root, string file) =>
+        string.Equals(root, file, StringComparison.OrdinalIgnoreCase)
+            ? System.IO.Path.GetFileName(file)
+            : System.IO.Path.GetRelativePath(root, file);
+
     private static IEnumerable<string> EnumerateFiles(string root, string? glob)
     {
+        // Skills routinely pass a specific file path (e.g. a controller cited
+        // in an upstream observation) instead of a directory. Directory.EnumerateFiles
+        // throws DirectoryNotFoundException on a file path, masking the real
+        // intent. Handle the file case explicitly; ignore glob when targeting
+        // a single file.
+        if (File.Exists(root))
+            return new[] { root };
+        if (!Directory.Exists(root))
+            return Array.Empty<string>();
         if (string.IsNullOrEmpty(glob) || glob == "**/*")
             return Directory.EnumerateFiles(root, "*", SearchOption.AllDirectories).Where(f => !IsExcluded(f));
         var pattern = NormalizeGlobToRegex(glob);

--- a/tests/AgentSmith.Sandbox.Agent.Tests/Services/GrepStepHandlerTests.cs
+++ b/tests/AgentSmith.Sandbox.Agent.Tests/Services/GrepStepHandlerTests.cs
@@ -84,6 +84,41 @@ public sealed class GrepStepHandlerTests : IDisposable
         matches.Should().HaveCount(1, "the >1MB binary file is skipped by the managed fallback");
     }
 
+    [Fact]
+    public async Task HandleAsync_PathIsSpecificFile_ScansThatFileOnly()
+    {
+        // Skills routinely call grep with a specific file (cited from an upstream
+        // observation), not a directory. The managed fallback used to throw
+        // DirectoryNotFoundException because Directory.EnumerateFiles requires a
+        // directory; the fix detects File.Exists and scans the file directly.
+        var filePath = Path.Combine(_root, "Controller.cs");
+        File.WriteAllText(filePath, "namespace X;\npublic Result CreateApplication() { return Ok(result); }\n");
+        var handler = BuildHandlerNoRipgrep();
+        var step = new Step(1, Guid.NewGuid(), StepKind.Grep, Path: filePath, Pattern: "CreateApplication|return Ok\\(");
+
+        var result = await handler.HandleAsync(step, _ => Task.CompletedTask, CancellationToken.None);
+
+        result.ExitCode.Should().Be(0);
+        var matches = JsonSerializer.Deserialize<List<JsonElement>>(result.OutputContent!)!;
+        matches.Should().HaveCount(1);
+        matches[0].GetProperty("line").GetInt32().Should().Be(2);
+        matches[0].GetProperty("path").GetString().Should().Be("Controller.cs");
+    }
+
+    [Fact]
+    public async Task HandleAsync_PathDoesNotExist_ReturnsEmptyArray_NoException()
+    {
+        var missing = Path.Combine(_root, "does-not-exist", "ghost.cs");
+        var handler = BuildHandlerNoRipgrep();
+        var step = new Step(1, Guid.NewGuid(), StepKind.Grep, Path: missing, Pattern: "anything");
+
+        var result = await handler.HandleAsync(step, _ => Task.CompletedTask, CancellationToken.None);
+
+        result.ExitCode.Should().Be(0, "missing path is a zero-match result, not a fatal error");
+        var matches = JsonSerializer.Deserialize<List<JsonElement>>(result.OutputContent!)!;
+        matches.Should().BeEmpty();
+    }
+
     private static GrepStepHandler BuildHandlerNoRipgrep()
     {
         var runnerMock = new Mock<IProcessRunner>();

--- a/tests/AgentSmith.Tests/Loop/ToolKitTests.cs
+++ b/tests/AgentSmith.Tests/Loop/ToolKitTests.cs
@@ -41,7 +41,10 @@ public sealed class ToolKitTests
 
         // p0151a: Plan-phase recon skills need ls/find via run_command for
         // directory inventory. WriteFile still excluded — Plan is read-side only.
-        tools.Should().Contain("read_file").And.Contain("grep").And.Contain("list_files")
+        // p0152: grep_in_file/grep_in_tree replace the overloaded grep; list_directory
+        // replaces list_files. The old names remain as deprecated aliases.
+        tools.Should().Contain("read_file")
+             .And.Contain("grep_in_tree").And.Contain("list_directory")
              .And.Contain("run_command").And.Contain("log_decision").And.Contain("ask_human");
         tools.Should().NotContain("write_file");
     }
@@ -53,10 +56,18 @@ public sealed class ToolKitTests
 
         var tools = NamesOf(kit.GetToolsFor("fix-bug", SkillExecutionPhase.Implementation, null, hosts));
 
-        // 8 filesystem-host tools (read, write, edit, list, grep, glob, run, http) + log_decision + ask_human
-        tools.Should().HaveCount(10);
+        // p0152: 9 new filesystem-host primitives (read/write/edit/list_directory/
+        // find_files/grep_in_file/grep_in_tree/run/http) + 3 deprecated aliases
+        // (grep/glob/list_files) + log_decision + ask_human = 14 total.
+        tools.Should().HaveCount(14);
         tools.Should().Contain(new[]
-            { "read_file", "write_file", "edit", "list_files", "grep", "glob", "run_command", "http_request", "log_decision", "ask_human" });
+        {
+            "read_file", "write_file", "edit",
+            "list_directory", "find_files", "grep_in_file", "grep_in_tree",
+            "run_command", "http_request",
+            "log_decision", "ask_human",
+            "grep", "glob", "list_files" // deprecated aliases — backward-compat for v2.5.1 skills
+        });
     }
 
     [Fact]
@@ -90,7 +101,7 @@ public sealed class ToolKitTests
         var tools = NamesOf(kit.GetToolsFor("fix-bug", null, null, hosts));
 
         // Same count as Implementation: full filesystem-host surface + log_decision + ask_human.
-        tools.Should().HaveCount(10);
+        tools.Should().HaveCount(14);
     }
 
     [Fact]

--- a/tests/AgentSmith.Tests/Tools/FilesystemToolHostTests.cs
+++ b/tests/AgentSmith.Tests/Tools/FilesystemToolHostTests.cs
@@ -22,6 +22,25 @@ public sealed class FilesystemToolHostTests
     private static IReadOnlyList<string> NamesOf(IEnumerable<AIFunction> tools)
         => tools.Select(f => f.Name).ToList();
 
+    // p0152: split the overloaded grep / glob / list_files surface into explicit
+    // primitives — grep_in_file vs grep_in_tree (file-or-directory disambiguated),
+    // find_files (was glob), list_directory (was list_files). Old names remain in
+    // every phase set as deprecated aliases until the agent-smith-skills catalog
+    // migrates its prompts; the assertions below cover both new + deprecated.
+    private static readonly string[] ReadOnlyToolNames =
+    {
+        "read_file", "grep_in_file", "grep_in_tree", "find_files", "list_directory",
+        "run_command", "http_request",
+        "grep", "glob", "list_files" // deprecated aliases
+    };
+
+    private static readonly string[] WriteCapableToolNames =
+    {
+        "read_file", "write_file", "edit", "grep_in_file", "grep_in_tree", "find_files",
+        "list_directory", "run_command", "http_request",
+        "grep", "glob", "list_files" // deprecated aliases
+    };
+
     [Fact]
     public void GetTools_PlanPhase_IncludesRunCommandForRecon()
     {
@@ -29,9 +48,7 @@ public sealed class FilesystemToolHostTests
 
         var names = NamesOf(host.GetTools(SkillExecutionPhase.Plan, null));
 
-        // Plan / Verify / Investigate / Review / Discuss / Filter / Synthesize all share
-        // the read+shell set so recon skills can run ls/find/curl freely at every stage.
-        names.Should().BeEquivalentTo("read_file", "grep", "glob", "list_files", "run_command", "http_request");
+        names.Should().BeEquivalentTo(ReadOnlyToolNames);
     }
 
     [Fact]
@@ -41,7 +58,7 @@ public sealed class FilesystemToolHostTests
 
         var names = NamesOf(host.GetTools(SkillExecutionPhase.Implementation, null));
 
-        names.Should().BeEquivalentTo("read_file", "write_file", "edit", "list_files", "grep", "glob", "run_command", "http_request");
+        names.Should().BeEquivalentTo(WriteCapableToolNames);
     }
 
     [Fact]
@@ -61,9 +78,7 @@ public sealed class FilesystemToolHostTests
 
         var names = NamesOf(host.GetTools(SkillExecutionPhase.Bootstrap, null));
 
-        // Bootstrap and Implementation are the write-capable sets; both expose
-        // edit (targeted string-replace) and write_file (full overwrite).
-        names.Should().BeEquivalentTo("read_file", "grep", "glob", "list_files", "write_file", "edit", "run_command", "http_request");
+        names.Should().BeEquivalentTo(WriteCapableToolNames);
     }
 
     [Theory]

--- a/tests/AgentSmith.Tests/Tools/ToolKitCompositionTests.cs
+++ b/tests/AgentSmith.Tests/Tools/ToolKitCompositionTests.cs
@@ -28,9 +28,13 @@ public sealed class ToolKitCompositionTests
 
         var tools = NamesOf(kit.GetToolsFor("fix-bug", SkillExecutionPhase.Plan, null, DefaultHosts()));
 
-        // Plan phase = read-side filesystem surface + log_decision + ask_human. No write_file / edit.
+        // p0152: read-side filesystem surface (new primitives + deprecated aliases)
+        // + log_decision + ask_human. No write_file / edit in Plan.
         tools.Should().BeEquivalentTo(
-            "read_file", "grep", "glob", "list_files", "run_command", "http_request", "log_decision", "ask_human");
+            "read_file", "grep_in_file", "grep_in_tree", "find_files", "list_directory",
+            "run_command", "http_request",
+            "grep", "glob", "list_files", // deprecated aliases
+            "log_decision", "ask_human");
     }
 
     [Fact]
@@ -40,8 +44,8 @@ public sealed class ToolKitCompositionTests
 
         var tools = NamesOf(kit.GetToolsFor("fix-bug", SkillExecutionPhase.Implementation, null, DefaultHosts()));
 
-        // 8 filesystem-host tools + log_decision + ask_human.
-        tools.Should().HaveCount(10);
+        // p0152: 9 new filesystem-host primitives + 3 deprecated aliases + log_decision + ask_human.
+        tools.Should().HaveCount(14);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Follow-up to PR #185, which fixed the immediate \`GrepStepHandler\` crash but left the underlying overload in place. This PR redesigns the filesystem tool surface exposed to LLMs to match the operator's mental model — each primitive does exactly one thing.

## The three overload-by-path ambiguities

| Tool | Problem |
|---|---|
| \`grep(pattern, path, glob?)\` | \`path\` could be file or directory; Description said \"search under the given path\" (primes for directory). Managed fallback crashed on file paths. Two distinct operations conflated. |
| \`glob(pattern, path)\` vs \`list_files(path, depth?)\` | Both list files under a directory. When does the LLM pick which? Unclear boundary, no doc guidance. |
| \`glob\`'s \`**/\` hint | Description said \"pass \`**/\` prefix to indicate recursion (default is already recursive)\" — the hint suggested a non-default behaviour that wasn't actually different. Self-contradictory. |

## New surface

\`\`\`
read_file(path)                                        # file only
write_file(path, content)                              # file only
edit(path, old, new)                                   # file only
list_directory(path, depth?)                           # directory contents
find_files(pattern, root?)                             # file-name discovery
grep_in_file(path, pattern, maxMatches?)               # regex in a known file
grep_in_tree(pattern, root?, glob?, maxMatches?)       # regex across a tree
run_command(cmd)                                       # raw shell
http_request(method, url, ...)                         # HTTP probing
\`\`\`

Each tool has a single, unambiguous responsibility. Descriptions cross-reference the right alternative (\"For a single known file, use grep_in_file\") so the LLM never picks the wrong primitive.

## Backward compatibility

Deprecated aliases (\`grep\`, \`glob\`, \`list_files\`) remain in every phase set, forwarding to the new implementations with \`[DEPRECATED ...]\` in their Description. They stay until the agent-smith-skills v2.6+ release migrates its SKILL.md prompts:

\`\`\`
16 files reference 'grep'        (agent-smith-skills/skills/**/SKILL.md)
12 files reference 'glob'
 1 file references  'list_files'
\`\`\`

Once skills migration ships, the aliases come out in a follow-up PR.

## Test plan

- [x] \`dotnet build\` — green
- [x] \`dotnet test --filter \"Category!=LiveLLM\"\` — 1930/1930 passed (3 test files updated for the new + deprecated split)
- [ ] Coordinated agent-smith-skills PR migrating 16+12+1 SKILL.md prompts to the new names
- [ ] Production run after both PRs ship — verify LLMs prefer the new primitives and the deprecated-alias warnings (in Description) show up in the tool-call traces

🤖 Generated with [Claude Code](https://claude.com/claude-code)