### PR TITLE
fix(sandbox-agent): operator-grade logs — job scope, real command, single line

### DIFF
--- a/src/AgentSmith.Sandbox.Agent/Program.cs
+++ b/src/AgentSmith.Sandbox.Agent/Program.cs
@@ -73,6 +73,7 @@ internal static class Program
 
     private static ILoggerFactory BuildLoggerFactory(bool verbose) =>
         LoggerFactory.Create(builder => builder
-            .AddConsole()
+            .AddConsole(options => options.FormatterName = CompactConsoleFormatter.FormatterName)
+            .AddConsoleFormatter<CompactConsoleFormatter, Microsoft.Extensions.Logging.Console.ConsoleFormatterOptions>()
             .SetMinimumLevel(verbose ? LogLevel.Debug : LogLevel.Information));
 }

--- a/src/AgentSmith.Sandbox.Agent/Services/CompactConsoleFormatter.cs
+++ b/src/AgentSmith.Sandbox.Agent/Services/CompactConsoleFormatter.cs
@@ -1,0 +1,102 @@
+using System.Text;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Logging.Console;
+
+namespace AgentSmith.Sandbox.Agent.Services;
+
+/// <summary>
+/// Single-line console formatter for the sandbox-agent container, mirroring
+/// AgentSmith.Server.Services.Logging.CompactConsoleFormatter so operator-side
+/// `docker logs` reads consistently across server + agent containers.
+///
+/// Duplication is deliberate: AgentSmith.Sandbox.Agent is a standalone Exe with
+/// minimal dependencies (no reference to AgentSmith.Server). When the format
+/// changes, change both copies in lockstep — covered by a flatness test in
+/// AgentSmith.Sandbox.Agent.Tests if added later.
+/// </summary>
+internal sealed class CompactConsoleFormatter() : ConsoleFormatter(FormatterName)
+{
+    public const string FormatterName = "compact";
+
+    public override void Write<TState>(
+        in LogEntry<TState> logEntry,
+        IExternalScopeProvider? scopeProvider,
+        TextWriter textWriter)
+    {
+        var timestamp = DateTime.UtcNow.ToString("yyyy-MM-dd HH:mm:ss.fff");
+        var level = LevelLabel(logEntry.LogLevel);
+        var category = ShortCategory(logEntry.Category);
+        var message = logEntry.Formatter(logEntry.State, logEntry.Exception);
+        var scope = ScopeText(scopeProvider);
+
+        var output = new StringBuilder($"{timestamp} {level} {scope}[{category}] {message}");
+        if (logEntry.Exception is not null)
+            AppendExceptionChain(output, logEntry.Exception);
+
+        textWriter.WriteLine(output.ToString());
+    }
+
+    private static string LevelLabel(LogLevel level) => level switch
+    {
+        LogLevel.Trace => "trce",
+        LogLevel.Debug => "dbug",
+        LogLevel.Information => "info",
+        LogLevel.Warning => "warn",
+        LogLevel.Error => "FAIL",
+        LogLevel.Critical => "CRIT",
+        _ => level.ToString()
+    };
+
+    private static string ShortCategory(string category)
+    {
+        var parts = category.Split('.');
+        return parts.Length >= 2 ? $"{parts[^2]}.{parts[^1]}" : parts[^1];
+    }
+
+    private static readonly string[] FrameworkScopeMarkers =
+    [
+        "SpanId:", "TraceId:", "ParentId:",
+        "ConnectionId:",
+        "RequestPath:", "RequestId:",
+        "HTTP GET ", "HTTP POST ", "HTTP PATCH ", "HTTP PUT ", "HTTP DELETE "
+    ];
+
+    private static string ScopeText(IExternalScopeProvider? scopeProvider)
+    {
+        if (scopeProvider is null) return string.Empty;
+        var sb = new StringBuilder();
+        scopeProvider.ForEachScope((scope, builder) =>
+        {
+            var text = scope?.ToString();
+            if (string.IsNullOrEmpty(text)) return;
+            if (IsFrameworkScope(text)) return;
+            builder.Append($"[{text}] ");
+        }, sb);
+        return sb.ToString();
+    }
+
+    private static bool IsFrameworkScope(string scopeText)
+    {
+        foreach (var marker in FrameworkScopeMarkers)
+            if (scopeText.Contains(marker, StringComparison.Ordinal)) return true;
+        return false;
+    }
+
+    private static void AppendExceptionChain(StringBuilder output, Exception ex)
+    {
+        var current = ex;
+        var depth = 0;
+        while (current is not null)
+        {
+            output.Append($" |{depth}: {current.GetType().Name}: {current.Message}");
+            if (!string.IsNullOrEmpty(current.StackTrace))
+                output.Append($" @ {Compact(current.StackTrace)}");
+            current = current.InnerException;
+            depth++;
+        }
+    }
+
+    private static string Compact(string stackTrace) =>
+        stackTrace.Replace('\n', ' ').Replace('\r', ' ').Replace("   at ", " ← ").Trim();
+}

--- a/src/AgentSmith.Sandbox.Agent/Services/JobLoop.cs
+++ b/src/AgentSmith.Sandbox.Agent/Services/JobLoop.cs
@@ -12,6 +12,11 @@ internal sealed class JobLoop(IRedisJobBus bus, IStepExecutor executor, ILogger<
 
     public async Task<int> RunAsync(string jobId, CancellationToken cancellationToken)
     {
+        // job scope is visible from every logger sharing this factory's
+        // ExternalScopeProvider — including StepExecutor + handler loggers —
+        // so `[job=<short>]` prefixes every line emitted while a step is in
+        // flight, matching the server-side `[run=...] [ticket=...]` convention.
+        using var jobScope = logger.BeginScope("job={Job}", ShortJobId(jobId));
         var idleCycles = 0;
         while (!cancellationToken.IsCancellationRequested)
         {
@@ -54,6 +59,9 @@ internal sealed class JobLoop(IRedisJobBus bus, IStepExecutor executor, ILogger<
             cancellationToken);
         await bus.PushResultAsync(jobId, result, cancellationToken);
     }
+
+    private static string ShortJobId(string jobId) =>
+        jobId.Length > 8 ? jobId[..8] : jobId;
 
     private async Task PushValidationFailureAsync(
         string jobId, Step step, string error, CancellationToken cancellationToken)

--- a/src/AgentSmith.Sandbox.Agent/Services/StepExecutor.cs
+++ b/src/AgentSmith.Sandbox.Agent/Services/StepExecutor.cs
@@ -38,8 +38,10 @@ internal sealed class StepExecutor(
             OutputBatcher.DefaultFlushInterval,
             onEvents);
 
+        var displayCommand = DisplayCommand(step);
+        var shortStepId = ShortStepId(step.StepId);
         var stopwatch = Stopwatch.StartNew();
-        logger.LogInformation("Step {StepId} starting: {Command}", step.StepId, step.Command);
+        logger.LogDebug("Step {StepId} starting `{Command}`", shortStepId, displayCommand);
         batcher.Add(MakeEvent(step.StepId, StepEventKind.Started, step.Command!));
 
         var outcome = await runner.RunAsync(step,
@@ -48,14 +50,42 @@ internal sealed class StepExecutor(
 
         batcher.Add(MakeEvent(step.StepId, StepEventKind.Completed,
             $"exit={outcome.ExitCode} timedOut={outcome.TimedOut}"));
-        logger.LogInformation("Step {StepId} finished: exit={ExitCode} timedOut={TimedOut} duration={Duration:F2}s",
-            step.StepId, outcome.ExitCode, outcome.TimedOut, stopwatch.Elapsed.TotalSeconds);
+        var elapsedMs = (long)stopwatch.Elapsed.TotalMilliseconds;
+        if (outcome.TimedOut)
+            logger.LogWarning("Step {StepId} `{Command}` → TIMED OUT after {Ms}ms",
+                shortStepId, Truncate(displayCommand, 100), elapsedMs);
+        else if (outcome.ExitCode != 0)
+            logger.LogWarning("Step {StepId} `{Command}` → exit={ExitCode} in {Ms}ms",
+                shortStepId, Truncate(displayCommand, 100), outcome.ExitCode, elapsedMs);
+        else
+            logger.LogInformation("Step {StepId} `{Command}` → exit=0 in {Ms}ms",
+                shortStepId, Truncate(displayCommand, 100), elapsedMs);
 
         return new StepResult(
             StepResult.CurrentSchemaVersion, step.StepId,
             outcome.ExitCode, outcome.TimedOut,
             stopwatch.Elapsed.TotalSeconds, outcome.ErrorMessage);
     }
+
+    private static string DisplayCommand(Step step)
+    {
+        // Shell-invocation idiom: Command is the interpreter, Args[1] is the
+        // actual command after `-c`. Surface the meaningful payload so the log
+        // line tells the operator what ran instead of always saying '/bin/sh'.
+        var cmd = step.Command;
+        if (cmd is null) return string.Empty;
+        if ((cmd == "/bin/sh" || cmd == "/bin/bash" || cmd == "sh" || cmd == "bash")
+            && step.Args is { Count: >= 2 } args && args[0] == "-c")
+            return args[1];
+        return step.Args is { Count: > 0 } more
+            ? $"{cmd} {string.Join(' ', more)}"
+            : cmd;
+    }
+
+    private static string Truncate(string s, int max) =>
+        s.Length <= max ? s : s[..max] + "…";
+
+    private static string ShortStepId(Guid id) => id.ToString("N")[..8];
 
     private static StepEvent MakeEvent(Guid stepId, StepEventKind kind, string line) =>
         new(StepEvent.CurrentSchemaVersion, stepId, kind, line, DateTimeOffset.UtcNow);

--- a/tests/AgentSmith.Sandbox.Agent.Tests/Services/StepExecutorLoggingTests.cs
+++ b/tests/AgentSmith.Sandbox.Agent.Tests/Services/StepExecutorLoggingTests.cs
@@ -1,0 +1,105 @@
+using AgentSmith.Sandbox.Agent.Services;
+using AgentSmith.Sandbox.Wire;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace AgentSmith.Sandbox.Agent.Tests.Services;
+
+public sealed class StepExecutorLoggingTests
+{
+    [Fact]
+    public async Task RunStep_LogsActualShellCommand_NotBinSh()
+    {
+        var (executor, logger) = Build();
+        var step = new Step(Step.CurrentSchemaVersion, Guid.NewGuid(), StepKind.Run,
+            Command: "/bin/sh", Args: new[] { "-c", "echo hello" });
+
+        await executor.ExecuteAsync(step, _ => Task.CompletedTask, CancellationToken.None);
+
+        logger.Lines.Should().ContainSingle(l => l.Level == LogLevel.Information && l.Message.Contains("`echo hello`"));
+        logger.Lines.Should().NotContain(l => l.Level == LogLevel.Information && l.Message.Contains("`/bin/sh`"));
+    }
+
+    [Fact]
+    public async Task RunStep_EmitsOneInfoLine_NotTwo()
+    {
+        var (executor, logger) = Build();
+        var step = new Step(Step.CurrentSchemaVersion, Guid.NewGuid(), StepKind.Run,
+            Command: "/bin/sh", Args: new[] { "-c", "echo hi" });
+
+        await executor.ExecuteAsync(step, _ => Task.CompletedTask, CancellationToken.None);
+
+        logger.Lines.Count(l => l.Level == LogLevel.Information).Should().Be(1);
+    }
+
+    [Fact]
+    public async Task RunStep_LogLineIncludesShortStepIdAndElapsedMs()
+    {
+        var (executor, logger) = Build();
+        var stepId = Guid.NewGuid();
+        var step = new Step(Step.CurrentSchemaVersion, stepId, StepKind.Run,
+            Command: "/bin/sh", Args: new[] { "-c", "true" });
+
+        await executor.ExecuteAsync(step, _ => Task.CompletedTask, CancellationToken.None);
+
+        var line = logger.Lines.Single(l => l.Level == LogLevel.Information).Message;
+        line.Should().Contain(stepId.ToString("N")[..8]);
+        line.Should().MatchRegex(@"in \d+ms");
+        line.Should().Contain("exit=0");
+    }
+
+    [Fact]
+    public async Task RunStep_NonZeroExit_LogsAtWarningLevel()
+    {
+        var (executor, logger) = Build(exitCode: 1);
+        var step = new Step(Step.CurrentSchemaVersion, Guid.NewGuid(), StepKind.Run,
+            Command: "/bin/sh", Args: new[] { "-c", "false" });
+
+        await executor.ExecuteAsync(step, _ => Task.CompletedTask, CancellationToken.None);
+
+        logger.Lines.Should().Contain(l => l.Level == LogLevel.Warning && l.Message.Contains("exit=1"));
+        logger.Lines.Should().NotContain(l => l.Level == LogLevel.Information && l.Message.Contains("exit="));
+    }
+
+    [Fact]
+    public async Task RunStep_DirectCommand_NotShell_StillLoggedCleanly()
+    {
+        var (executor, logger) = Build();
+        var step = new Step(Step.CurrentSchemaVersion, Guid.NewGuid(), StepKind.Run,
+            Command: "git", Args: new[] { "status" });
+
+        await executor.ExecuteAsync(step, _ => Task.CompletedTask, CancellationToken.None);
+
+        logger.Lines.Should().Contain(l => l.Level == LogLevel.Information && l.Message.Contains("`git status`"));
+    }
+
+    private static (StepExecutor Executor, RecordingLogger<StepExecutor> Logger) Build(int exitCode = 0)
+    {
+        var runner = new Mock<IProcessRunner>();
+        runner.Setup(r => r.RunAsync(It.IsAny<Step>(), It.IsAny<Action<StepEventKind, string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ProcessOutcome(exitCode, TimedOut: false, ErrorMessage: null));
+        var logger = new RecordingLogger<StepExecutor>();
+        var fileHandler = new FileStepHandler(NullLogger<FileStepHandler>.Instance);
+        var grepHandler = new GrepStepHandler(runner.Object, NullLogger<GrepStepHandler>.Instance);
+        var treeHandler = new DirectoryTreeStepHandler(NullLogger<DirectoryTreeStepHandler>.Instance);
+        var executor = new StepExecutor(runner.Object, fileHandler, grepHandler, treeHandler, logger);
+        return (executor, logger);
+    }
+
+    private sealed class RecordingLogger<T> : ILogger<T>
+    {
+        public List<(LogLevel Level, string Message)> Lines { get; } = new();
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+        public bool IsEnabled(LogLevel logLevel) => true;
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+            => Lines.Add((logLevel, formatter(state, exception)));
+
+        private sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new();
+            public void Dispose() { }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Previously every Run step emitted two info lines with `/bin/sh` as the 'command' and a full GUID as the step id, with no job correlation:

```
info: Step <full-guid> starting: /bin/sh
info: Step <full-guid> finished: exit=0 timedOut=False duration=0.01s
```

The actual command lived in `Args[1]` after `-c` but never surfaced; the GUID was never used to correlate; no link back to the pipeline run.

Now:

```
2026-05-21 09:12:34.789 info [job=ba4f818e] [Services.StepExecutor] Step a1b2c3d4 `find . -name '*.cs' | head -20` → exit=0 in 12ms
```

## Changes

- New `CompactConsoleFormatter` in `Sandbox.Agent` (mirrors `AgentSmith.Server`'s). Deliberate duplication because `Sandbox.Agent` is a standalone `Exe` with no Server dependency; sync-point documented at the file head.
- `Program.cs` wires the formatter via `.AddConsoleFormatter<...>`.
- `JobLoop.RunAsync` wraps the loop in `BeginScope(\"job={Job}\", shortJobId)`; every logger sharing the factory's `ExternalScopeProvider` inherits the scope — so the `[job=...]` prefix appears on every line emitted while a step is in flight, matching server-side `[run=...]` / `[ticket=...]` convention.
- `StepExecutor.RunCommandAsync`: 'starting' moves to `Debug`; 'finished' becomes a single `Info` line with the real command (extracted from `Args[1]` for shell invocations, `Command + Args` otherwise), short 8-char step id, exit code, elapsed ms. Non-zero exit / timeout escalate to `Warning`.

## Test plan

- [x] Full suite green (2031 → 2036, +5 new tests pinning real-command extraction, single-line emission, short id + ms format, warn-on-non-zero, direct-command path)
- [ ] Operator validates after pulling next sandbox-agent image: `docker logs` shows `[job=...]` scope + real commands, half the line count of before