### PR TITLE
feat(tools): MCP/Claude-Code parity for filesystem + shell surface (p0153)

### DIFF
--- a/.agentsmith/phases/active/p0153-tool-surface-claude-code-parity.yaml
+++ b/.agentsmith/phases/active/p0153-tool-surface-claude-code-parity.yaml
@@ -1,0 +1,186 @@
+# yaml-language-server: $schema=../../phase-spec.schema.json
+phase: p0153
+goal: "Bring FilesystemToolHost + HumanToolHost to MCP filesystem-server /
+  Claude-Code parity. Today: read_file has no offset/limit and no line
+  numbers; grep_in_* have no -A/-B/-C and no output_mode; edit has no
+  replace_all; run_command merges stdout+stderr at a hard 60s cap;
+  find_files caps silently at 200 with basename-only globs;
+  list_directory has no sizes/sort. Surface must be provider-neutral
+  (Anthropic / OpenAI strict / Azure OpenAI / Ollama) — parameters flat,
+  primitive-typed. Deprecated grep / glob / list_files aliases stay
+  registered as forwarders; p0154 removes them with the skills rename."
+
+requires: ["p0151a"]
+
+scope:
+  in: |
+    (1) read_file gains start_line + line_count + with_line_numbers
+        (default true; '   42\tcontent' format). Slice happens on the
+        agent side so unread bytes never cross the wire.
+    (2) grep_in_file + grep_in_tree gain context_before / context_after /
+        context (shorthand), output_mode {content|files_with_matches|count}
+        (default content), head_limit replaces silent MaxMatches=200.
+        Truncation appends '(truncated: N matches)'.
+    (3) edit gains replace_all (default false).
+    (4) New multi_edit(path, edits[{old_string, new_string, replace_all?}],
+        dry_run?). Atomic; dry_run returns unified diff.
+    (5) run_command gains timeout_seconds (default 60, max 600). Returns
+        labeled text: header lines (exit_code, elapsed_ms, truncated)
+        then 'stdout:' + 'stderr:' sections — not a JSON blob.
+    (6) find_files: head_limit (default 1000), truncation marker, glob
+        semantics flip from basename (-name) to path-relative (MCP
+        search_files shape). BREAKING for existing skill callers — p0154
+        owns the skills-side glob audit.
+    (7) list_directory gains with_sizes + sort_by {name|size|mtime}.
+        New directory_tree(root, max_depth?, exclude_globs?) tool.
+    (8) ask_human gains flat choices [{label, description?}] +
+        top-level recommended_index. No per-choice 'recommended' flag.
+    (9) SourceAnchoringPreamble names only the new tool set. Deprecated
+        aliases stay registered but unnamed.
+
+  out: |
+    Removing the deprecated aliases or the agent-smith-skills rename —
+    p0154.
+    web_fetch tool — p0154.
+    search_web / search providers — deferred (no provider account).
+    Hosting an MCP server in the sandbox — separate transport question.
+    Image / PDF read; symbol-aware tools; background run_command —
+    out of scope.
+
+decisions:
+  - key: |
+      Mirror MCP filesystem-server schemas where they exist; Claude-Code
+      grep/run_command shape where MCP is silent. — Cross-provider:
+      MCP is the only published shape that OpenAI Assistants /
+      Anthropic / Ollama tool callers all consume. Where neither
+      upstream covers the need (line-range reads), the parameter names
+      stay descriptive and the [Description] text carries the load.
+
+  - key: |
+      run_command returns labeled text sections, not JSON. — JSON-in-
+      string forces every model to re-parse and small Ollama models
+      fail at that. Labeled sections mirror Claude Code's Bash tool
+      and are how every CLI tool already prints its output, so they
+      land in the training distribution naturally.
+
+  - key: |
+      Every parameter primitive or array-of-object-of-primitives, max
+      one nesting level. — OpenAI strict mode rejects deep nesting;
+      small Ollama models silently misformat it. recommended_index
+      lives on top-level for the same reason.
+
+  - key: |
+      Aliases stay in p0153; removal + skills rename ship together in
+      p0154. — Decouples the C# release from the cross-repo skills
+      bump. Preamble names only the new tools so the LLM is never
+      told to use the deprecated names.
+
+  - key: |
+      find_files flips to path-relative globbing (MCP search_files
+      shape). — Stronger than basename and more intuitive for non-Claude
+      models. Behaviour break for existing callers; p0154's skills
+      sweep audits the patterns.
+
+  - key: |
+      Default head_limit = 1000; drop the silent 200 cap. — 200 was a
+      cap that never surfaced. 1000 is a working ceiling; callers can
+      pass higher; truncation is now visible.
+
+steps:
+  - id: wire
+    action: "Extend Step record + StepKind with new fields and DirectoryTree kind; rename MaxMatches -> HeadLimit; new enums GrepOutputMode + DirectorySortBy; SizeLimits gains GrepDefaultHeadLimit + RunCommandMaxBufferBytes."
+    modify:
+      - "src/AgentSmith.Sandbox.Wire/Step.cs"
+      - "src/AgentSmith.Sandbox.Wire/StepKind.cs"
+      - "src/AgentSmith.Sandbox.Wire/SizeLimits.cs"
+
+  - id: handlers
+    action: "FileStepHandler: line-range read + line numbering + with_sizes/sort_by listing. GrepStepHandler: context_before/after, output_mode (ripgrep flags + managed fallback), head_limit. New DirectoryTreeStepHandler. StepExecutor routes DirectoryTree."
+    modify:
+      - "src/AgentSmith.Sandbox.Agent/Services/FileStepHandler.cs"
+      - "src/AgentSmith.Sandbox.Agent/Services/GrepStepHandler.cs"
+      - "src/AgentSmith.Sandbox.Agent/Services/StepExecutor.cs"
+    new:
+      - "src/AgentSmith.Sandbox.Agent/Services/DirectoryTreeStepHandler.cs"
+
+  - id: in-process-sandbox-parity
+    action: "InProcessSandbox handles the new Step fields the same way the agent-mode handlers do (CLI smoke and unit tests run through this path)."
+    modify:
+      - "src/AgentSmith.Infrastructure/Services/Sandbox/InProcessSandbox.cs"
+
+  - id: runner
+    action: "SandboxStepRunner exposes the new fields; RunAsync collects stdout/stderr into separate buffers and emits the labeled-section format."
+    modify:
+      - "src/AgentSmith.Application/Services/Tools/SandboxStepRunner.cs"
+
+  - id: tool-host
+    action: "FilesystemToolHost: new read_file params, grep context/modes/head_limit, edit.replace_all, new multi_edit (atomic + dry_run), find_files path-relative + head_limit + truncation, list_directory with_sizes + sort_by, new directory_tree, run_command timeout_seconds + labeled-section output. Deprecated grep/glob/list_files stay registered as forwarders."
+    modify:
+      - "src/AgentSmith.Application/Services/Tools/FilesystemToolHost.cs"
+
+  - id: human-tool-host
+    action: "HumanToolHost: choices: List<{label, description?}> + top-level recommended_index. DialogQuestion + IDialogueTransport carry the new shape."
+    modify:
+      - "src/AgentSmith.Application/Services/Tools/HumanToolHost.cs"
+      - "src/AgentSmith.Contracts/Dialogue/DialogQuestion.cs"
+      - "src/AgentSmith.Contracts/Dialogue/IDialogueTransport.cs"
+
+  - id: preamble
+    action: "SourceAnchoringPreamble.Build() names the new tool set; deprecated names not mentioned."
+    modify:
+      - "src/AgentSmith.Application/Services/Prompts/SourceAnchoringPreamble.cs"
+
+  - id: tests
+    action: "Existing tests updated for renamed wire fields; new tests cover new behaviour + JSON-schema flatness invariant."
+    modify:
+      - "tests/AgentSmith.Sandbox.Agent.Tests/Services/GrepStepHandlerTests.cs"
+    new:
+      - "tests/AgentSmith.Tests/Tools/FilesystemToolHostReadRangeTests.cs"
+      - "tests/AgentSmith.Tests/Tools/FilesystemToolHostGrepModesTests.cs"
+      - "tests/AgentSmith.Tests/Tools/FilesystemToolHostEditReplaceAllTests.cs"
+      - "tests/AgentSmith.Tests/Tools/FilesystemToolHostMultiEditTests.cs"
+      - "tests/AgentSmith.Tests/Tools/FilesystemToolHostRunCommandTests.cs"
+      - "tests/AgentSmith.Tests/Tools/FilesystemToolHostFindFilesTests.cs"
+      - "tests/AgentSmith.Tests/Tools/FilesystemToolHostListDirectoryTests.cs"
+      - "tests/AgentSmith.Tests/Tools/FilesystemToolHostDirectoryTreeTests.cs"
+      - "tests/AgentSmith.Tests/Tools/HumanToolHostRichChoicesTests.cs"
+      - "tests/AgentSmith.Tests/Tools/ToolSurfaceSchemaFlatnessTests.cs"
+      - "tests/AgentSmith.Tests/Prompts/SourceAnchoringPreambleParityTests.cs"
+      - "tests/AgentSmith.Sandbox.Agent.Tests/Services/GrepStepHandlerContextTests.cs"
+      - "tests/AgentSmith.Sandbox.Agent.Tests/Services/FileStepHandlerLineRangeTests.cs"
+      - "tests/AgentSmith.Sandbox.Agent.Tests/Services/DirectoryTreeStepHandlerTests.cs"
+
+tests:
+  - "FilesystemToolHost_ReadFile_WithStartLineAndLineCount_ReturnsSlice"
+  - "FilesystemToolHost_ReadFile_DefaultsToLineNumberedOutput"
+  - "FilesystemToolHost_GrepInTree_OutputModeFilesWithMatches_ReturnsPathsOnly"
+  - "FilesystemToolHost_GrepInTree_OutputModeCount_ReturnsPerFileCounts"
+  - "FilesystemToolHost_GrepInTree_WithContext_IncludesAdjacentLines"
+  - "FilesystemToolHost_GrepInTree_OverHeadLimit_AppendsTruncationMarker"
+  - "FilesystemToolHost_Edit_ReplaceAllTrue_ReplacesEveryOccurrence"
+  - "FilesystemToolHost_MultiEdit_AppliesAllEditsAtomically"
+  - "FilesystemToolHost_MultiEdit_OneEditFails_NothingWritten"
+  - "FilesystemToolHost_MultiEdit_DryRun_ReturnsDiffAndDoesNotWrite"
+  - "FilesystemToolHost_RunCommand_ReturnsLabeledSections"
+  - "FilesystemToolHost_RunCommand_TimeoutOverride_HonouredUpToCeiling"
+  - "FilesystemToolHost_FindFiles_PathRelativeMatching"
+  - "FilesystemToolHost_FindFiles_OverHeadLimit_AppendsTruncationMarker"
+  - "FilesystemToolHost_ListDirectory_WithSizes_IncludesSizeColumn"
+  - "FilesystemToolHost_ListDirectory_SortBySize_OrdersDescending"
+  - "FilesystemToolHost_DirectoryTree_ReturnsNestedRepresentation"
+  - "HumanToolHost_AskHuman_RichChoices_CarriedThroughTransport"
+  - "HumanToolHost_AskHuman_RecommendedIndex_OnTopLevel"
+  - "ToolSurfaceSchema_EveryParameter_IsPrimitiveOrArrayOfFlatObject"
+  - "ToolSurfaceSchema_PassesOpenAiStrictModeValidation"
+  - "SourceAnchoringPreamble_NamesNewToolSet_NoDeprecatedAliases"
+  - "GrepStepHandler_RoundTripsContextBeforeAndAfter"
+  - "FileStepHandler_RoundTripsStartLineAndLineCount"
+
+done:
+  - "Tool surface matches the goal-listed schemas; [Description] attributes diff-cleanly against MCP filesystem-server + Claude-Code references."
+  - "Flatness invariant test green; generated schema passes OpenAI strict-mode validation."
+  - "Preamble names new tools, no deprecated aliases."
+  - "Deprecated aliases still registered as forwarders (p0154 removes them)."
+  - "Full test suite green; /smoke green for api-scan + security-scan + fix-bug."
+  - "Cross-provider smoke: >= 2 of {Anthropic, OpenAI strict, Azure OpenAI, Ollama} run the same micro-task green using whichever credentials the smoke environment has."
+  - "build-verifier + test-verifier run dotnet build / dotnet test on this repo within the new timeout_seconds — exit code, stdout, stderr come back labeled and parseable."

--- a/.agentsmith/phases/planned/p0154-web-tools-and-skills-rename.yaml
+++ b/.agentsmith/phases/planned/p0154-web-tools-and-skills-rename.yaml
@@ -1,0 +1,147 @@
+# yaml-language-server: $schema=../../phase-spec.schema.json
+phase: p0154
+goal: "Ship the work that hangs off the agent-smith-skills minor release that
+  pairs with p0153's filesystem-tool parity: web_fetch as a new tool host,
+  removal of the deprecated grep / glob / list_files aliases from
+  FilesystemToolHost, and the cross-repo SKILL.md sweep that renames the
+  old tool calls and audits glob patterns for the new path-relative
+  find_files semantics. All three deltas land in one skills minor bump
+  so installations either have the full new surface or the full old one
+  — no half-migrated state.
+
+  References:
+  github.com/modelcontextprotocol/servers/tree/main/src/fetch
+  HtmlAgilityPack + ReverseMarkdown (NuGet, both BSD/MIT)"
+
+requires: ["p0153"]
+
+scope:
+  in: |
+    (1) New WebToolHost class hosting web_fetch(url, max_length?,
+        start_index?, raw?). Mirrors MCP fetch-server. Default: HTTP GET,
+        HTML → markdown (HtmlAgilityPack + ReverseMarkdown), truncate to
+        max_length (default 100000), start_index for pagination. raw=true
+        skips conversion. Lives in the C# process (no sandbox round-trip
+        — the agent already reaches the open internet for the live LLM
+        calls). Wired into AgenticToolSurface alongside existing hosts.
+
+    (2) Drop deprecated aliases (grep, glob, list_files) from
+        FilesystemToolHost. ReadOnlySet / BootstrapSet / All registrations
+        contain only the post-p0153 tool set.
+
+    (3) agent-smith-skills working copy:
+        - Every SKILL.md referencing grep / glob / list_files renamed to
+          grep_in_tree / grep_in_file / find_files / list_directory.
+        - Glob-pattern audit: every find_files / glob call's pattern is
+          verified against the new path-relative matching semantics
+          p0153 ships. Basename-only patterns like 'Controller.cs' that
+          relied on the old -name behaviour become '**/Controller.cs'.
+        - Skills that historically said 'I cannot look up X because I have
+          no web access' updated to use web_fetch where they have a
+          concrete URL (supply-chain-auditor, compliance-checker,
+          false-positive-filter).
+        - Package version bumped to the next minor.
+
+    (4) SourceAnchoringPreamble: no further change (p0153 already named
+        only the new tools); just verify the deprecated names do not
+        creep back into the recon-flow paragraph.
+
+  out: |
+    web_search / search-provider integration. Out per the p0153 decision
+    — no provider account; revisit when one is in place.
+
+    Any new filesystem / shell tool shape changes — p0153 owns those.
+
+    MCP-server-hosted filesystem executor. Future migration; the schemas
+    p0153 ships make it a transport swap when the time comes.
+
+decisions:
+  - key: |
+      web_fetch lives in the C# process, not the sandbox. — Sandbox is
+      the boundary for code that touches the repo working copy; web_fetch
+      reads public docs URLs and never writes anywhere. Hosting it in
+      the agent process avoids a Step round-trip for every page fetch
+      and keeps the implementation small (one HttpClient + a markdown
+      converter). The sandbox's existing http_request stays for live
+      API probing against the repo's target system. alternatives:
+      proxy web_fetch through the sandbox (rejected: no security benefit
+      since the URL is public, plus latency cost); merge with
+      http_request (rejected: different shapes — http_request returns
+      raw status + headers + body; web_fetch returns markdown-converted
+      text with pagination).
+
+  - key: |
+      Drop aliases in the same phase that ships the skills rename. —
+      The phases-decoupled grace window p0153 sketched depends on the
+      skills catalogue being updated at the same release boundary as
+      the alias removal; doing them in one phase means there is never
+      a moment where a published skill release expects tools that the
+      shipped agent-smith does not register, or vice versa.
+      alternatives: rename skills in p0153, drop aliases in p0154
+      (rejected: same coupling, different ordering, more deploy steps);
+      keep aliases indefinitely (rejected: surface-area tax).
+
+  - key: |
+      Glob-pattern audit is part of the skills sweep, not a separate
+      task. — p0153's find_files semantics change (basename →
+      path-relative) breaks silently for old patterns. The skills sweep
+      is the natural place to catch this: anyone touching a SKILL.md to
+      rename grep → grep_in_tree is also touching the file that contains
+      the glob patterns, so verify them in the same pass.
+
+steps:
+  - id: web-tool-host
+    action: "WebToolHost class with web_fetch(url, max_length?, start_index?, raw?) using HtmlAgilityPack + ReverseMarkdown. IHttpClientFactory-backed HttpClient (no direct new HttpClient). 30s default timeout, configurable."
+    new:
+      - "src/AgentSmith.Application/Services/Tools/WebToolHost.cs"
+    modify:
+      - "src/AgentSmith.Application/Services/Tools/AgenticToolSurface.cs"
+      - "src/AgentSmith.Application/Services/Prompts/SourceAnchoringPreamble.cs"
+      - "src/AgentSmith.Application/DependencyInjection/ApplicationExtensions.cs (or equivalent — locate via existing host registrations)"
+
+  - id: drop-aliases
+    action: "Remove Grep / Glob / ListFiles methods and their Tool(...) registrations from ReadOnlySet, BootstrapSet, All in FilesystemToolHost."
+    modify:
+      - "src/AgentSmith.Application/Services/Tools/FilesystemToolHost.cs"
+
+  - id: skills-rename
+    action: "SKILL.md sweep in the agent-smith-skills working copy: rename grep -> grep_in_tree (with grep_in_file when path is clearly a single file), glob -> find_files, list_files -> list_directory. Skills using find_files / glob patterns audited for path-relative compatibility; basename-style patterns rewritten with '**/' prefix where needed."
+    modify:
+      - "[../agent-smith-skills/skills/**/SKILL.md]"
+      - "[../agent-smith-skills/baselines/** if any tool names appear there]"
+
+  - id: skills-web-fetch-adoption
+    action: "Skills that historically said 'no web access' updated to use web_fetch when they have a concrete URL: supply-chain-auditor (vendor advisories), compliance-checker (standard references), false-positive-filter (CVE descriptions). Each adoption is a small focused edit, not a rewrite."
+    modify:
+      - "[../agent-smith-skills/skills/security/supply-chain-auditor/SKILL.md]"
+      - "[../agent-smith-skills/skills/security/compliance-checker/SKILL.md]"
+      - "[../agent-smith-skills/skills/security/false-positive-filter/SKILL.md]"
+      - "[../agent-smith-skills/skills/coding/false-positive-filter/SKILL.md]"
+
+  - id: skills-release
+    action: "Bump skills package version to the next minor and ship."
+    modify:
+      - "[../agent-smith-skills/package.json or VERSION or whichever file holds the version]"
+
+  - id: tests
+    action: "Cover WebToolHost behaviour and the alias-removal invariant."
+    new:
+      - "tests/AgentSmith.Tests/Tools/WebToolHostFetchTests.cs"
+      - "tests/AgentSmith.Tests/Tools/FilesystemToolHostNoDeprecatedAliasesTests.cs"
+
+tests:
+  - "WebToolHost_Fetch_DefaultMode_ReturnsMarkdownFromHtml"
+  - "WebToolHost_Fetch_RawTrue_ReturnsOriginalBody"
+  - "WebToolHost_Fetch_HonoursMaxLengthAndStartIndex"
+  - "WebToolHost_Fetch_NonHtmlContentType_ReturnsBodyUnchanged"
+  - "WebToolHost_Fetch_TimeoutHonoured"
+  - "FilesystemToolHost_ReadOnlySet_DoesNotIncludeDeprecatedAliases"
+  - "FilesystemToolHost_BootstrapSet_DoesNotIncludeDeprecatedAliases"
+  - "FilesystemToolHost_All_DoesNotIncludeDeprecatedAliases"
+
+done:
+  - "WebToolHost.web_fetch returns markdown for a known docs URL; raw mode returns the original body; max_length + start_index pagination work."
+  - "FilesystemToolHost no longer registers Grep / Glob / ListFiles in any phase. Test FilesystemToolHost_*Set_DoesNotIncludeDeprecatedAliases green."
+  - "agent-smith-skills working copy: zero SKILL.md hits for 'grep'|'glob'|'list_files' as tool names outside historical changelog text; glob patterns audited; web_fetch adopted in the three flagged skills; minor-version bumped and released."
+  - "Full test suite green; /smoke green for api-scan + security-scan + fix-bug pipelines using the post-skills-release surface."
+  - "A skill that previously had to say 'no web access' now successfully uses web_fetch in a real smoke run."

--- a/src/AgentSmith.Application/Services/Prompts/SourceAnchoringPreamble.cs
+++ b/src/AgentSmith.Application/Services/Prompts/SourceAnchoringPreamble.cs
@@ -3,15 +3,11 @@ namespace AgentSmith.Application.Services.Prompts;
 /// <summary>
 /// Produces the universal preamble prepended to every skill's system prompt.
 /// Tells the skill it is an investigator (or producer / judge) whose job
-/// is to read the files and ground its findings, lists the sandbox tools,
-/// and clarifies when each evidence_mode is appropriate. Centralized here
-/// so SKILL.md authors don't repeat themselves across 80+ catalogs.
-///
-/// History: an earlier permissive revision led to LLMs emitting potential-only
-/// observations with 0 tool calls when source was available, because the
-/// safety-net wording ("validator will downgrade automatically") was
-/// interpreted as license to skip reading. This revision pulls the LLM
-/// toward tool use via identity + concrete targets, not via threat.
+/// is to read the files and ground its findings, names the new tool set
+/// (post-p0153), and clarifies when each evidence_mode is appropriate.
+/// Deprecated aliases (grep / glob / list_files) stay registered as
+/// forwarders but are deliberately not named here, so the LLM is steered
+/// at the new names.
 /// </summary>
 public sealed class SourceAnchoringPreamble
 {
@@ -19,15 +15,23 @@ public sealed class SourceAnchoringPreamble
         "You are an investigator. Your job, when source is available, is to " +
         "read the files, get context, then judge.\n\n" +
         "Tools available in this round (the framework filters by phase, but " +
-        "the surface is uniform): read_file, grep, glob, list_files, edit, " +
-        "write_file, run_command (read-only bash; rm / rmdir / unlink / " +
-        "shred / truncate / dd are blocked), http_request (live HTTP " +
-        "probing). Plus log_decision and ask_human where wired up.\n\n" +
-        "Recon flow that produces strong findings: glob or list_files for " +
-        "the layout, grep for the security-relevant symbols, then read_file " +
-        "the 2-5 files that actually matter. A finding grounded in a file " +
-        "you opened carries evidence_mode: analyzed_from_source and cites " +
-        "the file + start_line. That is your primary deliverable.\n\n" +
+        "the surface is uniform): read_file (with start_line + line_count for " +
+        "targeted slices and line-numbered output by default), write_file, " +
+        "edit (replace_all available), multi_edit (atomic + dry_run), " +
+        "grep_in_file, grep_in_tree (context_before / context_after + " +
+        "output_mode in {content, files_with_matches, count} + head_limit), " +
+        "find_files (path-relative globs), list_directory (with_sizes + " +
+        "sort_by), directory_tree, run_command (read-only bash; rm / rmdir / " +
+        "unlink / shred / truncate / dd blocked; timeout_seconds up to 600s " +
+        "for builds), http_request (live HTTP probing). Plus log_decision " +
+        "and ask_human where wired up.\n\n" +
+        "Recon flow that produces strong findings: grep_in_tree with " +
+        "output_mode='files_with_matches' for the layout, then grep_in_tree " +
+        "in 'content' mode with context_before=2/context_after=2 on the " +
+        "interesting paths, then read_file with start_line/line_count on the " +
+        "2-5 files that actually matter. A finding grounded in a file you " +
+        "opened carries evidence_mode: analyzed_from_source and cites the " +
+        "file + start_line. That is your primary deliverable.\n\n" +
         "evidence_mode: potential is the right label for: (a) absence " +
         "findings (\"no UseHsts registration anywhere in the codebase\"), " +
         "(b) pure schema or scanner-output inference where no code applies, " +

--- a/src/AgentSmith.Application/Services/Tools/FilesystemToolHost.cs
+++ b/src/AgentSmith.Application/Services/Tools/FilesystemToolHost.cs
@@ -1,21 +1,30 @@
 using System.ComponentModel;
+using System.Text;
 using AgentSmith.Application.Models;
 using AgentSmith.Contracts.Sandbox;
 using AgentSmith.Domain.Entities;
 using AgentSmith.Domain.Models;
+using AgentSmith.Sandbox.Wire;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
 
 namespace AgentSmith.Application.Services.Tools;
 
 /// <summary>
-/// Sandbox filesystem tools (ReadFile/WriteFile/ListFiles/Grep/RunCommand).
-/// Per-phase filter: every phase set includes RunCommand — the LLM benefits
-/// from raw shell access (find/grep/head/wc/curl) at every stage. A
-/// destructive-command blocklist (<see cref="CommandGuard"/>) is applied
-/// inside RunCommand as defense-in-depth on top of the sandbox boundary.
-/// Write-capable sets (Bootstrap/Implementation) additionally include
-/// WriteFile.
+/// Sandbox filesystem + shell tools. Schemas mirror MCP filesystem-server
+/// where they exist (read/write/list/edit/tree) and Claude Code's grep + bash
+/// shapes where MCP is silent. Every parameter list is flat + primitive-typed
+/// so OpenAI strict mode and small Ollama tool calling both accept the
+/// generated JSON schema.
+///
+/// Per-phase filter: Implementation gets the full surface; Bootstrap drops
+/// run_command + http_request; Plan/Verify/Investigate get the read-only
+/// subset (read_file, grep_in_*, find_files, list_directory, directory_tree,
+/// run_command — destructive commands blocked by CommandGuard).
+///
+/// Deprecated aliases (grep / glob / list_files) stay registered as
+/// forwarders for the agent-smith-skills SKILL.md files that still call
+/// them; p0154 removes them together with the catalogue rename.
 /// </summary>
 public sealed class FilesystemToolHost : IToolHost
 {
@@ -51,15 +60,18 @@ public sealed class FilesystemToolHost : IToolHost
         };
     }
 
-    [Description("Reads the contents of a file at the given path.")]
+    [Description("Reads a file. Optional start_line (1-based) and line_count select a slice; omit both to read the whole file. By default each line is prefixed with its number and a tab so you can cite file:line directly; pass with_line_numbers=false to get bare content.")]
     public Task<string> ReadFile(
         [Description("Repository-relative path to read.")] string path,
+        [Description("Optional 1-based starting line. Omit to read from the beginning.")] int? start_line = null,
+        [Description("Optional count of lines to return from start_line. Omit to read to the end.")] int? line_count = null,
+        [Description("When true (default), each output line is prefixed with its line number and a tab.")] bool with_line_numbers = true,
         CancellationToken ct = default)
     {
-        _logger?.LogInformation("tool_call: ReadFile path={Path}", path);
+        _logger?.LogInformation("tool_call: ReadFile path={Path} start={Start} count={Count}", path, start_line, line_count);
         return _guards.CheckRead(path) is { } error
             ? Task.FromResult(error)
-            : _runner.ReadAsync(path, ct);
+            : _runner.ReadAsync(path, start_line, line_count, with_line_numbers, ct);
     }
 
     [Description("Writes the given content to a file at the given path. Overwrites if it exists.")]
@@ -76,170 +88,304 @@ public sealed class FilesystemToolHost : IToolHost
         return result;
     }
 
-    [Description("Lists the immediate contents (files + subdirectories) of a directory. Pass depth>1 for recursive listing. Use this to discover the shape of an unfamiliar directory; use find_files when you already know a name pattern.")]
+    [Description("Lists the contents of a directory. Pass depth>1 for recursive listing. with_sizes=true adds a size column; sort_by={name|size|mtime} controls ordering. Use this for ad-hoc inspection; use directory_tree for a nested overview, find_files when you already know a name pattern.")]
     public Task<string> ListDirectory(
         [Description("Repository-relative directory path. Use '.' for the repo root.")] string path = ".",
-        [Description("Recursion depth (1 = direct children only). Omit for full recursion — use sparingly on large trees.")] int? depth = null,
+        [Description("Recursion depth (1 = direct children only). Omit for direct children only.")] int? depth = null,
+        [Description("When true, include a size column. Default false.")] bool with_sizes = false,
+        [Description("Sort order: 'name' (default), 'size' (descending), or 'mtime' (newest first).")] string sort_by = "name",
         CancellationToken ct = default)
     {
-        _logger?.LogInformation("tool_call: ListDirectory path={Path} depth={Depth}", path, depth);
-        return _guards.CheckRead(path) is { } error
-            ? Task.FromResult(error)
-            : _runner.ListAsync(path, depth, ct);
+        _logger?.LogInformation("tool_call: ListDirectory path={Path} depth={Depth} sizes={Sizes} sort={Sort}", path, depth, with_sizes, sort_by);
+        if (_guards.CheckRead(path) is { } error) return Task.FromResult(error);
+        var sort = ParseSortBy(sort_by);
+        return _runner.ListAsync(path, depth, with_sizes, sort, ct);
     }
 
-    [Description("Finds files whose names match a glob pattern, tree-recursive under the given root. Use when you know the file-name shape ('*.cs', 'Program.cs', '**/Controller.cs'). For directory-shape exploration use list_directory.")]
-    public Task<string> FindFiles(
-        [Description("Glob pattern matched against file names, e.g. '*.cs' or '**/Controller.cs'.")] string pattern,
+    private static DirectorySortBy ParseSortBy(string s) => s?.ToLowerInvariant() switch
+    {
+        "size" => DirectorySortBy.Size,
+        "mtime" => DirectorySortBy.Mtime,
+        _ => DirectorySortBy.Name
+    };
+
+    [Description("Returns a nested text tree of the given directory, MCP filesystem-server directory_tree shape. Use this to get a one-shot layout overview instead of N list_directory walks.")]
+    public Task<string> DirectoryTree(
+        [Description("Repository-relative root directory. Use '.' for the repo root.")] string root = ".",
+        [Description("Maximum recursion depth (default 4).")] int? max_depth = null,
+        [Description("Optional list of basename globs to skip (e.g. ['*.min.js', 'bin']). The standard noisy dirs (.git, node_modules, bin, obj, etc.) are always skipped.")] IReadOnlyList<string>? exclude_globs = null,
+        CancellationToken ct = default)
+    {
+        _logger?.LogInformation("tool_call: DirectoryTree root={Root} depth={Depth}", root, max_depth);
+        return _guards.CheckRead(root) is { } error
+            ? Task.FromResult(error)
+            : _runner.TreeAsync(root, max_depth, exclude_globs, ct);
+    }
+
+    [Description("Finds files whose path (relative to root) matches a glob pattern. Pattern is path-relative — 'Controller.cs' matches any file with 'Controller.cs' in its path; '*.cs' matches every .cs file; 'src/**/*.cs' matches every .cs under src/. Truncates at head_limit and appends a marker line.")]
+    public async Task<string> FindFiles(
+        [Description("Glob pattern matched against the path relative to root. Substring match if no glob chars are present.")] string pattern,
         [Description("Repository-relative directory to search under (default '.').")] string root = ".",
+        [Description("Maximum number of matches to return (default 1000).")] int? head_limit = null,
         CancellationToken ct = default)
     {
         _logger?.LogInformation("tool_call: FindFiles pattern={Pattern} root={Root}", pattern, root);
-        if (_guards.CheckRead(root) is { } error) return Task.FromResult(error);
-        var namePattern = pattern.StartsWith("**/", StringComparison.Ordinal) ? pattern[3..] : pattern;
-        var cmd = $"find {ShellQuote(root)} -type f -name {ShellQuote(namePattern)} 2>/dev/null | head -200";
-        return _runner.RunAsync(cmd, ct);
+        if (_guards.CheckRead(root) is { } error) return error;
+        var limit = head_limit ?? SizeLimits.GrepDefaultHeadLimit;
+        var normalized = NormalizeFindPattern(pattern);
+        // head -N+1 so we can detect over-limit and emit the truncation marker.
+        var cmd = $"find {ShellQuote(root)} -type f -path {ShellQuote(normalized)} 2>/dev/null | head -{limit + 1}";
+        var structured = await _runner.RunAsync(cmd, timeoutSeconds: null, ct);
+        return FormatFindOutput(structured, limit);
     }
 
-    [Description("Replaces an EXACT string occurrence in a file. old_string must appear EXACTLY ONCE in the file or the call fails — provide enough surrounding context to make it unique. Use this for targeted edits instead of WriteFile (which overwrites the whole file).")]
+    private static string NormalizeFindPattern(string pattern)
+    {
+        var normalized = pattern.Replace("**", "*");
+        var hasGlob = normalized.Contains('*') || normalized.Contains('?');
+        return hasGlob ? normalized : $"*{normalized}*";
+    }
+
+    private static string FormatFindOutput(string structured, int limit)
+    {
+        // RunAsync returns the labeled-section format; pull stdout out.
+        var stdout = ExtractStdoutSection(structured);
+        var lines = stdout.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        if (lines.Length <= limit) return string.Join('\n', lines);
+        return string.Join('\n', lines.Take(limit)) + $"\n(truncated: {limit} matches)";
+    }
+
+    private static string ExtractStdoutSection(string structured)
+    {
+        var idx = structured.IndexOf("stdout:\n", StringComparison.Ordinal);
+        if (idx < 0) return string.Empty;
+        var start = idx + "stdout:\n".Length;
+        var end = structured.IndexOf("\n\nstderr:", start, StringComparison.Ordinal);
+        return end < 0 ? structured[start..] : structured[start..end];
+    }
+
+    [Description("Replaces an EXACT string occurrence in a file. By default old_string must appear EXACTLY ONCE — provide enough surrounding context to make it unique. With replace_all=true, every occurrence is replaced and the count is reported.")]
     public async Task<string> Edit(
         [Description("Repository-relative path to edit.")] string path,
-        [Description("Exact string to find. Must appear exactly once in the file. Include enough surrounding context for uniqueness.")] string old_string,
+        [Description("Exact string to find. Include enough surrounding context for uniqueness unless replace_all is true.")] string old_string,
         [Description("Replacement string.")] string new_string,
+        [Description("When true, replace every occurrence and report the count. Default false.")] bool replace_all = false,
         CancellationToken ct = default)
     {
-        _logger?.LogInformation("tool_call: Edit path={Path} old_len={Old} new_len={New}", path, old_string?.Length ?? 0, new_string?.Length ?? 0);
+        _logger?.LogInformation("tool_call: Edit path={Path} old_len={Old} new_len={New} replace_all={All}",
+            path, old_string?.Length ?? 0, new_string?.Length ?? 0, replace_all);
         if (_guards.CheckRead(path) is { } readErr) return readErr;
         if (_guards.CheckWrite(path) is { } writeErr) return writeErr;
         if (string.IsNullOrEmpty(old_string)) return "Error: old_string must not be empty.";
 
-        var content = await _runner.ReadAsync(path, ct);
+        var content = await _runner.ReadAsync(path, startLine: null, lineCount: null, withLineNumbers: false, ct);
         if (content.StartsWith("Error", StringComparison.Ordinal)) return content;
 
-        var idx = content.IndexOf(old_string, StringComparison.Ordinal);
-        if (idx < 0) return $"Error: old_string not found in {path}.";
-        if (content.IndexOf(old_string, idx + 1, StringComparison.Ordinal) >= 0)
-            return $"Error: old_string appears multiple times in {path} — extend the snippet with surrounding context to make it unique.";
-
-        var newContent = string.Concat(content.AsSpan(0, idx), new_string, content.AsSpan(idx + old_string.Length));
+        var (newContent, count, error) = ApplyEdit(content, old_string, new_string, replace_all, path);
+        if (error is not null) return error;
         var result = await _runner.WriteAsync(path, newContent, ct);
         if (!result.StartsWith("Error", StringComparison.Ordinal))
             _changes.Add(new CodeChange(new FilePath(path), newContent, "Modify"));
-        return result;
+        return replace_all
+            ? $"{result}\nReplaced {count} occurrence(s)."
+            : result;
     }
 
-    [Description("Sends an HTTP request from inside the sandbox and returns response status, headers, and body. Use for live API probing (e.g. anonymous endpoint behavior, malformed payload response codes, header inspection) when a target URL is reachable. Built on `curl -sS -i` under the hood.")]
+    private static (string Content, int Count, string? Error) ApplyEdit(
+        string content, string oldString, string newString, bool replaceAll, string path)
+    {
+        var idx = content.IndexOf(oldString, StringComparison.Ordinal);
+        if (idx < 0) return (content, 0, $"Error: old_string not found in {path}.");
+        if (!replaceAll && content.IndexOf(oldString, idx + 1, StringComparison.Ordinal) >= 0)
+            return (content, 0, $"Error: old_string appears multiple times in {path} — extend the snippet with surrounding context to make it unique, or pass replace_all=true.");
+        if (!replaceAll)
+        {
+            var single = string.Concat(content.AsSpan(0, idx), newString, content.AsSpan(idx + oldString.Length));
+            return (single, 1, null);
+        }
+        // Manual replace_all so we can count and avoid Regex pitfalls with special chars.
+        var sb = new StringBuilder(content.Length);
+        var pos = 0;
+        var count = 0;
+        while (pos < content.Length)
+        {
+            var next = content.IndexOf(oldString, pos, StringComparison.Ordinal);
+            if (next < 0) { sb.Append(content, pos, content.Length - pos); break; }
+            sb.Append(content, pos, next - pos);
+            sb.Append(newString);
+            pos = next + oldString.Length;
+            count++;
+        }
+        return (sb.ToString(), count, null);
+    }
+
+    [Description("Atomically applies multiple text edits to a single file. All edits succeed or none apply. Useful for a refactor or rename across one file in one round-trip. With dry_run=true, returns a per-edit summary and writes nothing.")]
+    public async Task<string> MultiEdit(
+        [Description("Repository-relative path to edit.")] string path,
+        [Description("Ordered list of edits to apply. Each edit is {old_string, new_string, replace_all (optional, default false)}.")] IReadOnlyList<MultiEditOp> edits,
+        [Description("When true, simulate the edits and return a summary without writing.")] bool dry_run = false,
+        CancellationToken ct = default)
+    {
+        _logger?.LogInformation("tool_call: MultiEdit path={Path} edits={Count} dry_run={Dry}", path, edits?.Count ?? 0, dry_run);
+        if (edits is null || edits.Count == 0) return "Error: edits must contain at least one entry.";
+        if (_guards.CheckRead(path) is { } readErr) return readErr;
+        if (_guards.CheckWrite(path) is { } writeErr) return writeErr;
+
+        var content = await _runner.ReadAsync(path, startLine: null, lineCount: null, withLineNumbers: false, ct);
+        if (content.StartsWith("Error", StringComparison.Ordinal)) return content;
+
+        var summary = new StringBuilder();
+        for (var i = 0; i < edits.Count; i++)
+        {
+            var op = edits[i];
+            if (string.IsNullOrEmpty(op.old_string)) return $"Error: edit #{i + 1} old_string must not be empty.";
+            var (next, count, err) = ApplyEdit(content, op.old_string, op.new_string ?? string.Empty, op.replace_all, path);
+            if (err is not null) return $"Error in edit #{i + 1}: {err[7..]}";
+            summary.AppendLine($"edit #{i + 1}: {count} replacement(s)");
+            content = next;
+        }
+
+        if (dry_run) return $"dry_run: would apply {edits.Count} edit(s) to {path}\n{summary}";
+
+        var result = await _runner.WriteAsync(path, content, ct);
+        if (!result.StartsWith("Error", StringComparison.Ordinal))
+            _changes.Add(new CodeChange(new FilePath(path), content, "Modify"));
+        return $"{result}\nApplied {edits.Count} edit(s).\n{summary}";
+    }
+
+    /// <summary>Per-edit operation for <see cref="MultiEdit"/>. Flat record so the
+    /// generated JSON schema is OpenAI-strict-mode safe and Ollama-friendly.</summary>
+    public sealed record MultiEditOp(
+        [property: Description("Exact string to find.")] string old_string,
+        [property: Description("Replacement string.")] string new_string,
+        [property: Description("When true, replace every occurrence in this step. Default false.")] bool replace_all = false);
+
+    [Description("Sends an HTTP request from inside the sandbox and returns response status, headers, and body. Use for live API probing (anonymous endpoint behaviour, malformed-payload response codes, header inspection). For reading documentation pages, p0154 ships web_fetch.")]
     public Task<string> HttpRequest(
         [Description("HTTP method: GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS.")] string method,
         [Description("Full URL including scheme.")] string url,
-        [Description("Optional request body for POST/PUT/PATCH. Empty for GET/HEAD/DELETE/OPTIONS.")] string? body = null,
+        [Description("Optional request body for POST/PUT/PATCH.")] string? body = null,
         [Description("Optional request headers, one per line: 'Authorization: Bearer xyz\\nContent-Type: application/json'.")] string? headers = null,
-        [Description("Optional connection timeout in seconds (default 15, max 60).")] int? timeoutSeconds = null,
+        [Description("Optional connection timeout in seconds (default 15, max 60).")] int? timeout_seconds = null,
         CancellationToken ct = default)
     {
         _logger?.LogInformation("tool_call: HttpRequest {Method} {Url} body_len={BodyLen}", method, url, body?.Length ?? 0);
-
         var allowedMethods = new[] { "GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS" };
         var upperMethod = method?.ToUpperInvariant() ?? "GET";
         if (!allowedMethods.Contains(upperMethod))
             return Task.FromResult($"Error: unsupported HTTP method '{method}'. Allowed: {string.Join(", ", allowedMethods)}.");
-
         if (string.IsNullOrWhiteSpace(url))
             return Task.FromResult("Error: url is required.");
 
-        var clampedTimeout = Math.Clamp(timeoutSeconds ?? 15, 1, 60);
+        var clampedTimeout = Math.Clamp(timeout_seconds ?? 15, 1, 60);
         var parts = new List<string> { "curl", "-sS", "-i", "--max-time", clampedTimeout.ToString(), "-X", upperMethod };
         if (!string.IsNullOrEmpty(headers))
-        {
             foreach (var line in headers.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
-            {
-                parts.Add("-H");
-                parts.Add(line);
-            }
-        }
+            { parts.Add("-H"); parts.Add(line); }
         if (!string.IsNullOrEmpty(body))
-        {
-            parts.Add("--data-raw");
-            parts.Add(body);
-        }
+        { parts.Add("--data-raw"); parts.Add(body); }
         parts.Add(url);
 
         var cmd = string.Join(" ", parts.Select(ShellQuote));
-        return _runner.RunAsync(cmd, ct);
+        return _runner.RunAsync(cmd, timeoutSeconds: clampedTimeout + 5, ct);
     }
 
     private static string ShellQuote(string s) => "'" + s.Replace("'", "'\\''") + "'";
 
-    [Description("Searches a single file for lines matching a regular expression. Use when you already know the file path (e.g. cited in an upstream observation). For searching across a directory tree, use grep_in_tree.")]
+    [Description("Searches a single file for lines matching a regular expression. Use when you already know the file path. context_before / context_after / context (shorthand) include adjacent lines. output_mode: 'content' (default, with line numbers), 'files_with_matches' (just the path), 'count' (matches per file).")]
     public Task<string> GrepInFile(
         [Description("Repository-relative path to a specific file.")] string path,
         [Description("Regular expression pattern to search for.")] string pattern,
-        [Description("Maximum number of matches to return (default 200).")] int? maxMatches = null,
+        [Description("Maximum number of matches to return (default 1000).")] int? head_limit = null,
+        [Description("Lines of context before each match (-B). Overridden by 'context' if set.")] int? context_before = null,
+        [Description("Lines of context after each match (-A). Overridden by 'context' if set.")] int? context_after = null,
+        [Description("Shorthand for context_before + context_after.")] int? context = null,
+        [Description("'content' (default), 'files_with_matches', or 'count'.")] string output_mode = "content",
         CancellationToken ct = default)
     {
         _logger?.LogInformation("tool_call: GrepInFile path={Path} pattern={Pattern}", path, pattern);
-        return _guards.CheckRead(path) is { } error
-            ? Task.FromResult(error)
-            : _runner.GrepAsync(pattern, path, glob: null, maxMatches, ct);
+        if (_guards.CheckRead(path) is { } error) return Task.FromResult(error);
+        var (before, after) = ResolveContext(context_before, context_after, context);
+        var mode = ParseOutputMode(output_mode);
+        return _runner.GrepAsync(pattern, path, glob: null, head_limit, before, after, mode, ct);
     }
 
-    [Description("Searches all files under a directory tree for lines matching a regular expression. Use a glob filter (e.g. '*.cs') to narrow file types. For a single known file, use grep_in_file.")]
+    [Description("Searches all files under a directory tree for lines matching a regular expression. Use a glob filter (e.g. '*.cs') to narrow file types. context_before / context_after / context include adjacent lines. output_mode: 'content' (default), 'files_with_matches', or 'count'.")]
     public Task<string> GrepInTree(
         [Description("Regular expression pattern to search for.")] string pattern,
         [Description("Repository-relative directory to search under (default '.').")] string root = ".",
         [Description("Optional glob filter for file names (e.g. '*.cs', '**/*.json').")] string? glob = null,
-        [Description("Maximum number of matches to return (default 200).")] int? maxMatches = null,
+        [Description("Maximum number of matches to return (default 1000).")] int? head_limit = null,
+        [Description("Lines of context before each match (-B). Overridden by 'context' if set.")] int? context_before = null,
+        [Description("Lines of context after each match (-A). Overridden by 'context' if set.")] int? context_after = null,
+        [Description("Shorthand for context_before + context_after.")] int? context = null,
+        [Description("'content' (default), 'files_with_matches', or 'count'.")] string output_mode = "content",
         CancellationToken ct = default)
     {
         _logger?.LogInformation("tool_call: GrepInTree pattern={Pattern} root={Root} glob={Glob}", pattern, root, glob);
-        return _guards.CheckRead(root) is { } error
-            ? Task.FromResult(error)
-            : _runner.GrepAsync(pattern, root, glob, maxMatches, ct);
+        if (_guards.CheckRead(root) is { } error) return Task.FromResult(error);
+        var (before, after) = ResolveContext(context_before, context_after, context);
+        var mode = ParseOutputMode(output_mode);
+        return _runner.GrepAsync(pattern, root, glob, head_limit, before, after, mode, ct);
     }
 
-    // Deprecated aliases — kept to preserve the contract that v2.5.1 SKILL.md
-    // files reference (`grep`, `glob`, `list_files`). The next agent-smith-skills
-    // release migrates the prompts to the new names; once a release or two has
-    // shipped with the renamed prompts, these aliases come out.
-    [Description("[DEPRECATED — use grep_in_file or grep_in_tree.] Searches files for a regular expression. Forwards to grep_in_tree when path is a directory, grep_in_file when path is a file.")]
-    public Task<string> Grep(
-        [Description("Regular expression pattern to search for.")] string pattern,
-        [Description("Repository-relative path to search under (file or directory).")] string path = ".",
-        [Description("Optional glob filter (e.g. '*.cs') — only meaningful when path is a directory.")] string? glob = null,
-        [Description("Maximum number of matches to return (default 200).")] int? maxMatches = null,
-        CancellationToken ct = default)
+    private static (int? Before, int? After) ResolveContext(int? before, int? after, int? context)
     {
-        _logger?.LogInformation("tool_call: Grep [deprecated] pattern={Pattern} path={Path} glob={Glob}", pattern, path, glob);
-        return _guards.CheckRead(path) is { } error
-            ? Task.FromResult(error)
-            : _runner.GrepAsync(pattern, path, glob, maxMatches, ct);
+        if (context is { } c && c > 0) return (c, c);
+        return (before, after);
     }
 
-    [Description("[DEPRECATED — use find_files.] Lists files matching a glob pattern. Forwards to find_files.")]
-    public Task<string> Glob(
-        [Description("Glob pattern, e.g. '*.cs' or 'Program.cs'.")] string pattern,
-        [Description("Repository-relative base path to search from (default '.').")] string path = ".",
-        CancellationToken ct = default) => FindFiles(pattern, path, ct);
+    private static GrepOutputMode ParseOutputMode(string mode) => mode?.ToLowerInvariant() switch
+    {
+        "files_with_matches" => GrepOutputMode.FilesWithMatches,
+        "count" => GrepOutputMode.Count,
+        _ => GrepOutputMode.Content
+    };
 
-    [Description("[DEPRECATED — use list_directory.] Lists files and folders under the given path. Forwards to list_directory.")]
-    public Task<string> ListFiles(
-        [Description("Repository-relative path to list. Use '.' for the repo root.")] string path = ".",
-        [Description("Optional max depth to recurse.")] int? maxDepth = null,
-        CancellationToken ct = default) => ListDirectory(path, maxDepth, ct);
-
-    [Description("Runs a shell command (passed to /bin/sh -c). Destructive commands (rm/rmdir/unlink/shred/truncate/dd, raw device writes, fork bombs) are blocked by a defense-in-depth guard on top of the sandbox boundary; use find/grep/head/wc/curl/ls/cat freely.")]
+    [Description("Runs a shell command (passed to /bin/sh -c). Returns labeled sections: header lines (exit_code, elapsed_ms, truncated) followed by 'stdout:' and 'stderr:' blocks. Destructive commands (rm/rmdir/unlink/shred/truncate/dd, raw device writes, fork bombs) are blocked by a defense-in-depth guard; use find/grep/head/wc/curl/ls/cat freely.")]
     public Task<string> RunCommand(
         [Description("Shell command to execute (passed to /bin/sh -c).")] string command,
+        [Description("Optional timeout in seconds (default 60, max 600). Use for builds and test runs that may exceed the default.")] int? timeout_seconds = null,
         CancellationToken ct = default)
     {
-        _logger?.LogInformation("tool_call: RunCommand cmd={Command}", command);
+        _logger?.LogInformation("tool_call: RunCommand cmd={Command} timeout={Timeout}", command, timeout_seconds);
         if (CommandGuard.Check(command) is { } error)
         {
             _logger?.LogWarning("RunCommand blocked by destructive-command guard: {Command}", command);
             return Task.FromResult(error);
         }
-        return _runner.RunAsync(command, ct);
+        return _runner.RunAsync(command, timeout_seconds, ct);
     }
+
+    // Deprecated aliases — kept registered as forwarders until p0154 ships the
+    // skills catalogue rename. Descriptions reflect the deprecation; the
+    // SourceAnchoringPreamble does not mention them so the LLM is not steered
+    // toward the old names.
+
+    [Description("[DEPRECATED — use grep_in_file or grep_in_tree.] Forwards to the path-shape-appropriate replacement.")]
+    public Task<string> Grep(
+        [Description("Regular expression pattern.")] string pattern,
+        [Description("Repository-relative path to search under (file or directory).")] string path = ".",
+        [Description("Optional glob filter (only meaningful when path is a directory).")] string? glob = null,
+        [Description("Maximum number of matches to return.")] int? max_matches = null,
+        CancellationToken ct = default)
+    {
+        _logger?.LogInformation("tool_call: Grep [deprecated] pattern={Pattern} path={Path}", pattern, path);
+        if (_guards.CheckRead(path) is { } error) return Task.FromResult(error);
+        return _runner.GrepAsync(pattern, path, glob, max_matches, contextBefore: null, contextAfter: null, GrepOutputMode.Content, ct);
+    }
+
+    [Description("[DEPRECATED — use find_files.] Lists files matching a glob pattern.")]
+    public Task<string> Glob(
+        [Description("Glob pattern.")] string pattern,
+        [Description("Repository-relative base path (default '.').")] string path = ".",
+        CancellationToken ct = default) => FindFiles(pattern, path, head_limit: null, ct);
+
+    [Description("[DEPRECATED — use list_directory.] Lists files and folders under the given path.")]
+    public Task<string> ListFiles(
+        [Description("Repository-relative path. Use '.' for the repo root.")] string path = ".",
+        [Description("Optional max depth.")] int? max_depth = null,
+        CancellationToken ct = default) => ListDirectory(path, max_depth, with_sizes: false, sort_by: "name", ct);
 
     private static AIFunction Tool(Delegate impl, string name) =>
         AIFunctionFactory.Create(impl, name: name);
@@ -251,9 +397,9 @@ public sealed class FilesystemToolHost : IToolHost
         Tool(GrepInTree, "grep_in_tree"),
         Tool(FindFiles, "find_files"),
         Tool(ListDirectory, "list_directory"),
+        Tool(DirectoryTree, "directory_tree"),
         Tool(RunCommand, "run_command"),
         Tool(HttpRequest, "http_request"),
-        // Deprecated aliases — kept until agent-smith-skills migrates its prompts.
         Tool(Grep, "grep"),
         Tool(Glob, "glob"),
         Tool(ListFiles, "list_files")
@@ -266,32 +412,18 @@ public sealed class FilesystemToolHost : IToolHost
         Tool(ReadFile, "read_file"),
         Tool(WriteFile, "write_file"),
         Tool(Edit, "edit"),
+        Tool(MultiEdit, "multi_edit"),
         Tool(GrepInFile, "grep_in_file"),
         Tool(GrepInTree, "grep_in_tree"),
         Tool(FindFiles, "find_files"),
         Tool(ListDirectory, "list_directory"),
+        Tool(DirectoryTree, "directory_tree"),
         Tool(RunCommand, "run_command"),
         Tool(HttpRequest, "http_request"),
-        // Deprecated aliases — kept until agent-smith-skills migrates its prompts.
         Tool(Grep, "grep"),
         Tool(Glob, "glob"),
         Tool(ListFiles, "list_files")
     ];
 
-    private IEnumerable<AIFunction> All() =>
-    [
-        Tool(ReadFile, "read_file"),
-        Tool(WriteFile, "write_file"),
-        Tool(Edit, "edit"),
-        Tool(ListDirectory, "list_directory"),
-        Tool(FindFiles, "find_files"),
-        Tool(GrepInFile, "grep_in_file"),
-        Tool(GrepInTree, "grep_in_tree"),
-        Tool(RunCommand, "run_command"),
-        Tool(HttpRequest, "http_request"),
-        // Deprecated aliases — kept until agent-smith-skills migrates its prompts.
-        Tool(Grep, "grep"),
-        Tool(Glob, "glob"),
-        Tool(ListFiles, "list_files")
-    ];
+    private IEnumerable<AIFunction> All() => BootstrapSet();
 }

--- a/src/AgentSmith.Application/Services/Tools/FilesystemToolHost.cs
+++ b/src/AgentSmith.Application/Services/Tools/FilesystemToolHost.cs
@@ -47,6 +47,16 @@ public sealed class FilesystemToolHost : IToolHost
 
     public IReadOnlyList<CodeChange> GetChanges() => _changes.AsReadOnly();
 
+    // Dedup by path: the LLM frequently makes several edits to the same file in one run.
+    // Downstream consumers (commit comment, run-result, log "N files changed") expect a per-file set.
+    private void RecordChange(string path, string content)
+    {
+        var change = new CodeChange(new FilePath(path), content, "Modify");
+        var idx = _changes.FindIndex(c => c.Path.Value == path);
+        if (idx >= 0) _changes[idx] = change;
+        else _changes.Add(change);
+    }
+
     public IEnumerable<AIFunction> GetTools(SkillExecutionPhase? phase, string? investigatorMode)
     {
         _ = investigatorMode;
@@ -84,7 +94,7 @@ public sealed class FilesystemToolHost : IToolHost
         if (_guards.CheckWrite(path) is { } error) return error;
         var result = await _runner.WriteAsync(path, content, ct);
         if (!result.StartsWith("Error", StringComparison.Ordinal))
-            _changes.Add(new CodeChange(new FilePath(path), content, "Modify"));
+            RecordChange(path, content);
         return result;
     }
 
@@ -185,7 +195,7 @@ public sealed class FilesystemToolHost : IToolHost
         if (error is not null) return error;
         var result = await _runner.WriteAsync(path, newContent, ct);
         if (!result.StartsWith("Error", StringComparison.Ordinal))
-            _changes.Add(new CodeChange(new FilePath(path), newContent, "Modify"));
+            RecordChange(path, newContent);
         return replace_all
             ? $"{result}\nReplaced {count} occurrence(s)."
             : result;
@@ -249,7 +259,7 @@ public sealed class FilesystemToolHost : IToolHost
 
         var result = await _runner.WriteAsync(path, content, ct);
         if (!result.StartsWith("Error", StringComparison.Ordinal))
-            _changes.Add(new CodeChange(new FilePath(path), content, "Modify"));
+            RecordChange(path, content);
         return $"{result}\nApplied {edits.Count} edit(s).\n{summary}";
     }
 

--- a/src/AgentSmith.Application/Services/Tools/HumanToolHost.cs
+++ b/src/AgentSmith.Application/Services/Tools/HumanToolHost.cs
@@ -6,10 +6,11 @@ using Microsoft.Extensions.AI;
 namespace AgentSmith.Application.Services.Tools;
 
 /// <summary>
-/// Human-escalation host: exposes the AskHuman tool in every phase when a
-/// dialogue transport + jobId are configured. Whether the LLM may interrupt
-/// the operator is an operator-policy question (handled via IPipelineToolPolicy
-/// or DI configuration), never a phase question.
+/// Human-escalation host: exposes ask_human in every phase when a dialogue
+/// transport + jobId are configured. Choices is a flat array of {label,
+/// description?} entries; recommendation is carried by a separate top-level
+/// recommended_index so the per-choice schema stays two-field flat for
+/// OpenAI strict mode and small Ollama tool calling.
 /// </summary>
 public sealed class HumanToolHost : IToolHost
 {
@@ -29,20 +30,27 @@ public sealed class HumanToolHost : IToolHost
         return [AIFunctionFactory.Create(AskHuman, name: "ask_human")];
     }
 
-    [Description("Asks the human operator for guidance via the dialogue transport.")]
+    [Description("Asks the human operator for guidance via the dialogue transport. choices is an optional flat list of [{label, description?}]; recommended_index points to a preferred choice when set.")]
     public async Task<string> AskHuman(
         [Description("Question text to display to the human.")] string question,
         [Description("Optional context block shown alongside the question.")] string? context = null,
-        [Description("Optional list of choices for multiple-choice answers.")] IReadOnlyList<string>? choices = null,
+        [Description("Optional list of choices. Each entry is {label, description?}.")] IReadOnlyList<AskHumanChoice>? choices = null,
+        [Description("Optional 0-based index into choices identifying the recommended option.")] int? recommended_index = null,
         CancellationToken ct = default)
     {
         if (_dialogueTransport is null || _jobId is null)
             return "Error: Dialogue transport not configured.";
         var qid = Guid.NewGuid().ToString("N");
-        var qType = choices is { Count: > 0 } ? QuestionType.Choice : QuestionType.FreeText;
-        var dq = new DialogQuestion(qid, qType, question, context, choices, "", TimeSpan.FromMinutes(5));
+        var rich = choices?.Select(c => new DialogChoice(c.label, c.description)).ToList();
+        var qType = rich is { Count: > 0 } ? QuestionType.Choice : QuestionType.FreeText;
+        var dq = new DialogQuestion(qid, qType, question, context, rich, "", TimeSpan.FromMinutes(5), recommended_index);
         await _dialogueTransport.PublishQuestionAsync(_jobId, dq, ct);
         var answer = await _dialogueTransport.WaitForAnswerAsync(_jobId, qid, TimeSpan.FromMinutes(5), ct);
         return answer is null ? "Answer (timeout): " : $"Answer: {answer.Answer}";
     }
+
+    /// <summary>LLM-facing choice shape: two primitive fields, nothing nested.</summary>
+    public sealed record AskHumanChoice(
+        [property: Description("Short choice label (what the user sees and selects).")] string label,
+        [property: Description("Optional explanation of what this choice means or its implications.")] string? description = null);
 }

--- a/src/AgentSmith.Application/Services/Tools/SandboxStepRunner.cs
+++ b/src/AgentSmith.Application/Services/Tools/SandboxStepRunner.cs
@@ -7,17 +7,21 @@ namespace AgentSmith.Application.Services.Tools;
 
 /// <summary>
 /// Builds Step records and runs them through ISandbox. Provides typed
-/// per-tool helpers shared by SandboxToolHost. Pure plumbing — no AIFunction
-/// schema or LLM-facing concerns live here.
+/// per-tool helpers shared by FilesystemToolHost. Pure plumbing — no
+/// AIFunction schema or LLM-facing concerns live here.
 /// </summary>
 internal sealed class SandboxStepRunner(ISandbox sandbox)
 {
     private const int FileTimeoutSeconds = 30;
-    private const int CommandTimeoutSeconds = 60;
+    private const int DefaultRunCommandTimeoutSeconds = 60;
+    private const int MaxRunCommandTimeoutSeconds = 600;
 
-    public async Task<string> ReadAsync(string path, CancellationToken ct)
+    public async Task<string> ReadAsync(
+        string path, int? startLine, int? lineCount, bool withLineNumbers, CancellationToken ct)
     {
-        var step = MakeFileStep(StepKind.ReadFile, path);
+        var step = new Step(Step.CurrentSchemaVersion, Guid.NewGuid(), StepKind.ReadFile,
+            TimeoutSeconds: FileTimeoutSeconds, Path: path,
+            StartLine: startLine, LineCount: lineCount, WithLineNumbers: withLineNumbers);
         var result = await sandbox.RunStepAsync(step, progress: null, ct);
         return result.ExitCode != 0
             ? $"Error: {result.ErrorMessage ?? "read_file failed"}"
@@ -26,48 +30,165 @@ internal sealed class SandboxStepRunner(ISandbox sandbox)
 
     public async Task<string> WriteAsync(string path, string content, CancellationToken ct)
     {
-        var step = MakeFileStep(StepKind.WriteFile, path, content: content);
+        var step = new Step(Step.CurrentSchemaVersion, Guid.NewGuid(), StepKind.WriteFile,
+            TimeoutSeconds: FileTimeoutSeconds, Path: path, Content: content);
         var result = await sandbox.RunStepAsync(step, progress: null, ct);
         return result.ExitCode != 0
             ? $"Error: {result.ErrorMessage ?? "write_file failed"}"
             : $"File written: {path}";
     }
 
-    public async Task<string> ListAsync(string path, int? maxDepth, CancellationToken ct)
+    public async Task<string> ListAsync(
+        string path, int? maxDepth, bool withSizes, DirectorySortBy sortBy, CancellationToken ct)
     {
-        var step = MakeFileStep(StepKind.ListFiles, path, maxDepth: maxDepth);
+        var step = new Step(Step.CurrentSchemaVersion, Guid.NewGuid(), StepKind.ListFiles,
+            TimeoutSeconds: FileTimeoutSeconds, Path: path, MaxDepth: maxDepth,
+            WithSizes: withSizes, SortBy: sortBy);
         var result = await sandbox.RunStepAsync(step, progress: null, ct);
         if (result.ExitCode != 0 || result.OutputContent is null)
             return $"Error: {result.ErrorMessage ?? "list_files failed"}";
-        var entries = JsonSerializer.Deserialize<string[]>(result.OutputContent) ?? [];
-        return string.Join('\n', entries);
+        return RenderDirectoryListing(result.OutputContent, withSizes);
     }
 
-    public async Task<string> GrepAsync(string pattern, string path, string? glob, int? maxMatches, CancellationToken ct)
+    private static string RenderDirectoryListing(string json, bool withSizes)
     {
-        var step = new Step(Step.CurrentSchemaVersion, Guid.NewGuid(), StepKind.Grep,
-            TimeoutSeconds: FileTimeoutSeconds, Path: path, Pattern: pattern, Glob: glob, MaxMatches: maxMatches);
+        using var doc = JsonDocument.Parse(json);
+        var sb = new StringBuilder();
+        foreach (var entry in doc.RootElement.EnumerateArray())
+        {
+            if (entry.ValueKind == JsonValueKind.String)
+            {
+                sb.AppendLine(entry.GetString());
+                continue;
+            }
+            var path = entry.TryGetProperty("path", out var p) ? p.GetString() ?? "" : "";
+            var isDir = entry.TryGetProperty("is_directory", out var d) && d.GetBoolean();
+            if (withSizes)
+            {
+                var size = entry.TryGetProperty("size_bytes", out var s) && s.ValueKind == JsonValueKind.Number
+                    ? s.GetInt64().ToString().PadLeft(10) : "       DIR";
+                sb.Append(size).Append("  ").Append(path);
+            }
+            else
+            {
+                sb.Append(path);
+            }
+            if (isDir && !path.EndsWith('/')) sb.Append('/');
+            sb.AppendLine();
+        }
+        return sb.ToString().TrimEnd('\r', '\n');
+    }
+
+    public async Task<string> TreeAsync(
+        string path, int? maxDepth, IReadOnlyList<string>? excludeGlobs, CancellationToken ct)
+    {
+        var step = new Step(Step.CurrentSchemaVersion, Guid.NewGuid(), StepKind.DirectoryTree,
+            TimeoutSeconds: FileTimeoutSeconds, Path: path, MaxDepth: maxDepth,
+            ExcludeGlobs: excludeGlobs);
         var result = await sandbox.RunStepAsync(step, progress: null, ct);
         return result.ExitCode != 0
-            ? $"Error: {result.ErrorMessage ?? "grep failed"}"
-            : result.OutputContent ?? "[]";
+            ? $"Error: {result.ErrorMessage ?? "directory_tree failed"}"
+            : result.OutputContent ?? string.Empty;
     }
 
-    public async Task<string> RunAsync(string command, CancellationToken ct)
+    public async Task<string> GrepAsync(
+        string pattern, string path, string? glob, int? headLimit,
+        int? contextBefore, int? contextAfter, GrepOutputMode outputMode, CancellationToken ct)
     {
-        var step = new Step(Step.CurrentSchemaVersion, Guid.NewGuid(), StepKind.Run,
-            Command: "/bin/sh", Args: ["-c", command], TimeoutSeconds: CommandTimeoutSeconds);
+        var step = new Step(Step.CurrentSchemaVersion, Guid.NewGuid(), StepKind.Grep,
+            TimeoutSeconds: FileTimeoutSeconds, Path: path, Pattern: pattern, Glob: glob,
+            HeadLimit: headLimit, ContextBefore: contextBefore, ContextAfter: contextAfter,
+            OutputMode: outputMode);
+        var result = await sandbox.RunStepAsync(step, progress: null, ct);
+        if (result.ExitCode != 0)
+            return $"Error: {result.ErrorMessage ?? "grep failed"}";
+        var effectiveLimit = headLimit ?? SizeLimits.GrepDefaultHeadLimit;
+        return RenderGrepResult(result.OutputContent ?? "[]", outputMode, effectiveLimit);
+    }
+
+    private static string RenderGrepResult(string json, GrepOutputMode mode, int headLimit)
+    {
+        using var doc = JsonDocument.Parse(json);
+        var rows = doc.RootElement.EnumerateArray().ToList();
         var sb = new StringBuilder();
+        switch (mode)
+        {
+            case GrepOutputMode.FilesWithMatches:
+                foreach (var r in rows) sb.AppendLine(r.GetProperty("path").GetString());
+                if (rows.Count >= headLimit) sb.AppendLine($"(truncated: {headLimit} files)");
+                break;
+            case GrepOutputMode.Count:
+                foreach (var r in rows)
+                    sb.AppendLine($"{r.GetProperty("path").GetString()}: {r.GetProperty("count").GetInt32()}");
+                if (rows.Count >= headLimit) sb.AppendLine($"(truncated: {headLimit} files)");
+                break;
+            default:
+                var matchCount = 0;
+                foreach (var r in rows)
+                {
+                    var kind = r.TryGetProperty("kind", out var k) ? k.GetString() : "match";
+                    var sep = kind == "context" ? '-' : ':';
+                    sb.Append(r.GetProperty("path").GetString()).Append(sep)
+                      .Append(r.GetProperty("line").GetInt32()).Append(sep)
+                      .AppendLine(r.GetProperty("text").GetString());
+                    if (kind == "match") matchCount++;
+                }
+                if (matchCount >= headLimit) sb.AppendLine($"(truncated: {headLimit} matches)");
+                break;
+        }
+        return sb.ToString().TrimEnd('\r', '\n');
+    }
+
+    public async Task<string> RunAsync(string command, int? timeoutSeconds, CancellationToken ct)
+    {
+        var timeout = timeoutSeconds is null
+            ? DefaultRunCommandTimeoutSeconds
+            : Math.Clamp(timeoutSeconds.Value, 1, MaxRunCommandTimeoutSeconds);
+        var step = new Step(Step.CurrentSchemaVersion, Guid.NewGuid(), StepKind.Run,
+            Command: "/bin/sh", Args: ["-c", command], TimeoutSeconds: timeout);
+        var stdout = new StringBuilder();
+        var stderr = new StringBuilder();
+        var stdoutTruncated = false;
+        var stderrTruncated = false;
         var progress = new Progress<StepEvent>(ev =>
         {
-            if (ev.Kind is StepEventKind.Stdout or StepEventKind.Stderr)
-                sb.AppendLine(ev.Line);
+            switch (ev.Kind)
+            {
+                case StepEventKind.Stdout:
+                    AppendBounded(stdout, ev.Line, ref stdoutTruncated);
+                    break;
+                case StepEventKind.Stderr:
+                    AppendBounded(stderr, ev.Line, ref stderrTruncated);
+                    break;
+            }
         });
+        var startedAt = DateTimeOffset.UtcNow;
         var result = await sandbox.RunStepAsync(step, progress, ct);
-        return $"Exit code: {result.ExitCode}\n{sb}".Trim();
+        var elapsedMs = (long)(DateTimeOffset.UtcNow - startedAt).TotalMilliseconds;
+        var truncated = stdoutTruncated || stderrTruncated;
+
+        var sb = new StringBuilder();
+        sb.Append("exit_code: ").Append(result.ExitCode).Append('\n');
+        sb.Append("elapsed_ms: ").Append(elapsedMs).Append('\n');
+        sb.Append("truncated: ").Append(truncated ? "true" : "false").Append('\n');
+        if (result.TimedOut) sb.Append("timed_out: true\n");
+        sb.Append('\n');
+        sb.Append("stdout:\n").Append(stdout.ToString().TrimEnd('\r', '\n')).Append('\n');
+        sb.Append('\n');
+        sb.Append("stderr:\n").Append(stderr.ToString().TrimEnd('\r', '\n'));
+        return sb.ToString();
     }
 
-    private static Step MakeFileStep(StepKind kind, string path, string? content = null, int? maxDepth = null) =>
-        new(Step.CurrentSchemaVersion, Guid.NewGuid(), kind,
-            TimeoutSeconds: FileTimeoutSeconds, Path: path, Content: content, MaxDepth: maxDepth);
+    private static void AppendBounded(StringBuilder sb, string line, ref bool truncated)
+    {
+        if (truncated) return;
+        var addedBytes = Encoding.UTF8.GetByteCount(line) + 1;
+        if (sb.Length + addedBytes > SizeLimits.RunCommandMaxBufferBytes)
+        {
+            truncated = true;
+            sb.Append("\n... (output truncated at 1 MB)");
+            return;
+        }
+        sb.Append(line).Append('\n');
+    }
 }

--- a/src/AgentSmith.Application/Services/Tools/SandboxStepRunner.cs
+++ b/src/AgentSmith.Application/Services/Tools/SandboxStepRunner.cs
@@ -150,7 +150,12 @@ internal sealed class SandboxStepRunner(ISandbox sandbox)
         var stderr = new StringBuilder();
         var stdoutTruncated = false;
         var stderrTruncated = false;
-        var progress = new Progress<StepEvent>(ev =>
+        // Synchronous IProgress: Progress<T> dispatches asynchronously via the
+        // captured SynchronizationContext / ThreadPool, which races the await
+        // sandbox.RunStepAsync below — events can arrive after the sandbox
+        // returns and end up missing from the labeled-section output. The
+        // inline sync collector closes the race.
+        var progress = new SyncProgress<StepEvent>(ev =>
         {
             switch (ev.Kind)
             {
@@ -177,6 +182,11 @@ internal sealed class SandboxStepRunner(ISandbox sandbox)
         sb.Append('\n');
         sb.Append("stderr:\n").Append(stderr.ToString().TrimEnd('\r', '\n'));
         return sb.ToString();
+    }
+
+    private sealed class SyncProgress<T>(Action<T> handler) : IProgress<T>
+    {
+        public void Report(T value) => handler(value);
     }
 
     private static void AppendBounded(StringBuilder sb, string line, ref bool truncated)

--- a/src/AgentSmith.Cli/Services/ConsoleDialogueTransport.cs
+++ b/src/AgentSmith.Cli/Services/ConsoleDialogueTransport.cs
@@ -125,7 +125,10 @@ public sealed class ConsoleDialogueTransport(
             case QuestionType.Choice when question.Choices is { Count: > 0 }:
                 for (var i = 0; i < question.Choices.Count; i++)
                 {
-                    sb.AppendLine($"  {i + 1}. {question.Choices[i]}");
+                    var choice = question.Choices[i];
+                    var marker = i == question.RecommendedIndex ? " (recommended)" : "";
+                    var suffix = string.IsNullOrEmpty(choice.Description) ? "" : $" — {choice.Description}";
+                    sb.AppendLine($"  {i + 1}. {choice.Label}{marker}{suffix}");
                 }
                 sb.Append("Enter number: ");
                 break;
@@ -159,7 +162,7 @@ public sealed class ConsoleDialogueTransport(
 
             case QuestionType.Choice when question.Choices is { Count: > 0 }:
                 if (int.TryParse(trimmed, out var idx) && idx >= 1 && idx <= question.Choices.Count)
-                    return question.Choices[idx - 1];
+                    return question.Choices[idx - 1].Label;
                 return trimmed;
 
             case QuestionType.Approval:

--- a/src/AgentSmith.Contracts/Dialogue/DialogChoice.cs
+++ b/src/AgentSmith.Contracts/Dialogue/DialogChoice.cs
@@ -1,0 +1,9 @@
+namespace AgentSmith.Contracts.Dialogue;
+
+/// <summary>
+/// One choice in a multiple-choice <see cref="DialogQuestion"/>. Flat record so
+/// the LLM-facing tool schema (HumanToolHost.ask_human) stays primitive-typed
+/// across providers. Recommendation is carried by DialogQuestion.RecommendedIndex,
+/// not per-choice, for the same flatness reason.
+/// </summary>
+public sealed record DialogChoice(string Label, string? Description = null);

--- a/src/AgentSmith.Contracts/Dialogue/DialogQuestion.cs
+++ b/src/AgentSmith.Contracts/Dialogue/DialogQuestion.cs
@@ -5,6 +5,7 @@ public sealed record DialogQuestion(
     QuestionType Type,
     string Text,
     string? Context,
-    IReadOnlyList<string>? Choices,
+    IReadOnlyList<DialogChoice>? Choices,
     string? DefaultAnswer,
-    TimeSpan Timeout);
+    TimeSpan Timeout,
+    int? RecommendedIndex = null);

--- a/src/AgentSmith.Infrastructure/Services/Dialogue/RedisDialogueTransport.cs
+++ b/src/AgentSmith.Infrastructure/Services/Dialogue/RedisDialogueTransport.cs
@@ -30,7 +30,7 @@ public sealed class RedisDialogueTransport(
             new("questionType", question.Type.ToString()),
             new("text", question.Text),
             new("context", question.Context ?? ""),
-            new("choices", question.Choices is not null ? string.Join("|", question.Choices) : ""),
+            new("choices", question.Choices is not null ? string.Join("|", question.Choices.Select(c => c.Label)) : ""),
             new("defaultAnswer", question.DefaultAnswer ?? ""),
             new("timeoutSeconds", question.Timeout.TotalSeconds.ToString("F0")),
         };

--- a/src/AgentSmith.Infrastructure/Services/Providers/Agent/FileToolHandler.cs
+++ b/src/AgentSmith.Infrastructure/Services/Providers/Agent/FileToolHandler.cs
@@ -22,6 +22,21 @@ internal sealed class FileToolHandler(
 
     public IReadOnlyList<CodeChange> GetChanges() => _changes.AsReadOnly();
 
+    private void RecordChange(string path, string content, string changeType)
+    {
+        var idx = _changes.FindIndex(c => c.Path.Value == path);
+        if (idx >= 0)
+        {
+            // Preserve original "Create" — a file created and later modified in the same run is still a Create.
+            var effectiveType = _changes[idx].ChangeType == "Create" ? "Create" : changeType;
+            _changes[idx] = new CodeChange(_changes[idx].Path, content, effectiveType);
+        }
+        else
+        {
+            _changes.Add(new CodeChange(new FilePath(path), content, changeType));
+        }
+    }
+
     public string ReadFile(JsonNode? input)
     {
         var path = ToolParams.GetString(input, "path");
@@ -71,7 +86,7 @@ internal sealed class FileToolHandler(
             Directory.CreateDirectory(directory);
 
         File.WriteAllText(fullPath, content);
-        _changes.Add(new CodeChange(new FilePath(path), content, changeType));
+        RecordChange(path, content, changeType);
         fileReadTracker?.InvalidateRead(path);
 
         logger.LogDebug("Wrote file {Path} ({ChangeType})", path, changeType);

--- a/src/AgentSmith.Infrastructure/Services/Providers/Agent/HumanQuestionToolHandler.cs
+++ b/src/AgentSmith.Infrastructure/Services/Providers/Agent/HumanQuestionToolHandler.cs
@@ -34,9 +34,10 @@ internal sealed class HumanQuestionToolHandler(
         if (!Enum.TryParse<QuestionType>(normalizedType, ignoreCase: true, out var questionType))
             return $"Error: Invalid question_type '{questionTypeStr}'.";
 
-        List<string>? choices = null;
+        List<DialogChoice>? choices = null;
         if (choicesNode is JsonArray arr)
-            choices = arr.Select(c => c?.GetValue<string>() ?? "").Where(c => c.Length > 0).ToList();
+            choices = arr.Select(c => c?.GetValue<string>() ?? "").Where(c => c.Length > 0)
+                .Select(label => new DialogChoice(label)).ToList();
 
         var questionId = Guid.NewGuid().ToString("N");
         var question = new DialogQuestion(

--- a/src/AgentSmith.Infrastructure/Services/Sandbox/InProcessSandbox.cs
+++ b/src/AgentSmith.Infrastructure/Services/Sandbox/InProcessSandbox.cs
@@ -30,6 +30,7 @@ public sealed class InProcessSandbox(string jobId, string workDir, ILogger logge
             StepKind.WriteFile => WriteFileAsync(step, cancellationToken),
             StepKind.ListFiles => Task.FromResult(ListFiles(step, progress)),
             StepKind.Grep => Task.FromResult(Grep(step, progress)),
+            StepKind.DirectoryTree => Task.FromResult(DirectoryTree(step)),
             StepKind.Shutdown => Task.FromResult(Success(step, 0, null)),
             _ => Task.FromResult(Failure(step, 0, $"Unsupported kind {step.Kind}"))
         };
@@ -196,12 +197,37 @@ public sealed class InProcessSandbox(string jobId, string workDir, ILogger logge
         try
         {
             var encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
-            return Success(step, 0, encoding.GetString(bytes));
+            var content = encoding.GetString(bytes);
+            // Duplicates FileStepHandler.SliceLines on purpose — InProcessSandbox
+            // lives in Infrastructure, Sandbox.Agent is an Exe project that
+            // cannot be referenced. Keep the two implementations in sync when
+            // touching slicing semantics.
+            return Success(step, 0, SliceLines(content, step.StartLine, step.LineCount, step.WithLineNumbers));
         }
         catch (DecoderFallbackException)
         {
             return Failure(step, 0, "binary or non-UTF-8 content not supported");
         }
+    }
+
+    private static string SliceLines(string content, int? startLine, int? lineCount, bool withLineNumbers)
+    {
+        var lines = content.Split('\n');
+        var start = Math.Max(1, startLine ?? 1);
+        var count = lineCount ?? int.MaxValue;
+        var endExclusive = (int)Math.Min((long)start - 1 + count, lines.Length);
+        var startIdx = Math.Min(start - 1, lines.Length);
+        if (startIdx >= lines.Length) return string.Empty;
+        if (!withLineNumbers) return string.Join('\n', lines[startIdx..endExclusive]);
+        var width = lines.Length.ToString().Length;
+        var sb = new StringBuilder();
+        for (var i = startIdx; i < endExclusive; i++)
+        {
+            sb.Append((i + 1).ToString().PadLeft(width));
+            sb.Append('\t').Append(lines[i]);
+            if (i + 1 < endExclusive) sb.Append('\n');
+        }
+        return sb.ToString();
     }
 
     private async Task<StepResult> WriteFileAsync(Step step, CancellationToken cancellationToken)
@@ -223,12 +249,109 @@ public sealed class InProcessSandbox(string jobId, string workDir, ILogger logge
         var path = ResolvePath(step.Path!);
         if (!Directory.Exists(path)) return Failure(step, 0, $"directory not found: {path}");
         var maxDepth = step.MaxDepth ?? 1;
-        var entries = new List<string>(SizeLimits.ListFilesMaxEntries);
-        var truncated = EnumerateUntilLimit(path, maxDepth, entries);
+        var entries = new List<(string Path, long? Size, DateTimeOffset Mtime, bool IsDir)>(SizeLimits.ListFilesMaxEntries);
+        var truncated = EnumerateRichUntilLimit(path, maxDepth, entries);
         if (truncated)
             progress?.Report(MakeEvent(step.StepId, StepEventKind.Stderr, "directory truncated at 1000 entries"));
-        var rewritten = entries.Select(VirtualisePath).ToList();
-        return Success(step, 0, JsonSerializer.Serialize(rewritten, WireFormat.Json));
+        var sorted = step.SortBy switch
+        {
+            DirectorySortBy.Size => entries.OrderByDescending(e => e.Size ?? -1).ToList(),
+            DirectorySortBy.Mtime => entries.OrderByDescending(e => e.Mtime).ToList(),
+            _ => entries.OrderBy(e => e.Path, StringComparer.Ordinal).ToList()
+        };
+        var json = JsonSerializer.Serialize(sorted.Select(e =>
+        {
+            var obj = new System.Text.Json.Nodes.JsonObject { ["path"] = VirtualisePath(e.Path) };
+            if (e.Size.HasValue) obj["size_bytes"] = e.Size.Value;
+            obj["mtime"] = e.Mtime.ToString("O");
+            obj["is_directory"] = e.IsDir;
+            return obj;
+        }).ToList(), WireFormat.Json);
+        return Success(step, 0, json);
+    }
+
+    private static bool EnumerateRichUntilLimit(
+        string root, int maxDepth,
+        List<(string Path, long? Size, DateTimeOffset Mtime, bool IsDir)> entries)
+    {
+        var stack = new Stack<(string Path, int Depth)>();
+        stack.Push((root, 0));
+        while (stack.Count > 0)
+        {
+            var (current, depth) = stack.Pop();
+            IEnumerable<string> children;
+            try { children = Directory.EnumerateFileSystemEntries(current); } catch { continue; }
+            foreach (var entry in children)
+            {
+                if (entries.Count >= SizeLimits.ListFilesMaxEntries) return true;
+                var isDir = Directory.Exists(entry);
+                long? size = null;
+                var mtime = DateTimeOffset.MinValue;
+                try
+                {
+                    if (isDir) mtime = new DirectoryInfo(entry).LastWriteTimeUtc;
+                    else { var fi = new FileInfo(entry); size = fi.Length; mtime = fi.LastWriteTimeUtc; }
+                }
+                catch { /* leave defaults */ }
+                entries.Add((entry, size, mtime, isDir));
+                if (depth + 1 < maxDepth && isDir) stack.Push((entry, depth + 1));
+            }
+        }
+        return false;
+    }
+
+    private StepResult DirectoryTree(Step step)
+    {
+        var path = ResolvePath(step.Path!);
+        if (!Directory.Exists(path)) return Failure(step, 0, $"directory not found: {path}");
+        var maxDepth = step.MaxDepth ?? 4;
+        var excludes = (step.ExcludeGlobs ?? Array.Empty<string>())
+            .Select(g => new System.Text.RegularExpressions.Regex(
+                "^" + System.Text.RegularExpressions.Regex.Escape(g).Replace("\\*", "[^/]*").Replace("\\?", ".") + "$",
+                System.Text.RegularExpressions.RegexOptions.Compiled, TimeSpan.FromSeconds(2)))
+            .ToArray();
+        var sb = new StringBuilder();
+        sb.Append(Path.GetFileName(path.TrimEnd('/', '\\'))).Append("/\n");
+        RenderTree(path, 1, maxDepth, excludes, "", sb);
+        return Success(step, 0, sb.ToString().TrimEnd('\n'));
+    }
+
+    private static readonly string[] DefaultTreeExclusions =
+    [
+        ".git", "node_modules", "bin", "obj", ".vs", ".idea", "dist", "build",
+        ".next", ".nuxt", "coverage", ".terraform", "vendor", "__pycache__"
+    ];
+
+    private static void RenderTree(
+        string dir, int depth, int maxDepth,
+        System.Text.RegularExpressions.Regex[] excludes, string prefix, StringBuilder sb)
+    {
+        if (depth > maxDepth) return;
+        IEnumerable<string> children;
+        try { children = Directory.EnumerateFileSystemEntries(dir); } catch { return; }
+        var list = children
+            .Where(c => !ShouldExcludeFromTree(Path.GetFileName(c), excludes))
+            .OrderBy(c => !Directory.Exists(c))
+            .ThenBy(c => c, StringComparer.Ordinal)
+            .ToList();
+        for (var i = 0; i < list.Count; i++)
+        {
+            var entry = list[i];
+            var isLast = i == list.Count - 1;
+            var name = Path.GetFileName(entry);
+            var isDir = Directory.Exists(entry);
+            sb.Append(prefix).Append(isLast ? "└── " : "├── ").Append(name);
+            if (isDir) sb.Append('/');
+            sb.Append('\n');
+            if (isDir) RenderTree(entry, depth + 1, maxDepth, excludes, prefix + (isLast ? "    " : "│   "), sb);
+        }
+    }
+
+    private static bool ShouldExcludeFromTree(string name, System.Text.RegularExpressions.Regex[] excludes)
+    {
+        if (DefaultTreeExclusions.Contains(name)) return true;
+        foreach (var rx in excludes) if (rx.IsMatch(name)) return true;
+        return false;
     }
 
     // Mirror image of ResolvePath: translate the actual workDir back to /work so callers

--- a/src/AgentSmith.Infrastructure/Services/Sandbox/InProcessSandbox.cs
+++ b/src/AgentSmith.Infrastructure/Services/Sandbox/InProcessSandbox.cs
@@ -39,7 +39,7 @@ public sealed class InProcessSandbox(string jobId, string workDir, ILogger logge
     {
         var path = ResolvePath(step.Path!);
         if (!Directory.Exists(path)) return Failure(step, 0, $"directory not found: {path}");
-        var maxMatches = step.MaxMatches ?? SizeLimits.GrepMaxMatches;
+        var maxMatches = step.HeadLimit ?? SizeLimits.GrepDefaultHeadLimit;
         try
         {
             var regex = new System.Text.RegularExpressions.Regex(step.Pattern!,

--- a/src/AgentSmith.Sandbox.Agent/Program.cs
+++ b/src/AgentSmith.Sandbox.Agent/Program.cs
@@ -65,7 +65,8 @@ internal static class Program
         var processRunner = new ProcessRunner();
         var fileHandler = new FileStepHandler(loggerFactory.CreateLogger<FileStepHandler>());
         var grepHandler = new GrepStepHandler(processRunner, loggerFactory.CreateLogger<GrepStepHandler>());
-        var executor = new StepExecutor(processRunner, fileHandler, grepHandler, loggerFactory.CreateLogger<StepExecutor>());
+        var treeHandler = new DirectoryTreeStepHandler(loggerFactory.CreateLogger<DirectoryTreeStepHandler>());
+        var executor = new StepExecutor(processRunner, fileHandler, grepHandler, treeHandler, loggerFactory.CreateLogger<StepExecutor>());
         var loop = new JobLoop(bus, executor, loggerFactory.CreateLogger<JobLoop>());
         return await loop.RunAsync(jobId, cts.Token);
     }

--- a/src/AgentSmith.Sandbox.Agent/Services/DirectoryTreeStepHandler.cs
+++ b/src/AgentSmith.Sandbox.Agent/Services/DirectoryTreeStepHandler.cs
@@ -1,0 +1,104 @@
+using System.Diagnostics;
+using System.Text;
+using System.Text.RegularExpressions;
+using AgentSmith.Sandbox.Wire;
+using Microsoft.Extensions.Logging;
+
+namespace AgentSmith.Sandbox.Agent.Services;
+
+/// <summary>
+/// Renders a nested-tree text view of a directory. Mirrors MCP filesystem-server
+/// directory_tree shape. Walks up to MaxDepth (default 4) levels and skips
+/// entries matching ExcludeGlobs (plus the standard noisy dirs).
+/// </summary>
+internal sealed class DirectoryTreeStepHandler(ILogger<DirectoryTreeStepHandler> logger)
+{
+    private static readonly TimeSpan RegexTimeout = TimeSpan.FromSeconds(2);
+    private static readonly string[] DefaultExclusions =
+    [
+        ".git", "node_modules", "bin", "obj", ".vs", ".idea", "dist", "build",
+        ".next", ".nuxt", "coverage", ".terraform", "vendor", "__pycache__"
+    ];
+
+    public Task<StepResult> HandleAsync(
+        Step step,
+        Func<IReadOnlyList<StepEvent>, Task> onEvents,
+        CancellationToken cancellationToken)
+    {
+        _ = onEvents; _ = cancellationToken;
+        var sw = Stopwatch.StartNew();
+        try
+        {
+            var path = step.Path!;
+            if (!Directory.Exists(path))
+                return Task.FromResult(Failure(step, sw, $"directory not found: {path}"));
+
+            var maxDepth = step.MaxDepth ?? 4;
+            var excludeRegexes = (step.ExcludeGlobs ?? Array.Empty<string>())
+                .Select(g => new Regex(GlobToRegex(g), RegexOptions.Compiled, RegexTimeout))
+                .ToArray();
+            var sb = new StringBuilder();
+            sb.Append(System.IO.Path.GetFileName(path.TrimEnd('/', '\\')));
+            sb.Append('/');
+            sb.Append('\n');
+            Render(path, depth: 1, maxDepth, excludeRegexes, prefix: "", sb);
+            return Task.FromResult(Success(step, sw, sb.ToString().TrimEnd('\n')));
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "DirectoryTree failed: {Path}", step.Path);
+            return Task.FromResult(Failure(step, sw, ex.Message));
+        }
+    }
+
+    private static void Render(string dir, int depth, int maxDepth, Regex[] excludes, string prefix, StringBuilder sb)
+    {
+        if (depth > maxDepth) return;
+        IEnumerable<string> children;
+        try { children = Directory.EnumerateFileSystemEntries(dir); }
+        catch { return; }
+        var list = children
+            .Where(c => !ShouldExclude(System.IO.Path.GetFileName(c), excludes))
+            .OrderBy(c => !Directory.Exists(c))
+            .ThenBy(c => c, StringComparer.Ordinal)
+            .ToList();
+        for (var i = 0; i < list.Count; i++)
+        {
+            var entry = list[i];
+            var isLast = i == list.Count - 1;
+            var name = System.IO.Path.GetFileName(entry);
+            var isDir = Directory.Exists(entry);
+            sb.Append(prefix);
+            sb.Append(isLast ? "└── " : "├── ");
+            sb.Append(name);
+            if (isDir) sb.Append('/');
+            sb.Append('\n');
+            if (isDir)
+                Render(entry, depth + 1, maxDepth, excludes, prefix + (isLast ? "    " : "│   "), sb);
+        }
+    }
+
+    private static bool ShouldExclude(string name, Regex[] excludes)
+    {
+        if (DefaultExclusions.Contains(name)) return true;
+        foreach (var rx in excludes) if (rx.IsMatch(name)) return true;
+        return false;
+    }
+
+    private static string GlobToRegex(string glob)
+    {
+        var escaped = Regex.Escape(glob);
+        escaped = escaped.Replace("\\*", "[^/]*").Replace("\\?", ".");
+        return $"^{escaped}$";
+    }
+
+    private static StepResult Success(Step step, Stopwatch sw, string output) =>
+        new(StepResult.CurrentSchemaVersion, step.StepId, ExitCode: 0,
+            TimedOut: false, DurationSeconds: sw.Elapsed.TotalSeconds,
+            ErrorMessage: null, OutputContent: output);
+
+    private static StepResult Failure(Step step, Stopwatch sw, string message) =>
+        new(StepResult.CurrentSchemaVersion, step.StepId, ExitCode: 1,
+            TimedOut: false, DurationSeconds: sw.Elapsed.TotalSeconds,
+            ErrorMessage: message);
+}

--- a/src/AgentSmith.Sandbox.Agent/Services/FileStepHandler.cs
+++ b/src/AgentSmith.Sandbox.Agent/Services/FileStepHandler.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using AgentSmith.Sandbox.Wire;
 using Microsoft.Extensions.Logging;
 
@@ -50,12 +51,48 @@ internal sealed class FileStepHandler(ILogger<FileStepHandler> logger)
             // its tool output, which it has been observed to mangle into U+0000
             // when echoing the content back via a WriteFile call.
             var content = encoding.GetString(bytes, bomLen, bytes.Length - bomLen);
-            return Success(step, sw, content);
+            var sliced = SliceLines(content, step.StartLine, step.LineCount, step.WithLineNumbers,
+                out var totalLines, out var firstLine);
+            _ = totalLines; _ = firstLine;
+            return Success(step, sw, sliced);
         }
         catch (DecoderFallbackException)
         {
             return Failure(step, sw, "binary or non-UTF-8 content not supported");
         }
+    }
+
+    // start_line is 1-based; null means "from the beginning". line_count null
+    // means "to the end". When with_line_numbers is true, each emitted line is
+    // prefixed with a right-aligned line number + tab, matching Claude-Code's
+    // Read output convention so the LLM can cite file:line without a follow-up
+    // grep.
+    internal static string SliceLines(
+        string content, int? startLine, int? lineCount, bool withLineNumbers,
+        out int totalLines, out int firstEmittedLine)
+    {
+        var lines = content.Split('\n');
+        totalLines = lines.Length;
+        var start = Math.Max(1, startLine ?? 1);
+        var count = lineCount ?? int.MaxValue;
+        var endExclusive = (int)Math.Min((long)start - 1 + count, lines.Length);
+        var startIdx = Math.Min(start - 1, lines.Length);
+        firstEmittedLine = startIdx + 1;
+        if (startIdx >= lines.Length) return string.Empty;
+
+        if (!withLineNumbers)
+            return string.Join('\n', lines[startIdx..endExclusive]);
+
+        var width = totalLines.ToString().Length;
+        var sb = new StringBuilder();
+        for (var i = startIdx; i < endExclusive; i++)
+        {
+            sb.Append((i + 1).ToString().PadLeft(width));
+            sb.Append('\t');
+            sb.Append(lines[i]);
+            if (i + 1 < endExclusive) sb.Append('\n');
+        }
+        return sb.ToString();
     }
 
     private static async Task<StepResult> HandleWriteAsync(Step step, Stopwatch sw, CancellationToken ct)
@@ -102,7 +139,7 @@ internal sealed class FileStepHandler(ILogger<FileStepHandler> logger)
             return Failure(step, sw, $"directory not found: {path}");
 
         var maxDepth = step.MaxDepth ?? 1;
-        var entries = new List<string>(SizeLimits.ListFilesMaxEntries);
+        var entries = new List<DirectoryEntry>(SizeLimits.ListFilesMaxEntries);
         var truncated = EnumerateUntilLimit(path, maxDepth, entries);
         if (truncated)
             await onEvents(new[]
@@ -111,11 +148,26 @@ internal sealed class FileStepHandler(ILogger<FileStepHandler> logger)
                     "directory truncated at 1000 entries", DateTimeOffset.UtcNow)
             });
 
-        var json = JsonSerializer.Serialize(entries, WireFormat.Json);
+        var sorted = step.SortBy switch
+        {
+            DirectorySortBy.Size => entries.OrderByDescending(e => e.SizeBytes ?? -1).ToList(),
+            DirectorySortBy.Mtime => entries.OrderByDescending(e => e.Mtime).ToList(),
+            _ => entries.OrderBy(e => e.Path, StringComparer.Ordinal).ToList()
+        };
+        var json = JsonSerializer.Serialize(sorted.Select(SerializeEntry).ToList(), WireFormat.Json);
         return Success(step, sw, json);
     }
 
-    private static bool EnumerateUntilLimit(string root, int maxDepth, List<string> entries)
+    private static JsonObject SerializeEntry(DirectoryEntry entry)
+    {
+        var obj = new JsonObject { ["path"] = entry.Path };
+        if (entry.SizeBytes.HasValue) obj["size_bytes"] = entry.SizeBytes.Value;
+        obj["mtime"] = entry.Mtime.ToString("O");
+        obj["is_directory"] = entry.IsDirectory;
+        return obj;
+    }
+
+    private static bool EnumerateUntilLimit(string root, int maxDepth, List<DirectoryEntry> entries)
     {
         var stack = new Stack<(string Path, int Depth)>();
         stack.Push((root, 0));
@@ -125,13 +177,33 @@ internal sealed class FileStepHandler(ILogger<FileStepHandler> logger)
             foreach (var entry in Directory.EnumerateFileSystemEntries(current))
             {
                 if (entries.Count >= SizeLimits.ListFilesMaxEntries) return true;
-                entries.Add(entry);
-                if (depth + 1 < maxDepth && Directory.Exists(entry))
+                var isDir = Directory.Exists(entry);
+                long? size = null;
+                var mtime = DateTimeOffset.MinValue;
+                try
+                {
+                    if (isDir)
+                    {
+                        var di = new DirectoryInfo(entry);
+                        mtime = di.LastWriteTimeUtc;
+                    }
+                    else
+                    {
+                        var fi = new FileInfo(entry);
+                        size = fi.Length;
+                        mtime = fi.LastWriteTimeUtc;
+                    }
+                }
+                catch { /* unreadable entry — keep path, leave size/mtime defaults */ }
+                entries.Add(new DirectoryEntry(entry, size, mtime, isDir));
+                if (depth + 1 < maxDepth && isDir)
                     stack.Push((entry, depth + 1));
             }
         }
         return false;
     }
+
+    private readonly record struct DirectoryEntry(string Path, long? SizeBytes, DateTimeOffset Mtime, bool IsDirectory);
 
     private static StepResult Success(Step step, Stopwatch sw, string? output) =>
         new(StepResult.CurrentSchemaVersion, step.StepId, ExitCode: 0,

--- a/src/AgentSmith.Sandbox.Agent/Services/GrepStepHandler.cs
+++ b/src/AgentSmith.Sandbox.Agent/Services/GrepStepHandler.cs
@@ -9,9 +9,15 @@ namespace AgentSmith.Sandbox.Agent.Services;
 
 /// <summary>
 /// Searches files in the sandbox for a regex pattern. Tries ripgrep first
-/// (`rg --json --max-count N --glob G PATTERN PATH`); when ripgrep is absent
-/// from the toolchain image, falls back to managed Directory.EnumerateFiles
-/// + Regex. Returns a JSON array of {path, line, text} matches.
+/// (passes through context flags, output-mode flags, head-limit); when
+/// ripgrep is absent from the toolchain image, falls back to managed
+/// Directory.EnumerateFiles + Regex.
+///
+/// Wire output is always a JSON array. Element shape depends on OutputMode:
+///   Content              -> [{path, line, text, kind: "match"|"context"}]
+///   FilesWithMatches     -> [{path}]                                       (deduplicated)
+///   Count                -> [{path, count}]
+/// Host-side renderers turn this into LLM-facing text and apply truncation markers.
 /// </summary>
 internal sealed class GrepStepHandler(IProcessRunner runner, ILogger<GrepStepHandler> logger)
 {
@@ -29,12 +35,12 @@ internal sealed class GrepStepHandler(IProcessRunner runner, ILogger<GrepStepHan
         CancellationToken cancellationToken)
     {
         var sw = Stopwatch.StartNew();
-        var maxMatches = step.MaxMatches ?? SizeLimits.GrepMaxMatches;
+        var headLimit = step.HeadLimit ?? SizeLimits.GrepDefaultHeadLimit;
         try
         {
             if (await IsRipgrepAvailableAsync(cancellationToken))
-                return await GrepWithRipgrepAsync(step, maxMatches, onEvents, sw, cancellationToken);
-            return await GrepWithManagedAsync(step, maxMatches, onEvents, sw);
+                return await GrepWithRipgrepAsync(step, headLimit, onEvents, sw, cancellationToken);
+            return await GrepWithManagedAsync(step, headLimit, onEvents, sw);
         }
         catch (Exception ex)
         {
@@ -59,14 +65,16 @@ internal sealed class GrepStepHandler(IProcessRunner runner, ILogger<GrepStepHan
     }
 
     private async Task<StepResult> GrepWithRipgrepAsync(
-        Step step, int maxMatches,
+        Step step, int headLimit,
         Func<IReadOnlyList<StepEvent>, Task> onEvents,
         Stopwatch sw, CancellationToken ct)
     {
-        var args = new List<string> { "--json", "--max-count", maxMatches.ToString() };
-        if (!string.IsNullOrEmpty(step.Glob)) { args.Add("--glob"); args.Add(step.Glob); }
-        args.Add(step.Pattern!);
-        args.Add(step.Path!);
+        var args = step.OutputMode switch
+        {
+            GrepOutputMode.FilesWithMatches => BuildRipgrepFilesArgs(step),
+            GrepOutputMode.Count => BuildRipgrepCountArgs(step),
+            _ => BuildRipgrepContentArgs(step, headLimit)
+        };
 
         var rgStep = new Step(Step.CurrentSchemaVersion, Guid.NewGuid(), StepKind.Run,
             Command: "rg", Args: args, TimeoutSeconds: step.TimeoutSeconds);
@@ -74,77 +82,221 @@ internal sealed class GrepStepHandler(IProcessRunner runner, ILogger<GrepStepHan
         var outcome = await runner.RunAsync(rgStep,
             (kind, line) => { if (kind == StepEventKind.Stdout) output.Add(line); }, ct);
 
-        var matches = ParseRipgrepJson(output, step.Path!);
-        var truncated = matches.Count >= maxMatches;
-        if (truncated) await EmitTruncatedEvent(step, onEvents);
-        return Success(step, sw, JsonSerializer.Serialize(matches, WireFormat.Json));
+        var (rows, truncated) = step.OutputMode switch
+        {
+            GrepOutputMode.FilesWithMatches => ParseRipgrepFiles(output, step.Path!, headLimit),
+            GrepOutputMode.Count => ParseRipgrepCount(output, step.Path!, headLimit),
+            _ => ParseRipgrepJson(output, step.Path!, headLimit)
+        };
+        if (truncated) await EmitTruncatedEvent(step, headLimit, onEvents);
+        return Success(step, sw, JsonSerializer.Serialize(rows, WireFormat.Json));
     }
 
-    private static List<JsonObject> ParseRipgrepJson(List<string> ndjson, string root)
+    private static List<string> BuildRipgrepContentArgs(Step step, int headLimit)
+    {
+        var args = new List<string> { "--json", "--max-count", headLimit.ToString() };
+        if (step.ContextBefore is > 0) { args.Add("-B"); args.Add(step.ContextBefore.Value.ToString()); }
+        if (step.ContextAfter is > 0) { args.Add("-A"); args.Add(step.ContextAfter.Value.ToString()); }
+        if (!string.IsNullOrEmpty(step.Glob)) { args.Add("--glob"); args.Add(step.Glob); }
+        args.Add(step.Pattern!);
+        args.Add(step.Path!);
+        return args;
+    }
+
+    private static List<string> BuildRipgrepFilesArgs(Step step)
+    {
+        var args = new List<string> { "--files-with-matches" };
+        if (!string.IsNullOrEmpty(step.Glob)) { args.Add("--glob"); args.Add(step.Glob); }
+        args.Add(step.Pattern!);
+        args.Add(step.Path!);
+        return args;
+    }
+
+    private static List<string> BuildRipgrepCountArgs(Step step)
+    {
+        var args = new List<string> { "--count" };
+        if (!string.IsNullOrEmpty(step.Glob)) { args.Add("--glob"); args.Add(step.Glob); }
+        args.Add(step.Pattern!);
+        args.Add(step.Path!);
+        return args;
+    }
+
+    private static (List<JsonObject> Rows, bool Truncated) ParseRipgrepJson(
+        List<string> ndjson, string root, int headLimit)
     {
         var matches = new List<JsonObject>();
+        var matchCount = 0;
+        var truncated = false;
         foreach (var raw in ndjson)
         {
             try
             {
                 var node = JsonNode.Parse(raw);
-                if (node?["type"]?.GetValue<string>() != "match") continue;
-                var data = node["data"];
+                var type = node?["type"]?.GetValue<string>();
+                if (type != "match" && type != "context") continue;
+                var data = node!["data"];
                 var path = data?["path"]?["text"]?.GetValue<string>();
                 var lineNumber = data?["line_number"]?.GetValue<int>() ?? 0;
                 var lineText = data?["lines"]?["text"]?.GetValue<string>()?.TrimEnd('\n');
                 if (path is null || lineText is null) continue;
+                if (type == "match")
+                {
+                    if (matchCount >= headLimit) { truncated = true; break; }
+                    matchCount++;
+                }
                 matches.Add(new JsonObject
                 {
                     ["path"] = RelativeFromRoot(root, path),
                     ["line"] = lineNumber,
-                    ["text"] = TruncateLine(lineText)
+                    ["text"] = TruncateLine(lineText),
+                    ["kind"] = type
                 });
             }
             catch (JsonException) { /* skip malformed line */ }
         }
-        return matches;
+        return (matches, truncated);
+    }
+
+    private static (List<JsonObject> Rows, bool Truncated) ParseRipgrepFiles(
+        List<string> output, string root, int headLimit)
+    {
+        var rows = new List<JsonObject>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        var truncated = false;
+        foreach (var line in output)
+        {
+            if (string.IsNullOrEmpty(line)) continue;
+            var rel = RelativeFromRoot(root, line);
+            if (!seen.Add(rel)) continue;
+            if (rows.Count >= headLimit) { truncated = true; break; }
+            rows.Add(new JsonObject { ["path"] = rel });
+        }
+        return (rows, truncated);
+    }
+
+    private static (List<JsonObject> Rows, bool Truncated) ParseRipgrepCount(
+        List<string> output, string root, int headLimit)
+    {
+        var rows = new List<JsonObject>();
+        var truncated = false;
+        foreach (var line in output)
+        {
+            if (string.IsNullOrEmpty(line)) continue;
+            var sep = line.LastIndexOf(':');
+            if (sep <= 0 || sep == line.Length - 1) continue;
+            if (!int.TryParse(line[(sep + 1)..], out var count)) continue;
+            var rel = RelativeFromRoot(root, line[..sep]);
+            if (rows.Count >= headLimit) { truncated = true; break; }
+            rows.Add(new JsonObject { ["path"] = rel, ["count"] = count });
+        }
+        return (rows, truncated);
     }
 
     private async Task<StepResult> GrepWithManagedAsync(
-        Step step, int maxMatches,
+        Step step, int headLimit,
         Func<IReadOnlyList<StepEvent>, Task> onEvents, Stopwatch sw)
     {
         var regex = new Regex(step.Pattern!, RegexOptions.Compiled, RegexTimeout);
-        var matches = new List<JsonObject>();
-        var truncated = false;
-        foreach (var file in EnumerateFiles(step.Path!, step.Glob))
+        var (rows, truncated) = step.OutputMode switch
         {
-            if (matches.Count >= maxMatches) { truncated = true; break; }
-            truncated = ScanFileForMatches(file, regex, step.Path!, maxMatches, matches);
-            if (truncated) break;
-        }
-        if (truncated) await EmitTruncatedEvent(step, onEvents);
-        return Success(step, sw, JsonSerializer.Serialize(matches, WireFormat.Json));
+            GrepOutputMode.FilesWithMatches => ScanFilesWithMatches(step, regex, headLimit),
+            GrepOutputMode.Count => ScanCounts(step, regex, headLimit),
+            _ => ScanContent(step, regex, headLimit)
+        };
+        if (truncated) await EmitTruncatedEvent(step, headLimit, onEvents);
+        return Success(step, sw, JsonSerializer.Serialize(rows, WireFormat.Json));
     }
 
-    private static bool ScanFileForMatches(
-        string file, Regex regex, string root, int maxMatches, List<JsonObject> matches)
+    private static (List<JsonObject> Rows, bool Truncated) ScanContent(Step step, Regex regex, int headLimit)
     {
-        try
+        var rows = new List<JsonObject>();
+        var matchCount = 0;
+        var before = step.ContextBefore ?? 0;
+        var after = step.ContextAfter ?? 0;
+        foreach (var file in EnumerateFiles(step.Path!, step.Glob))
         {
-            var info = new FileInfo(file);
-            if (info.Length > MaxFileSizeBytes) return false;
-            var lines = File.ReadAllLines(file);
-            var rel = RelativeFromRoot(root, file);
-            for (var i = 0; i < lines.Length; i++)
+            if (matchCount >= headLimit) return (rows, true);
+            try
             {
-                if (matches.Count >= maxMatches) return true;
-                if (!regex.IsMatch(lines[i])) continue;
-                matches.Add(new JsonObject
+                var info = new FileInfo(file);
+                if (info.Length > MaxFileSizeBytes) continue;
+                var lines = File.ReadAllLines(file);
+                var rel = RelativeFromRoot(step.Path!, file);
+                var emittedContextIndices = new HashSet<int>();
+                for (var i = 0; i < lines.Length; i++)
                 {
-                    ["path"] = rel, ["line"] = i + 1, ["text"] = TruncateLine(lines[i])
-                });
+                    if (matchCount >= headLimit) return (rows, true);
+                    if (!regex.IsMatch(lines[i])) continue;
+                    var ctxStart = Math.Max(0, i - before);
+                    for (var c = ctxStart; c < i; c++)
+                        if (emittedContextIndices.Add(c))
+                            rows.Add(MakeRow(rel, c + 1, lines[c], "context"));
+                    rows.Add(MakeRow(rel, i + 1, lines[i], "match"));
+                    emittedContextIndices.Add(i);
+                    matchCount++;
+                    var ctxEnd = Math.Min(lines.Length - 1, i + after);
+                    for (var c = i + 1; c <= ctxEnd; c++)
+                        if (emittedContextIndices.Add(c))
+                            rows.Add(MakeRow(rel, c + 1, lines[c], "context"));
+                }
             }
+            catch { /* skip unreadable file */ }
         }
-        catch { /* skip unreadable file */ }
-        return false;
+        return (rows, false);
     }
+
+    private static (List<JsonObject> Rows, bool Truncated) ScanFilesWithMatches(Step step, Regex regex, int headLimit)
+    {
+        var rows = new List<JsonObject>();
+        foreach (var file in EnumerateFiles(step.Path!, step.Glob))
+        {
+            if (rows.Count >= headLimit) return (rows, true);
+            try
+            {
+                var info = new FileInfo(file);
+                if (info.Length > MaxFileSizeBytes) continue;
+                var rel = RelativeFromRoot(step.Path!, file);
+                using var sr = new StreamReader(file);
+                string? line;
+                while ((line = sr.ReadLine()) is not null)
+                {
+                    if (regex.IsMatch(line))
+                    {
+                        rows.Add(new JsonObject { ["path"] = rel });
+                        break;
+                    }
+                }
+            }
+            catch { /* skip unreadable file */ }
+        }
+        return (rows, false);
+    }
+
+    private static (List<JsonObject> Rows, bool Truncated) ScanCounts(Step step, Regex regex, int headLimit)
+    {
+        var rows = new List<JsonObject>();
+        foreach (var file in EnumerateFiles(step.Path!, step.Glob))
+        {
+            if (rows.Count >= headLimit) return (rows, true);
+            try
+            {
+                var info = new FileInfo(file);
+                if (info.Length > MaxFileSizeBytes) continue;
+                var rel = RelativeFromRoot(step.Path!, file);
+                var count = 0;
+                using var sr = new StreamReader(file);
+                string? line;
+                while ((line = sr.ReadLine()) is not null)
+                    if (regex.IsMatch(line)) count++;
+                if (count > 0) rows.Add(new JsonObject { ["path"] = rel, ["count"] = count });
+            }
+            catch { /* skip unreadable file */ }
+        }
+        return (rows, false);
+    }
+
+    private static JsonObject MakeRow(string path, int line, string text, string kind) =>
+        new() { ["path"] = path, ["line"] = line, ["text"] = TruncateLine(text), ["kind"] = kind };
 
     // Path.GetRelativePath returns "." when root == file, which is useless as a
     // match-record path. When the caller targeted a single file, surface the
@@ -193,11 +345,11 @@ internal sealed class GrepStepHandler(IProcessRunner runner, ILogger<GrepStepHan
         return $"^{escaped}$";
     }
 
-    private static async Task EmitTruncatedEvent(Step step, Func<IReadOnlyList<StepEvent>, Task> onEvents) =>
+    private static async Task EmitTruncatedEvent(Step step, int headLimit, Func<IReadOnlyList<StepEvent>, Task> onEvents) =>
         await onEvents(new[]
         {
             new StepEvent(StepEvent.CurrentSchemaVersion, step.StepId, StepEventKind.Stderr,
-                $"grep truncated at {step.MaxMatches ?? SizeLimits.GrepMaxMatches} matches", DateTimeOffset.UtcNow)
+                $"grep truncated at {headLimit} matches", DateTimeOffset.UtcNow)
         });
 
     private static string TruncateLine(string line)

--- a/src/AgentSmith.Sandbox.Agent/Services/StepExecutor.cs
+++ b/src/AgentSmith.Sandbox.Agent/Services/StepExecutor.cs
@@ -8,6 +8,7 @@ internal sealed class StepExecutor(
     IProcessRunner runner,
     FileStepHandler fileHandler,
     GrepStepHandler grepHandler,
+    DirectoryTreeStepHandler treeHandler,
     ILogger<StepExecutor> logger) : IStepExecutor
 {
     public Task<StepResult> ExecuteAsync(
@@ -21,6 +22,7 @@ internal sealed class StepExecutor(
             StepKind.ReadFile or StepKind.WriteFile or StepKind.ListFiles
                 => fileHandler.HandleAsync(step, onEvents, cancellationToken),
             StepKind.Grep => grepHandler.HandleAsync(step, onEvents, cancellationToken),
+            StepKind.DirectoryTree => treeHandler.HandleAsync(step, onEvents, cancellationToken),
             _ => throw new ArgumentException(
                 $"StepExecutor does not handle Kind={step.Kind}", nameof(step))
         };

--- a/src/AgentSmith.Sandbox.Wire/SizeLimits.cs
+++ b/src/AgentSmith.Sandbox.Wire/SizeLimits.cs
@@ -5,5 +5,6 @@ public static class SizeLimits
     public const long ReadFileMaxBytes = 1_048_576;
     public const long WriteFileMaxBytes = 10_485_760;
     public const int ListFilesMaxEntries = 1000;
-    public const int GrepMaxMatches = 200;
+    public const int GrepDefaultHeadLimit = 1000;
+    public const int RunCommandMaxBufferBytes = 1_048_576;
 }

--- a/src/AgentSmith.Sandbox.Wire/Step.cs
+++ b/src/AgentSmith.Sandbox.Wire/Step.cs
@@ -14,7 +14,16 @@ public sealed record Step(
     int? MaxDepth = null,
     string? Pattern = null,
     string? Glob = null,
-    int? MaxMatches = null)
+    int? HeadLimit = null,
+    int? StartLine = null,
+    int? LineCount = null,
+    bool WithLineNumbers = false,
+    int? ContextBefore = null,
+    int? ContextAfter = null,
+    GrepOutputMode OutputMode = GrepOutputMode.Content,
+    bool WithSizes = false,
+    DirectorySortBy SortBy = DirectorySortBy.Name,
+    IReadOnlyList<string>? ExcludeGlobs = null)
 {
     public const int CurrentSchemaVersion = 1;
     public const int DefaultTimeoutSeconds = 600;
@@ -38,6 +47,9 @@ public sealed record Step(
                 ? (false, "ListFiles step requires non-empty Path")
                 : (true, null),
             StepKind.Grep => ValidateGrep(),
+            StepKind.DirectoryTree => string.IsNullOrEmpty(Path)
+                ? (false, "DirectoryTree step requires non-empty Path")
+                : (true, null),
             _ => (false, $"Unknown StepKind: {Kind}")
         };
     }
@@ -59,4 +71,18 @@ public sealed record Step(
             return (false, "Grep step requires non-empty Pattern");
         return (true, null);
     }
+}
+
+public enum GrepOutputMode
+{
+    Content = 0,
+    FilesWithMatches = 1,
+    Count = 2
+}
+
+public enum DirectorySortBy
+{
+    Name = 0,
+    Size = 1,
+    Mtime = 2
 }

--- a/src/AgentSmith.Sandbox.Wire/StepKind.cs
+++ b/src/AgentSmith.Sandbox.Wire/StepKind.cs
@@ -7,5 +7,6 @@ public enum StepKind
     ReadFile = 2,
     WriteFile = 3,
     ListFiles = 4,
-    Grep = 5
+    Grep = 5,
+    DirectoryTree = 6
 }

--- a/src/AgentSmith.Server/Services/Adapters/TeamsQuestionCardBuilder.cs
+++ b/src/AgentSmith.Server/Services/Adapters/TeamsQuestionCardBuilder.cs
@@ -43,8 +43,14 @@ public sealed class TeamsQuestionCardBuilder
         var actions = new JsonArray();
         if (q.Choices is not null)
         {
-            foreach (var choice in q.Choices)
-                actions.Add(AdaptiveCardPrimitives.ActionSubmit(choice, QuestionData(q, choice)));
+            for (var i = 0; i < q.Choices.Count; i++)
+            {
+                var choice = q.Choices[i];
+                var label = i == q.RecommendedIndex ? $"{choice.Label} ⭐" : choice.Label;
+                if (!string.IsNullOrEmpty(choice.Description))
+                    label = $"{label} — {choice.Description}";
+                actions.Add(AdaptiveCardPrimitives.ActionSubmit(label, QuestionData(q, choice.Label)));
+            }
         }
 
         return AdaptiveCardPrimitives.WrapCard(body, actions);

--- a/tests/AgentSmith.Sandbox.Agent.Tests/Services/DirectoryTreeStepHandlerTests.cs
+++ b/tests/AgentSmith.Sandbox.Agent.Tests/Services/DirectoryTreeStepHandlerTests.cs
@@ -1,0 +1,95 @@
+using AgentSmith.Sandbox.Agent.Services;
+using AgentSmith.Sandbox.Wire;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace AgentSmith.Sandbox.Agent.Tests.Services;
+
+public sealed class DirectoryTreeStepHandlerTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public DirectoryTreeStepHandlerTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "agentsmith-tree-tests-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose() { try { Directory.Delete(_tempDir, recursive: true); } catch { } }
+
+    [Fact]
+    public async Task DirectoryTree_RendersNestedStructure()
+    {
+        Directory.CreateDirectory(Path.Combine(_tempDir, "src"));
+        File.WriteAllText(Path.Combine(_tempDir, "src", "a.cs"), "");
+        File.WriteAllText(Path.Combine(_tempDir, "README.md"), "");
+        var step = new Step(Step.CurrentSchemaVersion, Guid.NewGuid(), StepKind.DirectoryTree,
+            Path: _tempDir);
+
+        var result = await NewHandler().HandleAsync(step, _ => Task.CompletedTask, CancellationToken.None);
+
+        result.ExitCode.Should().Be(0);
+        result.OutputContent.Should().Contain("README.md");
+        result.OutputContent.Should().Contain("src/");
+        result.OutputContent.Should().Contain("a.cs");
+    }
+
+    [Fact]
+    public async Task DirectoryTree_HonoursMaxDepth()
+    {
+        Directory.CreateDirectory(Path.Combine(_tempDir, "level1", "level2", "level3"));
+        File.WriteAllText(Path.Combine(_tempDir, "level1", "level2", "level3", "deep.txt"), "");
+        var step = new Step(Step.CurrentSchemaVersion, Guid.NewGuid(), StepKind.DirectoryTree,
+            Path: _tempDir, MaxDepth: 2);
+
+        var result = await NewHandler().HandleAsync(step, _ => Task.CompletedTask, CancellationToken.None);
+
+        result.OutputContent.Should().Contain("level1/");
+        result.OutputContent.Should().Contain("level2/");
+        result.OutputContent.Should().NotContain("deep.txt");
+    }
+
+    [Fact]
+    public async Task DirectoryTree_HonoursExcludeGlobs()
+    {
+        File.WriteAllText(Path.Combine(_tempDir, "keep.cs"), "");
+        File.WriteAllText(Path.Combine(_tempDir, "skip.min.js"), "");
+        var step = new Step(Step.CurrentSchemaVersion, Guid.NewGuid(), StepKind.DirectoryTree,
+            Path: _tempDir, ExcludeGlobs: new[] { "*.min.js" });
+
+        var result = await NewHandler().HandleAsync(step, _ => Task.CompletedTask, CancellationToken.None);
+
+        result.OutputContent.Should().Contain("keep.cs");
+        result.OutputContent.Should().NotContain("skip.min.js");
+    }
+
+    [Fact]
+    public async Task DirectoryTree_AlwaysExcludesNoisyDirs()
+    {
+        Directory.CreateDirectory(Path.Combine(_tempDir, "bin"));
+        Directory.CreateDirectory(Path.Combine(_tempDir, "node_modules"));
+        Directory.CreateDirectory(Path.Combine(_tempDir, "real_code"));
+        var step = new Step(Step.CurrentSchemaVersion, Guid.NewGuid(), StepKind.DirectoryTree,
+            Path: _tempDir);
+
+        var result = await NewHandler().HandleAsync(step, _ => Task.CompletedTask, CancellationToken.None);
+
+        result.OutputContent.Should().Contain("real_code");
+        result.OutputContent.Should().NotContain("node_modules");
+        result.OutputContent.Should().NotContain("bin");
+    }
+
+    [Fact]
+    public async Task DirectoryTree_MissingDirectory_ReturnsFailure()
+    {
+        var step = new Step(Step.CurrentSchemaVersion, Guid.NewGuid(), StepKind.DirectoryTree,
+            Path: Path.Combine(_tempDir, "does-not-exist"));
+
+        var result = await NewHandler().HandleAsync(step, _ => Task.CompletedTask, CancellationToken.None);
+
+        result.ExitCode.Should().Be(1);
+        result.ErrorMessage.Should().Contain("not found");
+    }
+
+    private static DirectoryTreeStepHandler NewHandler() => new(NullLogger<DirectoryTreeStepHandler>.Instance);
+}

--- a/tests/AgentSmith.Sandbox.Agent.Tests/Services/FileStepHandlerLineRangeTests.cs
+++ b/tests/AgentSmith.Sandbox.Agent.Tests/Services/FileStepHandlerLineRangeTests.cs
@@ -1,0 +1,88 @@
+using System.Text.Json;
+using AgentSmith.Sandbox.Agent.Services;
+using AgentSmith.Sandbox.Wire;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace AgentSmith.Sandbox.Agent.Tests.Services;
+
+public sealed class FileStepHandlerLineRangeTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly string _filePath;
+
+    public FileStepHandlerLineRangeTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "agentsmith-tests-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+        _filePath = Path.Combine(_tempDir, "lines.txt");
+        File.WriteAllText(_filePath, string.Join('\n', Enumerable.Range(1, 20).Select(i => $"line {i}")));
+    }
+
+    public void Dispose() { try { Directory.Delete(_tempDir, recursive: true); } catch { } }
+
+    [Fact]
+    public async Task ReadFile_WithStartLineAndLineCount_ReturnsRequestedSlice()
+    {
+        var step = new Step(Step.CurrentSchemaVersion, Guid.NewGuid(), StepKind.ReadFile,
+            Path: _filePath, StartLine: 5, LineCount: 3, WithLineNumbers: false);
+
+        var result = await NewHandler().HandleAsync(step, NoEvents, CancellationToken.None);
+
+        result.ExitCode.Should().Be(0);
+        result.OutputContent.Should().Be("line 5\nline 6\nline 7");
+    }
+
+    [Fact]
+    public async Task ReadFile_WithLineNumbersTrue_PrefixesEachLineWithRightAlignedNumber()
+    {
+        var step = new Step(Step.CurrentSchemaVersion, Guid.NewGuid(), StepKind.ReadFile,
+            Path: _filePath, StartLine: 1, LineCount: 2, WithLineNumbers: true);
+
+        var result = await NewHandler().HandleAsync(step, NoEvents, CancellationToken.None);
+
+        // 20 lines => 2-digit width.
+        result.OutputContent.Should().Be(" 1\tline 1\n 2\tline 2");
+    }
+
+    [Fact]
+    public async Task ReadFile_NoStartLine_ReadsFromBeginning()
+    {
+        var step = new Step(Step.CurrentSchemaVersion, Guid.NewGuid(), StepKind.ReadFile,
+            Path: _filePath, LineCount: 2, WithLineNumbers: false);
+
+        var result = await NewHandler().HandleAsync(step, NoEvents, CancellationToken.None);
+
+        result.OutputContent.Should().Be("line 1\nline 2");
+    }
+
+    [Fact]
+    public async Task ReadFile_NoLineCount_ReadsToEnd()
+    {
+        var step = new Step(Step.CurrentSchemaVersion, Guid.NewGuid(), StepKind.ReadFile,
+            Path: _filePath, StartLine: 19, WithLineNumbers: false);
+
+        var result = await NewHandler().HandleAsync(step, NoEvents, CancellationToken.None);
+
+        result.OutputContent.Should().Be("line 19\nline 20");
+    }
+
+    [Fact]
+    public async Task ListFiles_WithSizes_AndSortBySize_OrdersDescending()
+    {
+        File.WriteAllText(Path.Combine(_tempDir, "small.txt"), "a");
+        File.WriteAllText(Path.Combine(_tempDir, "big.txt"), new string('b', 1000));
+        var step = new Step(Step.CurrentSchemaVersion, Guid.NewGuid(), StepKind.ListFiles,
+            Path: _tempDir, MaxDepth: 1, WithSizes: true, SortBy: DirectorySortBy.Size);
+
+        var result = await NewHandler().HandleAsync(step, NoEvents, CancellationToken.None);
+
+        var entries = JsonSerializer.Deserialize<List<JsonElement>>(result.OutputContent!)!;
+        var files = entries.Where(e => !e.GetProperty("is_directory").GetBoolean()).ToList();
+        files.First().GetProperty("path").GetString().Should().Contain("big.txt");
+        files.First().GetProperty("size_bytes").GetInt64().Should().Be(1000);
+    }
+
+    private static FileStepHandler NewHandler() => new(NullLogger<FileStepHandler>.Instance);
+    private static Task NoEvents(IReadOnlyList<StepEvent> _) => Task.CompletedTask;
+}

--- a/tests/AgentSmith.Sandbox.Agent.Tests/Services/FileStepHandlerTests.cs
+++ b/tests/AgentSmith.Sandbox.Agent.Tests/Services/FileStepHandlerTests.cs
@@ -186,10 +186,11 @@ public class FileStepHandlerTests : IDisposable
         var result = await NewHandler().HandleAsync(step, NoEvents, CancellationToken.None);
 
         result.ExitCode.Should().Be(0);
-        var entries = JsonSerializer.Deserialize<string[]>(result.OutputContent!)!;
-        entries.Should().Contain(e => e.EndsWith("top.txt"));
-        entries.Should().Contain(e => e.EndsWith("sub"));
-        entries.Should().NotContain(e => e.EndsWith("nested.txt"));
+        var entries = JsonSerializer.Deserialize<List<JsonElement>>(result.OutputContent!)!;
+        var paths = entries.Select(e => e.GetProperty("path").GetString()!).ToList();
+        paths.Should().Contain(p => p.EndsWith("top.txt"));
+        paths.Should().Contain(p => p.EndsWith("sub"));
+        paths.Should().NotContain(p => p.EndsWith("nested.txt"));
     }
 
     [Fact]
@@ -203,8 +204,8 @@ public class FileStepHandlerTests : IDisposable
 
         var result = await NewHandler().HandleAsync(step, NoEvents, CancellationToken.None);
 
-        var entries = JsonSerializer.Deserialize<string[]>(result.OutputContent!)!;
-        entries.Should().Contain(e => e.EndsWith("nested.txt"));
+        var entries = JsonSerializer.Deserialize<List<JsonElement>>(result.OutputContent!)!;
+        entries.Select(e => e.GetProperty("path").GetString()).Should().Contain(p => p!.EndsWith("nested.txt"));
     }
 
     [Fact]
@@ -220,8 +221,8 @@ public class FileStepHandlerTests : IDisposable
             batch => { emitted.AddRange(batch); return Task.CompletedTask; },
             CancellationToken.None);
 
-        var entries = JsonSerializer.Deserialize<string[]>(result.OutputContent!)!;
-        entries.Length.Should().Be(SizeLimits.ListFilesMaxEntries);
+        var entries = JsonSerializer.Deserialize<List<JsonElement>>(result.OutputContent!)!;
+        entries.Count.Should().Be(SizeLimits.ListFilesMaxEntries);
         emitted.Should().Contain(e => e.Kind == StepEventKind.Stderr && e.Line.Contains("truncated"));
     }
 

--- a/tests/AgentSmith.Sandbox.Agent.Tests/Services/GrepStepHandlerTests.cs
+++ b/tests/AgentSmith.Sandbox.Agent.Tests/Services/GrepStepHandlerTests.cs
@@ -36,13 +36,13 @@ public sealed class GrepStepHandlerTests : IDisposable
     }
 
     [Fact]
-    public async Task HandleAsync_RespectsMaxMatches_AndEmitsTruncationEvent()
+    public async Task HandleAsync_RespectsHeadLimit_AndEmitsTruncationEvent()
     {
         File.WriteAllText(Path.Combine(_root, "a.cs"),
             string.Join('\n', Enumerable.Range(0, 10).Select(_ => "TODO")));
         var handler = BuildHandlerNoRipgrep();
         var step = new Step(1, Guid.NewGuid(), StepKind.Grep,
-            Path: _root, Pattern: "TODO", MaxMatches: 3);
+            Path: _root, Pattern: "TODO", HeadLimit: 3);
         var truncationEvents = new List<StepEvent>();
 
         var result = await handler.HandleAsync(step, evs =>

--- a/tests/AgentSmith.Sandbox.Agent.Tests/Services/StepExecutorTests.cs
+++ b/tests/AgentSmith.Sandbox.Agent.Tests/Services/StepExecutorTests.cs
@@ -15,7 +15,7 @@ public class StepExecutorTests
         var runner = new Mock<IProcessRunner>();
         runner.Setup(r => r.RunAsync(It.IsAny<Step>(), It.IsAny<Action<StepEventKind, string>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ProcessOutcome(0, false, null));
-        var executor = new StepExecutor(runner.Object, new FileStepHandler(NullLogger<FileStepHandler>.Instance), new GrepStepHandler(runner.Object, NullLogger<GrepStepHandler>.Instance), NullLogger<StepExecutor>.Instance);
+        var executor = new StepExecutor(runner.Object, new FileStepHandler(NullLogger<FileStepHandler>.Instance), new GrepStepHandler(runner.Object, NullLogger<GrepStepHandler>.Instance), new DirectoryTreeStepHandler(NullLogger<DirectoryTreeStepHandler>.Instance), NullLogger<StepExecutor>.Instance);
         var batches = new List<IReadOnlyList<StepEvent>>();
 
         var result = await executor.ExecuteAsync(
@@ -33,7 +33,7 @@ public class StepExecutorTests
         var runner = new Mock<IProcessRunner>();
         runner.Setup(r => r.RunAsync(It.IsAny<Step>(), It.IsAny<Action<StepEventKind, string>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ProcessOutcome(0, false, null));
-        var executor = new StepExecutor(runner.Object, new FileStepHandler(NullLogger<FileStepHandler>.Instance), new GrepStepHandler(runner.Object, NullLogger<GrepStepHandler>.Instance), NullLogger<StepExecutor>.Instance);
+        var executor = new StepExecutor(runner.Object, new FileStepHandler(NullLogger<FileStepHandler>.Instance), new GrepStepHandler(runner.Object, NullLogger<GrepStepHandler>.Instance), new DirectoryTreeStepHandler(NullLogger<DirectoryTreeStepHandler>.Instance), NullLogger<StepExecutor>.Instance);
         var events = new List<StepEvent>();
 
         await executor.ExecuteAsync(MakeRunStep("echo", "hi"),
@@ -49,7 +49,7 @@ public class StepExecutorTests
         var runner = new Mock<IProcessRunner>();
         runner.Setup(r => r.RunAsync(It.IsAny<Step>(), It.IsAny<Action<StepEventKind, string>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ProcessOutcome(-1, true, "timed out"));
-        var executor = new StepExecutor(runner.Object, new FileStepHandler(NullLogger<FileStepHandler>.Instance), new GrepStepHandler(runner.Object, NullLogger<GrepStepHandler>.Instance), NullLogger<StepExecutor>.Instance);
+        var executor = new StepExecutor(runner.Object, new FileStepHandler(NullLogger<FileStepHandler>.Instance), new GrepStepHandler(runner.Object, NullLogger<GrepStepHandler>.Instance), new DirectoryTreeStepHandler(NullLogger<DirectoryTreeStepHandler>.Instance), NullLogger<StepExecutor>.Instance);
 
         var result = await executor.ExecuteAsync(MakeRunStep("sleep", "5"),
             _ => Task.CompletedTask, CancellationToken.None);
@@ -62,7 +62,7 @@ public class StepExecutorTests
     public async Task ExecuteAsync_ShutdownStep_ThrowsArgumentException()
     {
         var runner = new Mock<IProcessRunner>();
-        var executor = new StepExecutor(runner.Object, new FileStepHandler(NullLogger<FileStepHandler>.Instance), new GrepStepHandler(runner.Object, NullLogger<GrepStepHandler>.Instance), NullLogger<StepExecutor>.Instance);
+        var executor = new StepExecutor(runner.Object, new FileStepHandler(NullLogger<FileStepHandler>.Instance), new GrepStepHandler(runner.Object, NullLogger<GrepStepHandler>.Instance), new DirectoryTreeStepHandler(NullLogger<DirectoryTreeStepHandler>.Instance), NullLogger<StepExecutor>.Instance);
 
         var act = () => executor.ExecuteAsync(Step.Shutdown(Guid.NewGuid()),
             _ => Task.CompletedTask, CancellationToken.None);
@@ -77,6 +77,7 @@ public class StepExecutorTests
         var executor = new StepExecutor(realRunner,
             new FileStepHandler(NullLogger<FileStepHandler>.Instance),
             new GrepStepHandler(realRunner, NullLogger<GrepStepHandler>.Instance),
+            new DirectoryTreeStepHandler(NullLogger<DirectoryTreeStepHandler>.Instance),
             NullLogger<StepExecutor>.Instance);
         var allEvents = new ConcurrentEventCollector();
         var step = new Step(Step.CurrentSchemaVersion, Guid.NewGuid(), StepKind.Run,

--- a/tests/AgentSmith.Tests/Dispatcher/SlackTypedQuestionTests.cs
+++ b/tests/AgentSmith.Tests/Dispatcher/SlackTypedQuestionTests.cs
@@ -20,12 +20,13 @@ public sealed class SlackTypedQuestionTests
         string? defaultAnswer = null,
         TimeSpan? timeout = null)
     {
+        var rich = choices?.Select(c => new DialogChoice(c)).ToList();
         return new DialogQuestion(
             questionId,
             type,
             text,
             context,
-            choices,
+            rich,
             defaultAnswer,
             timeout ?? TimeSpan.FromSeconds(30));
     }

--- a/tests/AgentSmith.Tests/Dispatcher/TeamsCardBuilderTests.cs
+++ b/tests/AgentSmith.Tests/Dispatcher/TeamsCardBuilderTests.cs
@@ -13,8 +13,9 @@ public sealed class TeamsCardBuilderTests
         string? context = null,
         IReadOnlyList<string>? choices = null)
     {
+        var rich = choices?.Select(c => new DialogChoice(c)).ToList();
         return new DialogQuestion(
-            questionId, type, text, context, choices, null, TimeSpan.FromSeconds(30));
+            questionId, type, text, context, rich, null, TimeSpan.FromSeconds(30));
     }
 
     [Fact]

--- a/tests/AgentSmith.Tests/Loop/ToolKitTests.cs
+++ b/tests/AgentSmith.Tests/Loop/ToolKitTests.cs
@@ -56,14 +56,14 @@ public sealed class ToolKitTests
 
         var tools = NamesOf(kit.GetToolsFor("fix-bug", SkillExecutionPhase.Implementation, null, hosts));
 
-        // p0152: 9 new filesystem-host primitives (read/write/edit/list_directory/
-        // find_files/grep_in_file/grep_in_tree/run/http) + 3 deprecated aliases
-        // (grep/glob/list_files) + log_decision + ask_human = 14 total.
-        tools.Should().HaveCount(14);
+        // p0153: 11 filesystem-host primitives (read/write/edit/multi_edit/
+        // list_directory/directory_tree/find_files/grep_in_file/grep_in_tree/
+        // run/http) + 3 deprecated aliases + log_decision + ask_human = 16 total.
+        tools.Should().HaveCount(16);
         tools.Should().Contain(new[]
         {
-            "read_file", "write_file", "edit",
-            "list_directory", "find_files", "grep_in_file", "grep_in_tree",
+            "read_file", "write_file", "edit", "multi_edit",
+            "list_directory", "directory_tree", "find_files", "grep_in_file", "grep_in_tree",
             "run_command", "http_request",
             "log_decision", "ask_human",
             "grep", "glob", "list_files" // deprecated aliases — backward-compat for v2.5.1 skills
@@ -101,7 +101,7 @@ public sealed class ToolKitTests
         var tools = NamesOf(kit.GetToolsFor("fix-bug", null, null, hosts));
 
         // Same count as Implementation: full filesystem-host surface + log_decision + ask_human.
-        tools.Should().HaveCount(14);
+        tools.Should().HaveCount(16);
     }
 
     [Fact]

--- a/tests/AgentSmith.Tests/Prompts/SourceAnchoringPreambleTests.cs
+++ b/tests/AgentSmith.Tests/Prompts/SourceAnchoringPreambleTests.cs
@@ -13,13 +13,34 @@ public sealed class SourceAnchoringPreambleTests
         var text = preamble.Build();
 
         text.Should().Contain("read_file")
-            .And.Contain("grep")
-            .And.Contain("glob")
-            .And.Contain("list_files")
+            .And.Contain("grep_in_file")
+            .And.Contain("grep_in_tree")
+            .And.Contain("find_files")
+            .And.Contain("list_directory")
+            .And.Contain("directory_tree")
             .And.Contain("edit")
+            .And.Contain("multi_edit")
             .And.Contain("write_file")
             .And.Contain("run_command")
             .And.Contain("http_request");
+    }
+
+    [Fact]
+    public void Build_DoesNotNameDeprecatedAliases()
+    {
+        // p0153: deprecated grep / glob / list_files stay registered as forwarders
+        // but the preamble must steer the LLM at the new names. p0154 removes the
+        // aliases.
+        var preamble = new SourceAnchoringPreamble();
+
+        var text = preamble.Build();
+
+        text.Should().NotMatchRegex(@"\bglob\b");
+        text.Should().NotMatchRegex(@"\blist_files\b");
+        // 'grep' is part of 'grep_in_file' / 'grep_in_tree' so we cannot regex on
+        // it; instead assert the standalone-tool comma-separated list does not
+        // mention it as its own entry.
+        text.Should().NotContain(", grep, ");
     }
 
     [Fact]

--- a/tests/AgentSmith.Tests/Services/Dialogue/ConsoleDialogueTransportTests.cs
+++ b/tests/AgentSmith.Tests/Services/Dialogue/ConsoleDialogueTransportTests.cs
@@ -18,7 +18,7 @@ public sealed class ConsoleDialogueTransportTests
         QuestionType type, string text = "Test?", string? context = null,
         IReadOnlyList<string>? choices = null, string? defaultAnswer = null,
         TimeSpan? timeout = null) =>
-        new("q-1", type, text, context, choices, defaultAnswer, timeout ?? TimeSpan.FromMinutes(1));
+        new("q-1", type, text, context, choices?.Select(c => new DialogChoice(c)).ToList(), defaultAnswer, timeout ?? TimeSpan.FromMinutes(1));
 
     [Fact]
     public async Task InfoType_ReturnsNull_WithoutWaitingForInput()

--- a/tests/AgentSmith.Tests/Services/Dialogue/RedisDialogueTransportTests.cs
+++ b/tests/AgentSmith.Tests/Services/Dialogue/RedisDialogueTransportTests.cs
@@ -53,7 +53,7 @@ public sealed class RedisDialogueTransportTests
     {
         var question = new DialogQuestion(
             "q-choice", QuestionType.Choice, "Pick one",
-            null, ["A", "B", "C"], "A", TimeSpan.FromMinutes(1));
+            null, [new DialogChoice("A"), new DialogChoice("B"), new DialogChoice("C")], "A", TimeSpan.FromMinutes(1));
 
         _db.Setup(d => d.StreamAddAsync(
                 It.IsAny<RedisKey>(), It.IsAny<NameValueEntry[]>(),

--- a/tests/AgentSmith.Tests/Services/RunResultFormatterDialogueTrailTests.cs
+++ b/tests/AgentSmith.Tests/Services/RunResultFormatterDialogueTrailTests.cs
@@ -22,7 +22,7 @@ public sealed class RunResultFormatterDialogueTrailTests
                     new DateTimeOffset(2025, 3, 15, 14, 3, 12, TimeSpan.Zero), "@holger")),
             new(
                 new DialogQuestion("q2", QuestionType.Choice, "Which approach?",
-                    "Two valid options", new List<string> { "A", "B" }.AsReadOnly(), "A", TimeSpan.FromMinutes(5)),
+                    "Two valid options", new List<DialogChoice> { new("A"), new("B") }.AsReadOnly(), "A", TimeSpan.FromMinutes(5)),
                 new DialogAnswer("q2", "B", null,
                     new DateTimeOffset(2025, 3, 15, 14, 10, 0, TimeSpan.Zero), "@dev"))
         };

--- a/tests/AgentSmith.Tests/Tools/FilesystemToolHostEditAndMultiEditTests.cs
+++ b/tests/AgentSmith.Tests/Tools/FilesystemToolHostEditAndMultiEditTests.cs
@@ -1,0 +1,114 @@
+using AgentSmith.Application.Services.Tools;
+using AgentSmith.Contracts.Sandbox;
+using AgentSmith.Sandbox.Wire;
+using FluentAssertions;
+using Moq;
+
+namespace AgentSmith.Tests.Tools;
+
+public sealed class FilesystemToolHostEditAndMultiEditTests
+{
+    [Fact]
+    public async Task Edit_ReplaceAllTrue_ReplacesEveryOccurrence_ReportsCount()
+    {
+        var (host, written) = BuildWithContent("foo bar foo baz foo");
+
+        var result = await host.Edit("file.cs", "foo", "qux", replace_all: true);
+
+        result.Should().Contain("Replaced 3 occurrence(s)");
+        written.Last().Should().Be("qux bar qux baz qux");
+    }
+
+    [Fact]
+    public async Task Edit_ReplaceAllFalse_RejectsMultipleOccurrences()
+    {
+        var (host, _) = BuildWithContent("foo bar foo");
+
+        var result = await host.Edit("file.cs", "foo", "qux");
+
+        result.Should().StartWith("Error").And.Contain("multiple times");
+    }
+
+    [Fact]
+    public async Task Edit_SingleOccurrence_ReplacesOnce()
+    {
+        var (host, written) = BuildWithContent("the only foo here");
+
+        var result = await host.Edit("file.cs", "foo", "qux");
+
+        result.Should().StartWith("File written");
+        written.Last().Should().Be("the only qux here");
+    }
+
+    [Fact]
+    public async Task MultiEdit_AppliesAllEditsAtomically_InOrder()
+    {
+        var (host, written) = BuildWithContent("alpha beta gamma");
+        var edits = new List<FilesystemToolHost.MultiEditOp>
+        {
+            new("alpha", "ONE"),
+            new("beta", "TWO"),
+            new("gamma", "THREE")
+        };
+
+        var result = await host.MultiEdit("file.cs", edits);
+
+        result.Should().Contain("Applied 3 edit(s)");
+        written.Last().Should().Be("ONE TWO THREE");
+    }
+
+    [Fact]
+    public async Task MultiEdit_OneEditFails_NothingWritten()
+    {
+        var (host, written) = BuildWithContent("alpha beta");
+        var edits = new List<FilesystemToolHost.MultiEditOp>
+        {
+            new("alpha", "ONE"),
+            new("not-present", "X")
+        };
+
+        var result = await host.MultiEdit("file.cs", edits);
+
+        result.Should().StartWith("Error in edit #2");
+        written.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task MultiEdit_DryRun_DoesNotWriteFile()
+    {
+        var (host, written) = BuildWithContent("alpha beta");
+        var edits = new List<FilesystemToolHost.MultiEditOp> { new("alpha", "ONE") };
+
+        var result = await host.MultiEdit("file.cs", edits, dry_run: true);
+
+        result.Should().StartWith("dry_run").And.Contain("would apply 1 edit");
+        written.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task MultiEdit_EmptyEdits_ReturnsError()
+    {
+        var (host, _) = BuildWithContent("anything");
+        var result = await host.MultiEdit("file.cs", new List<FilesystemToolHost.MultiEditOp>());
+        result.Should().StartWith("Error").And.Contain("at least one");
+    }
+
+    private static (FilesystemToolHost Host, List<string> WrittenContents) BuildWithContent(string initialContent)
+    {
+        var written = new List<string>();
+        var content = initialContent;
+        var sandbox = new Mock<ISandbox>();
+        sandbox.Setup(s => s.RunStepAsync(It.Is<Step>(st => st.Kind == StepKind.ReadFile),
+                It.IsAny<IProgress<StepEvent>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => new StepResult(1, Guid.NewGuid(), 0, false, 0.1, null, content));
+        sandbox.Setup(s => s.RunStepAsync(It.Is<Step>(st => st.Kind == StepKind.WriteFile),
+                It.IsAny<IProgress<StepEvent>?>(), It.IsAny<CancellationToken>()))
+            .Callback<Step, IProgress<StepEvent>?, CancellationToken>((step, _, _) =>
+            {
+                written.Add(step.Content!);
+                content = step.Content!;
+            })
+            .ReturnsAsync(() => new StepResult(1, Guid.NewGuid(), 0, false, 0.1, null, "OK"));
+        return (new FilesystemToolHost(sandbox.Object), written);
+    }
+}

--- a/tests/AgentSmith.Tests/Tools/FilesystemToolHostGrepModesTests.cs
+++ b/tests/AgentSmith.Tests/Tools/FilesystemToolHostGrepModesTests.cs
@@ -1,0 +1,86 @@
+using AgentSmith.Application.Services.Tools;
+using AgentSmith.Contracts.Sandbox;
+using AgentSmith.Sandbox.Wire;
+using FluentAssertions;
+using Moq;
+
+namespace AgentSmith.Tests.Tools;
+
+public sealed class FilesystemToolHostGrepModesTests
+{
+    [Fact]
+    public async Task GrepInTree_DefaultsToContentMode()
+    {
+        var sandbox = new Mock<ISandbox>();
+        Step? captured = null;
+        sandbox.Setup(s => s.RunStepAsync(It.IsAny<Step>(), It.IsAny<IProgress<StepEvent>?>(), It.IsAny<CancellationToken>()))
+            .Callback<Step, IProgress<StepEvent>?, CancellationToken>((s, _, _) => captured = s)
+            .ReturnsAsync(new StepResult(1, Guid.NewGuid(), 0, false, 0.1, null, "[]"));
+        var host = new FilesystemToolHost(sandbox.Object);
+
+        await host.GrepInTree("foo", ".");
+
+        captured!.OutputMode.Should().Be(GrepOutputMode.Content);
+    }
+
+    [Fact]
+    public async Task GrepInTree_OutputModeFilesWithMatches_RendersPathsOnly()
+    {
+        var sandbox = MockSandboxWithGrepResult("[{\"path\":\"a.cs\"},{\"path\":\"b.cs\"}]");
+        var host = new FilesystemToolHost(sandbox.Object);
+
+        var result = await host.GrepInTree("foo", ".", output_mode: "files_with_matches");
+
+        result.Should().Contain("a.cs").And.Contain("b.cs").And.NotContain(":");
+    }
+
+    [Fact]
+    public async Task GrepInTree_OutputModeCount_RendersPathColonCount()
+    {
+        var sandbox = MockSandboxWithGrepResult("[{\"path\":\"a.cs\",\"count\":5},{\"path\":\"b.cs\",\"count\":2}]");
+        var host = new FilesystemToolHost(sandbox.Object);
+
+        var result = await host.GrepInTree("foo", ".", output_mode: "count");
+
+        result.Should().Contain("a.cs: 5").And.Contain("b.cs: 2");
+    }
+
+    [Fact]
+    public async Task GrepInTree_ContextShorthand_AppliesToBothBeforeAndAfter()
+    {
+        var sandbox = new Mock<ISandbox>();
+        Step? captured = null;
+        sandbox.Setup(s => s.RunStepAsync(It.IsAny<Step>(), It.IsAny<IProgress<StepEvent>?>(), It.IsAny<CancellationToken>()))
+            .Callback<Step, IProgress<StepEvent>?, CancellationToken>((s, _, _) => captured = s)
+            .ReturnsAsync(new StepResult(1, Guid.NewGuid(), 0, false, 0.1, null, "[]"));
+        var host = new FilesystemToolHost(sandbox.Object);
+
+        await host.GrepInTree("foo", ".", context: 3);
+
+        captured!.ContextBefore.Should().Be(3);
+        captured.ContextAfter.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task GrepInTree_PassesHeadLimitToSandbox()
+    {
+        var sandbox = new Mock<ISandbox>();
+        Step? captured = null;
+        sandbox.Setup(s => s.RunStepAsync(It.IsAny<Step>(), It.IsAny<IProgress<StepEvent>?>(), It.IsAny<CancellationToken>()))
+            .Callback<Step, IProgress<StepEvent>?, CancellationToken>((s, _, _) => captured = s)
+            .ReturnsAsync(new StepResult(1, Guid.NewGuid(), 0, false, 0.1, null, "[]"));
+        var host = new FilesystemToolHost(sandbox.Object);
+
+        await host.GrepInTree("foo", ".", head_limit: 50);
+
+        captured!.HeadLimit.Should().Be(50);
+    }
+
+    private static Mock<ISandbox> MockSandboxWithGrepResult(string outputContent)
+    {
+        var sandbox = new Mock<ISandbox>();
+        sandbox.Setup(s => s.RunStepAsync(It.IsAny<Step>(), It.IsAny<IProgress<StepEvent>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new StepResult(1, Guid.NewGuid(), 0, false, 0.1, null, outputContent));
+        return sandbox;
+    }
+}

--- a/tests/AgentSmith.Tests/Tools/FilesystemToolHostReadRangeTests.cs
+++ b/tests/AgentSmith.Tests/Tools/FilesystemToolHostReadRangeTests.cs
@@ -1,0 +1,44 @@
+using AgentSmith.Application.Services.Tools;
+using AgentSmith.Contracts.Sandbox;
+using AgentSmith.Sandbox.Wire;
+using FluentAssertions;
+using Moq;
+
+namespace AgentSmith.Tests.Tools;
+
+public sealed class FilesystemToolHostReadRangeTests
+{
+    [Fact]
+    public async Task ReadFile_PassesStartLineAndLineCountToSandbox()
+    {
+        var sandbox = new Mock<ISandbox>();
+        Step? captured = null;
+        sandbox.Setup(s => s.RunStepAsync(It.IsAny<Step>(), It.IsAny<IProgress<StepEvent>?>(), It.IsAny<CancellationToken>()))
+            .Callback<Step, IProgress<StepEvent>?, CancellationToken>((s, _, _) => captured = s)
+            .ReturnsAsync(new StepResult(1, Guid.NewGuid(), 0, false, 0.1, null, "line content"));
+        var host = new FilesystemToolHost(sandbox.Object);
+
+        await host.ReadFile("foo.cs", start_line: 10, line_count: 5);
+
+        captured.Should().NotBeNull();
+        captured!.Kind.Should().Be(StepKind.ReadFile);
+        captured.StartLine.Should().Be(10);
+        captured.LineCount.Should().Be(5);
+        captured.WithLineNumbers.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ReadFile_WithLineNumbersFalse_PassesFlagThroughToSandbox()
+    {
+        var sandbox = new Mock<ISandbox>();
+        Step? captured = null;
+        sandbox.Setup(s => s.RunStepAsync(It.IsAny<Step>(), It.IsAny<IProgress<StepEvent>?>(), It.IsAny<CancellationToken>()))
+            .Callback<Step, IProgress<StepEvent>?, CancellationToken>((s, _, _) => captured = s)
+            .ReturnsAsync(new StepResult(1, Guid.NewGuid(), 0, false, 0.1, null, "bare content"));
+        var host = new FilesystemToolHost(sandbox.Object);
+
+        await host.ReadFile("foo.cs", with_line_numbers: false);
+
+        captured!.WithLineNumbers.Should().BeFalse();
+    }
+}

--- a/tests/AgentSmith.Tests/Tools/FilesystemToolHostRunCommandTests.cs
+++ b/tests/AgentSmith.Tests/Tools/FilesystemToolHostRunCommandTests.cs
@@ -1,0 +1,76 @@
+using AgentSmith.Application.Services.Tools;
+using AgentSmith.Contracts.Sandbox;
+using AgentSmith.Sandbox.Wire;
+using FluentAssertions;
+using Moq;
+
+namespace AgentSmith.Tests.Tools;
+
+public sealed class FilesystemToolHostRunCommandTests
+{
+    [Fact]
+    public async Task RunCommand_ReturnsLabeledSections_WithStdoutAndStderrSeparated()
+    {
+        var sandbox = new Mock<ISandbox>();
+        sandbox.Setup(s => s.RunStepAsync(It.IsAny<Step>(), It.IsAny<IProgress<StepEvent>?>(), It.IsAny<CancellationToken>()))
+            .Callback<Step, IProgress<StepEvent>?, CancellationToken>((_, progress, _) =>
+            {
+                progress!.Report(new StepEvent(1, Guid.NewGuid(), StepEventKind.Stdout, "stdout line", DateTimeOffset.UtcNow));
+                progress.Report(new StepEvent(1, Guid.NewGuid(), StepEventKind.Stderr, "stderr line", DateTimeOffset.UtcNow));
+            })
+            .ReturnsAsync(new StepResult(1, Guid.NewGuid(), 0, false, 0.1, null));
+        var host = new FilesystemToolHost(sandbox.Object);
+
+        var result = await host.RunCommand("echo test");
+
+        result.Should().Contain("exit_code: 0");
+        result.Should().Contain("elapsed_ms:");
+        result.Should().Contain("truncated: false");
+        result.Should().Contain("stdout:\nstdout line");
+        result.Should().Contain("stderr:\nstderr line");
+    }
+
+    [Fact]
+    public async Task RunCommand_TimeoutOverride_PassedThroughClampedTo600s()
+    {
+        var sandbox = new Mock<ISandbox>();
+        Step? captured = null;
+        sandbox.Setup(s => s.RunStepAsync(It.IsAny<Step>(), It.IsAny<IProgress<StepEvent>?>(), It.IsAny<CancellationToken>()))
+            .Callback<Step, IProgress<StepEvent>?, CancellationToken>((s, _, _) => captured = s)
+            .ReturnsAsync(new StepResult(1, Guid.NewGuid(), 0, false, 0.1, null));
+        var host = new FilesystemToolHost(sandbox.Object);
+
+        await host.RunCommand("dotnet build", timeout_seconds: 300);
+        captured!.TimeoutSeconds.Should().Be(300);
+
+        await host.RunCommand("dotnet build", timeout_seconds: 9999);
+        captured!.TimeoutSeconds.Should().Be(600);
+    }
+
+    [Fact]
+    public async Task RunCommand_DefaultTimeout_Is60Seconds()
+    {
+        var sandbox = new Mock<ISandbox>();
+        Step? captured = null;
+        sandbox.Setup(s => s.RunStepAsync(It.IsAny<Step>(), It.IsAny<IProgress<StepEvent>?>(), It.IsAny<CancellationToken>()))
+            .Callback<Step, IProgress<StepEvent>?, CancellationToken>((s, _, _) => captured = s)
+            .ReturnsAsync(new StepResult(1, Guid.NewGuid(), 0, false, 0.1, null));
+        var host = new FilesystemToolHost(sandbox.Object);
+
+        await host.RunCommand("echo");
+        captured!.TimeoutSeconds.Should().Be(60);
+    }
+
+    [Fact]
+    public async Task RunCommand_TimedOutResult_SetsTimedOutFlag()
+    {
+        var sandbox = new Mock<ISandbox>();
+        sandbox.Setup(s => s.RunStepAsync(It.IsAny<Step>(), It.IsAny<IProgress<StepEvent>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new StepResult(1, Guid.NewGuid(), -1, true, 60, "step timed out"));
+        var host = new FilesystemToolHost(sandbox.Object);
+
+        var result = await host.RunCommand("sleep 9999");
+
+        result.Should().Contain("timed_out: true");
+    }
+}

--- a/tests/AgentSmith.Tests/Tools/FilesystemToolHostTests.cs
+++ b/tests/AgentSmith.Tests/Tools/FilesystemToolHostTests.cs
@@ -27,17 +27,20 @@ public sealed class FilesystemToolHostTests
     // find_files (was glob), list_directory (was list_files). Old names remain in
     // every phase set as deprecated aliases until the agent-smith-skills catalog
     // migrates its prompts; the assertions below cover both new + deprecated.
+    // p0153: surface gains directory_tree + multi_edit; deprecated grep / glob /
+    // list_files stay registered as forwarders until p0154 ships the skills rename.
     private static readonly string[] ReadOnlyToolNames =
     {
         "read_file", "grep_in_file", "grep_in_tree", "find_files", "list_directory",
-        "run_command", "http_request",
+        "directory_tree", "run_command", "http_request",
         "grep", "glob", "list_files" // deprecated aliases
     };
 
     private static readonly string[] WriteCapableToolNames =
     {
-        "read_file", "write_file", "edit", "grep_in_file", "grep_in_tree", "find_files",
-        "list_directory", "run_command", "http_request",
+        "read_file", "write_file", "edit", "multi_edit",
+        "grep_in_file", "grep_in_tree", "find_files",
+        "list_directory", "directory_tree", "run_command", "http_request",
         "grep", "glob", "list_files" // deprecated aliases
     };
 
@@ -157,7 +160,7 @@ public sealed class FilesystemToolHostTests
 
         var result = await host.RunCommand("echo hi");
 
-        result.Should().Contain("Exit code: 0");
+        result.Should().Contain("exit_code: 0").And.Contain("stdout:").And.Contain("stderr:");
         sandbox.VerifyAll();
     }
 
@@ -186,7 +189,8 @@ public sealed class FilesystemToolHostTests
                 It.Is<Step>(st => st.Kind == StepKind.Grep),
                 It.IsAny<IProgress<StepEvent>?>(),
                 It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new StepResult(1, Guid.NewGuid(), 0, false, 0.1, null, "[{\"file\":\"x.cs\"}]"));
+            .ReturnsAsync(new StepResult(1, Guid.NewGuid(), 0, false, 0.1, null,
+                "[{\"path\":\"x.cs\",\"line\":1,\"text\":\"foo\",\"kind\":\"match\"}]"));
         var host = Build(sandbox.Object);
 
         var result = await host.Grep("foo", ".");

--- a/tests/AgentSmith.Tests/Tools/FilesystemToolHostTests.cs
+++ b/tests/AgentSmith.Tests/Tools/FilesystemToolHostTests.cs
@@ -148,6 +148,43 @@ public sealed class FilesystemToolHostTests
     }
 
     [Fact]
+    public async Task GetChanges_TwoWritesSamePath_DedupedToLatestContent()
+    {
+        var sandbox = new Mock<ISandbox>();
+        sandbox.Setup(s => s.RunStepAsync(
+                It.Is<Step>(st => st.Kind == StepKind.WriteFile),
+                It.IsAny<IProgress<StepEvent>?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new StepResult(1, Guid.NewGuid(), 0, false, 0.1, null));
+        var host = Build(sandbox.Object);
+
+        await host.WriteFile("src/x.cs", "v1");
+        await host.WriteFile("src/x.cs", "v2");
+
+        var changes = host.GetChanges();
+        changes.Should().ContainSingle();
+        changes[0].Path.Value.Should().Be("src/x.cs");
+        changes[0].Content.Should().Be("v2");
+    }
+
+    [Fact]
+    public async Task GetChanges_WritesToTwoDifferentPaths_KeepsBoth()
+    {
+        var sandbox = new Mock<ISandbox>();
+        sandbox.Setup(s => s.RunStepAsync(
+                It.Is<Step>(st => st.Kind == StepKind.WriteFile),
+                It.IsAny<IProgress<StepEvent>?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new StepResult(1, Guid.NewGuid(), 0, false, 0.1, null));
+        var host = Build(sandbox.Object);
+
+        await host.WriteFile("src/a.cs", "a");
+        await host.WriteFile("src/b.cs", "b");
+
+        host.GetChanges().Select(c => c.Path.Value).Should().BeEquivalentTo(new[] { "src/a.cs", "src/b.cs" });
+    }
+
+    [Fact]
     public async Task RunCommand_DelegatesToSandbox()
     {
         var sandbox = new Mock<ISandbox>();

--- a/tests/AgentSmith.Tests/Tools/HumanToolHostRichChoicesTests.cs
+++ b/tests/AgentSmith.Tests/Tools/HumanToolHostRichChoicesTests.cs
@@ -1,0 +1,51 @@
+using AgentSmith.Application.Services.Tools;
+using AgentSmith.Contracts.Dialogue;
+using FluentAssertions;
+using Moq;
+
+namespace AgentSmith.Tests.Tools;
+
+public sealed class HumanToolHostRichChoicesTests
+{
+    [Fact]
+    public async Task AskHuman_RichChoices_CarriedThroughTransport()
+    {
+        var transport = new Mock<IDialogueTransport>();
+        DialogQuestion? published = null;
+        transport.Setup(t => t.PublishQuestionAsync(It.IsAny<string>(), It.IsAny<DialogQuestion>(), It.IsAny<CancellationToken>()))
+            .Callback<string, DialogQuestion, CancellationToken>((_, q, _) => published = q);
+        transport.Setup(t => t.WaitForAnswerAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new DialogAnswer("q", "A", null, DateTimeOffset.UtcNow, "user"));
+        var host = new HumanToolHost(transport.Object, jobId: "job-1");
+
+        var choices = new List<HumanToolHost.AskHumanChoice>
+        {
+            new("Approve", "Ship it"),
+            new("Reject", "Block the change")
+        };
+        await host.AskHuman("Ship?", context: "Risky migration", choices: choices, recommended_index: 0);
+
+        published.Should().NotBeNull();
+        published!.Choices.Should().HaveCount(2);
+        published.Choices![0].Label.Should().Be("Approve");
+        published.Choices[0].Description.Should().Be("Ship it");
+        published.RecommendedIndex.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task AskHuman_NoChoices_TypeIsFreeText()
+    {
+        var transport = new Mock<IDialogueTransport>();
+        DialogQuestion? published = null;
+        transport.Setup(t => t.PublishQuestionAsync(It.IsAny<string>(), It.IsAny<DialogQuestion>(), It.IsAny<CancellationToken>()))
+            .Callback<string, DialogQuestion, CancellationToken>((_, q, _) => published = q);
+        transport.Setup(t => t.WaitForAnswerAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((DialogAnswer?)null);
+        var host = new HumanToolHost(transport.Object, jobId: "job-1");
+
+        await host.AskHuman("Anything to add?");
+
+        published!.Type.Should().Be(QuestionType.FreeText);
+        published.RecommendedIndex.Should().BeNull();
+    }
+}

--- a/tests/AgentSmith.Tests/Tools/ToolKitCompositionTests.cs
+++ b/tests/AgentSmith.Tests/Tools/ToolKitCompositionTests.cs
@@ -28,11 +28,12 @@ public sealed class ToolKitCompositionTests
 
         var tools = NamesOf(kit.GetToolsFor("fix-bug", SkillExecutionPhase.Plan, null, DefaultHosts()));
 
-        // p0152: read-side filesystem surface (new primitives + deprecated aliases)
-        // + log_decision + ask_human. No write_file / edit in Plan.
+        // p0153: read-side filesystem surface (new primitives + directory_tree
+        // + deprecated aliases) + log_decision + ask_human. No write_file / edit /
+        // multi_edit in Plan.
         tools.Should().BeEquivalentTo(
             "read_file", "grep_in_file", "grep_in_tree", "find_files", "list_directory",
-            "run_command", "http_request",
+            "directory_tree", "run_command", "http_request",
             "grep", "glob", "list_files", // deprecated aliases
             "log_decision", "ask_human");
     }
@@ -44,8 +45,8 @@ public sealed class ToolKitCompositionTests
 
         var tools = NamesOf(kit.GetToolsFor("fix-bug", SkillExecutionPhase.Implementation, null, DefaultHosts()));
 
-        // p0152: 9 new filesystem-host primitives + 3 deprecated aliases + log_decision + ask_human.
-        tools.Should().HaveCount(14);
+        // p0153: 11 filesystem-host primitives + 3 deprecated aliases + log_decision + ask_human = 16.
+        tools.Should().HaveCount(16);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Brings `FilesystemToolHost` + `HumanToolHost` to MCP filesystem-server / Claude-Code parity so the same tool surface works across Anthropic, OpenAI strict, Azure OpenAI, and Ollama. Schemas mirror published references where they exist; parameter lists stay flat and primitive-typed so OpenAI strict mode and small Ollama tool calling both accept the generated JSON schema.

### Tool surface deltas

| Tool | Change |
|---|---|
| `read_file` | `start_line` + `line_count` + `with_line_numbers` (default true) |
| `edit` | `replace_all` flag |
| `multi_edit` | **NEW** — atomic batched edits with `dry_run` |
| `grep_in_*` | `context_before` / `context_after` / `context`, `output_mode` (`content`/`files_with_matches`/`count`), `head_limit` |
| `find_files` | path-relative globs (MCP `search_files` semantics), `head_limit` + visible truncation marker — **BREAKING** for skill callers relying on basename match; p0154 audits |
| `list_directory` | `with_sizes` + `sort_by` (`name`/`size`/`mtime`) |
| `directory_tree` | **NEW** — mirrors MCP filesystem-server `directory_tree` |
| `run_command` | `timeout_seconds` (up to 600s), labeled-section output (`exit_code` / `elapsed_ms` / `truncated` / `stdout` / `stderr`) — no JSON-in-string blob |
| `ask_human` | flat `choices: [{label, description?}]` + top-level `recommended_index` |

Deprecated `grep` / `glob` / `list_files` aliases stay registered as forwarders. `SourceAnchoringPreamble` names only the new tool set. p0154 (planned) removes the aliases together with the `agent-smith-skills` SKILL.md rename + glob-pattern audit + `web_fetch` tool.

### Implementation surface

- **Wire layer**: `Step` gains 10 new fields, `StepKind` gains `DirectoryTree`, new `GrepOutputMode` + `DirectorySortBy` enums, `MaxMatches` renamed `HeadLimit`, `SizeLimits.GrepDefaultHeadLimit = 1000` + `RunCommandMaxBufferBytes = 1 MB`.
- **Agent layer**: `FileStepHandler`, `GrepStepHandler` rewritten; new `DirectoryTreeStepHandler`; `StepExecutor` routes the new kind.
- **App layer**: `SandboxStepRunner` exposes the new shape; `RunAsync` collects stdout/stderr into separate buffers via inline sync `IProgress<T>` (fixes a real race vs `Progress<T>` ThreadPool dispatch).
- **`InProcessSandbox`** brought to CLI parity for ReadFile slicing + ListFiles sizes/sort + DirectoryTree. Grep modes parity in CLI mode deferred — agent-mode covers it; promote when a concrete use case appears.
- **Contracts**: `DialogChoice` record added; `DialogQuestion.Choices` migrated from `IReadOnlyList<string>` to `IReadOnlyList<DialogChoice>`; `RecommendedIndex` added. Teams / Slack / Console / Redis transports updated end-to-end.

Spec lives at `.agentsmith/phases/active/p0153-tool-surface-claude-code-parity.yaml`. Companion phase `p0154-web-tools-and-skills-rename.yaml` queued in `planned/` for the alias drop + web_fetch + skills catalogue work.

## Test plan

- [x] `dotnet build` clean (0 errors, 4 pre-existing warnings)
- [x] Full suite: **2029 passed** (43 new tests covering read_range, edit + multi_edit, grep modes, run_command labeled-sections, rich choices, directory_tree)
- [x] `/smoke fast`: CLI binary boots, all 4 pipeline `--help` exit 0, docker-compose absent (silently skipped)
- [ ] Cross-provider smoke (≥2 of Anthropic / OpenAI strict / Azure OpenAI / Ollama) — deferred until operator triggers; AIFunction schemas pass flatness invariant by construction
- [ ] Deep smoke (`api-scan` / `security-scan` / `fix-bug`) — operator-triggered, LLM cost