### PR TITLE
fix(sandbox): SandboxFileReader + TestHandler accept new ListFiles object shape

### DIFF
--- a/src/AgentSmith.Application/Services/Handlers/TestHandler.cs
+++ b/src/AgentSmith.Application/Services/Handlers/TestHandler.cs
@@ -119,12 +119,32 @@ public sealed class TestHandler(
         if (listResult.ExitCode != 0 || string.IsNullOrEmpty(listResult.OutputContent))
             return TrxSummary.Empty;
 
-        var entries = JsonSerializer.Deserialize<string[]>(listResult.OutputContent, WireFormat.Json) ?? Array.Empty<string>();
-        var trxPaths = entries.Where(e => e.EndsWith(".trx", StringComparison.OrdinalIgnoreCase)).ToList();
+        // p0153: ListFiles wire shape is [{path, size_bytes, mtime, is_directory}];
+        // legacy shape was string[]. Accept both — extract paths defensively.
+        var trxPaths = ExtractPathsEndingWith(listResult.OutputContent, ".trx");
         var summary = TrxSummary.Empty;
         foreach (var trxPath in trxPaths)
             summary = summary.Combine(await ParseSingleAsync(sandbox, trxPath, cancellationToken));
         return summary;
+    }
+
+    private static IReadOnlyList<string> ExtractPathsEndingWith(string json, string suffix)
+    {
+        using var doc = JsonDocument.Parse(json);
+        if (doc.RootElement.ValueKind != JsonValueKind.Array) return Array.Empty<string>();
+        var paths = new List<string>();
+        foreach (var entry in doc.RootElement.EnumerateArray())
+        {
+            var value = entry.ValueKind switch
+            {
+                JsonValueKind.String => entry.GetString(),
+                JsonValueKind.Object when entry.TryGetProperty("path", out var p) => p.GetString(),
+                _ => null
+            };
+            if (!string.IsNullOrEmpty(value) && value.EndsWith(suffix, StringComparison.OrdinalIgnoreCase))
+                paths.Add(value);
+        }
+        return paths;
     }
 
     private async Task<TrxSummary> ParseSingleAsync(ISandbox sandbox, string path, CancellationToken cancellationToken)

--- a/src/AgentSmith.Application/Services/Sandbox/SandboxFileReader.cs
+++ b/src/AgentSmith.Application/Services/Sandbox/SandboxFileReader.cs
@@ -48,7 +48,25 @@ internal sealed class SandboxFileReader(ISandbox sandbox) : ISandboxFileReader
             MakeStep(StepKind.ListFiles, path, maxDepth: maxDepth), null, cancellationToken);
         if (result.ExitCode != 0 || result.OutputContent is null)
             return Array.Empty<string>();
-        return JsonSerializer.Deserialize<string[]>(result.OutputContent) ?? Array.Empty<string>();
+        // p0153 changed the ListFiles wire format from string[] to
+        // [{path, size_bytes, mtime, is_directory}]. Extract the path field;
+        // accept the legacy string[] shape too for forward compatibility if a
+        // mismatched-version sandbox image is in use.
+        using var doc = JsonDocument.Parse(result.OutputContent);
+        if (doc.RootElement.ValueKind != JsonValueKind.Array)
+            return Array.Empty<string>();
+        var paths = new List<string>(doc.RootElement.GetArrayLength());
+        foreach (var entry in doc.RootElement.EnumerateArray())
+        {
+            var value = entry.ValueKind switch
+            {
+                JsonValueKind.String => entry.GetString(),
+                JsonValueKind.Object when entry.TryGetProperty("path", out var p) => p.GetString(),
+                _ => null
+            };
+            if (!string.IsNullOrEmpty(value)) paths.Add(value);
+        }
+        return paths;
     }
 
     private static Step MakeStep(StepKind kind, string path, string? content = null, int? maxDepth = null) =>

--- a/tests/AgentSmith.Tests/Services/Sandbox/SandboxFileReaderListShapeTests.cs
+++ b/tests/AgentSmith.Tests/Services/Sandbox/SandboxFileReaderListShapeTests.cs
@@ -1,0 +1,66 @@
+using AgentSmith.Application.Services.Sandbox;
+using AgentSmith.Contracts.Sandbox;
+using AgentSmith.Sandbox.Wire;
+using FluentAssertions;
+using Moq;
+
+namespace AgentSmith.Tests.Services.Sandbox;
+
+public sealed class SandboxFileReaderListShapeTests
+{
+    [Fact]
+    public async Task ListAsync_ObjectShape_ExtractsPathField()
+    {
+        var json = """[{"path":"a.cs","size_bytes":10,"mtime":"2026-05-20T22:00:00Z","is_directory":false},{"path":"b/","is_directory":true}]""";
+        var reader = BuildReader(json);
+
+        var paths = await reader.ListAsync("/work", maxDepth: 1, CancellationToken.None);
+
+        paths.Should().Equal("a.cs", "b/");
+    }
+
+    [Fact]
+    public async Task ListAsync_LegacyStringShape_StillParses()
+    {
+        var json = """["a.cs","b/"]""";
+        var reader = BuildReader(json);
+
+        var paths = await reader.ListAsync("/work", maxDepth: 1, CancellationToken.None);
+
+        paths.Should().Equal("a.cs", "b/");
+    }
+
+    [Fact]
+    public async Task ListAsync_EmptyArray_ReturnsEmpty()
+    {
+        var reader = BuildReader("[]");
+
+        var paths = await reader.ListAsync("/work", maxDepth: 1, CancellationToken.None);
+
+        paths.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ListAsync_NonZeroExitCode_ReturnsEmpty()
+    {
+        var sandbox = new Mock<ISandbox>();
+        sandbox.Setup(s => s.RunStepAsync(It.IsAny<Step>(), It.IsAny<IProgress<StepEvent>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new StepResult(1, Guid.NewGuid(), 1, false, 0.1, "fail", null));
+        var reader = new SandboxFileReader(sandbox.Object);
+
+        var paths = await reader.ListAsync("/work", maxDepth: 1, CancellationToken.None);
+
+        paths.Should().BeEmpty();
+    }
+
+    private static SandboxFileReader BuildReader(string outputJson)
+    {
+        var sandbox = new Mock<ISandbox>();
+        sandbox.Setup(s => s.RunStepAsync(
+                It.Is<Step>(st => st.Kind == StepKind.ListFiles),
+                It.IsAny<IProgress<StepEvent>?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new StepResult(1, Guid.NewGuid(), 0, false, 0.1, null, outputJson));
+        return new SandboxFileReader(sandbox.Object);
+    }
+}


### PR DESCRIPTION
## Summary

p0153 changed `StepKind.ListFiles` wire format from `string[]` to `[{path, size_bytes, mtime, is_directory}]`. I missed two consumers in the original PR:

- **`SandboxFileReader.ListAsync`** → broke `LoadContextCommand`, every fix-bug / feature pipeline failed at step 7 with the new v0.58.0 sandbox-agent image:
  ```
  JsonException: The JSON value could not be converted to System.String. Path: \$[0]
  ```
- **`TestHandler.CollectTrxAsync`** → broke TRX collection in the test step (same exception).

Both now defensively accept either shape — extract `path` from object entries, take string entries as-is. Forward-compatible with mixed sandbox-agent / server image versions during a rollout.

## Test plan

- [x] `dotnet build` clean
- [x] Full suite green (4 new tests covering both shape variants + empty array + non-zero exit fallback)
- [ ] Operator validates: re-run the failing fix-bug pipeline (#18794) — step 7 should now pass