### PR TITLE
fix(tickets): atomic AzDO finalize to prevent TF26071 rev race

### DIFF
--- a/src/AgentSmith.Application/Services/Lifecycle/TicketLifecycle.cs
+++ b/src/AgentSmith.Application/Services/Lifecycle/TicketLifecycle.cs
@@ -12,6 +12,13 @@ namespace AgentSmith.Application.Services.Lifecycle;
 /// Ticket — so handlers that only have the id (init-project's label-triggered
 /// path) can call it without an extra FetchTicket step.
 /// </summary>
+/// <remarks>
+/// Delegates to <see cref="ITicketProvider.FinalizeAsync"/> so the provider can
+/// pick the atomic-vs-sequential shape that fits its backend. AzDO collapses
+/// both writes into one PATCH to avoid the TF26071 (System.Rev) race that bit
+/// production when comment + state landed as two PATCHes; GitHub/GitLab/Jira
+/// stay on two sequential calls (no rev guard exists there).
+/// </remarks>
 public static class TicketLifecycle
 {
     public static async Task FinalizeAsync(
@@ -26,20 +33,10 @@ public static class TicketLifecycle
         try
         {
             var provider = ticketFactory.Create(ticketConfig);
-
-            if (!string.IsNullOrWhiteSpace(doneStatus))
-            {
-                await provider.UpdateStatusAsync(ticketId, summary, cancellationToken);
-                await provider.TransitionToAsync(ticketId, doneStatus, cancellationToken);
-                logger.LogInformation(
-                    "Ticket {Ticket} transitioned to '{DoneStatus}' with summary",
-                    ticketId, doneStatus);
-            }
-            else
-            {
-                await provider.CloseTicketAsync(ticketId, summary, cancellationToken);
-                logger.LogInformation("Ticket {Ticket} closed with summary", ticketId);
-            }
+            await provider.FinalizeAsync(ticketId, summary, doneStatus, cancellationToken);
+            logger.LogInformation(
+                "Ticket {Ticket} finalized (status='{Status}')",
+                ticketId, doneStatus ?? "<close>");
         }
         catch (Exception ex)
         {

--- a/src/AgentSmith.Contracts/Providers/ITicketProvider.cs
+++ b/src/AgentSmith.Contracts/Providers/ITicketProvider.cs
@@ -62,6 +62,24 @@ public interface ITicketProvider : ITypedProvider
         => Task.CompletedTask;
 
     /// <summary>
+    /// Post-PR finalize: in one provider-native step, post the summary comment
+    /// AND move the ticket to <paramref name="doneStatus"/> (or close it when
+    /// <paramref name="doneStatus"/> is null/empty).
+    /// </summary>
+    /// <remarks>
+    /// On Azure DevOps the two changes MUST land in the same WIT PATCH —
+    /// AzDO bumps <c>System.Rev</c> after every write and any concurrent
+    /// observer (other agent-smith run, operator UI edit, server-side
+    /// automation rule) between two sequential PATCHes produces
+    /// <c>TF26071: This work item has been changed by someone else</c>
+    /// and the second call aborts. Other providers (GitHub/GitLab/Jira)
+    /// have no equivalent rev guard, so the default body's two sequential
+    /// calls are safe — they implement this method by delegation.
+    /// </remarks>
+    Task FinalizeAsync(
+        TicketId ticketId, string comment, string? doneStatus, CancellationToken cancellationToken);
+
+    /// <summary>
     /// Lists tickets whose lifecycle label matches the given status. Used by
     /// EnqueuedReconciler and StaleJobDetector to enumerate Enqueued/InProgress tickets.
     /// Default: empty list — providers that don't support lifecycle search don't participate.

--- a/src/AgentSmith.Infrastructure/Services/Providers/Tickets/AzureDevOpsTicketProvider.cs
+++ b/src/AgentSmith.Infrastructure/Services/Providers/Tickets/AzureDevOpsTicketProvider.cs
@@ -99,6 +99,20 @@ public sealed class AzureDevOpsTicketProvider : ITicketProvider
     public Task TransitionToAsync(TicketId ticketId, string statusName, CancellationToken cancellationToken)
         => PatchAsync(ticketId, [Op("/fields/System.State", statusName)], cancellationToken);
 
+    // Atomic post-PR finalize: AzDO bumps System.Rev on every PATCH, so two
+    // sequential UpdateStatus + Transition calls race with any concurrent
+    // observer (parallel run, operator UI edit, automation rule) and the
+    // second one crashes with TF26071. Combining both ops into one PATCH
+    // is the only safe pattern. CloseTicketAsync uses the same shape.
+    public Task FinalizeAsync(
+        TicketId ticketId, string comment, string? doneStatus, CancellationToken cancellationToken)
+    {
+        var state = string.IsNullOrWhiteSpace(doneStatus) ? _doneStatus : doneStatus;
+        return PatchAsync(ticketId,
+            [Op("/fields/System.History", ToHtml(comment)), Op("/fields/System.State", state)],
+            cancellationToken);
+    }
+
     private async Task PatchAsync(TicketId ticketId, JsonPatchDocument patch, CancellationToken cancellationToken)
     {
         if (!int.TryParse(ticketId.Value, out var id)) return;

--- a/src/AgentSmith.Infrastructure/Services/Providers/Tickets/GitHubTicketProvider.cs
+++ b/src/AgentSmith.Infrastructure/Services/Providers/Tickets/GitHubTicketProvider.cs
@@ -96,6 +96,19 @@ public sealed class GitHubTicketProvider : ITicketProvider
             await _client.Issue.Labels.AddToIssue(_owner, _repo, n, [statusName]);
     }
 
+    // GitHub issues have no rev-guard; sequential comment + state change is safe.
+    public async Task FinalizeAsync(
+        TicketId ticketId, string comment, string? doneStatus, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(doneStatus))
+            await CloseTicketAsync(ticketId, comment, cancellationToken);
+        else
+        {
+            await UpdateStatusAsync(ticketId, comment, cancellationToken);
+            await TransitionToAsync(ticketId, doneStatus, cancellationToken);
+        }
+    }
+
     private static bool TryParseIssueNumber(TicketId id, out int n) => int.TryParse(id.Value, out n);
 
     private static (string owner, string repo) ParseGitHubUrl(string url)

--- a/src/AgentSmith.Infrastructure/Services/Providers/Tickets/GitLabTicketProvider.cs
+++ b/src/AgentSmith.Infrastructure/Services/Providers/Tickets/GitLabTicketProvider.cs
@@ -96,6 +96,19 @@ public sealed class GitLabTicketProvider : ITicketProvider
         _http.SendAsync(HttpMethod.Put, IssueUrl(ticketId),
             new { state_event = ToStateEvent(statusName) }, cancellationToken);
 
+    // GitLab issues have no rev-guard; sequential note + state change is safe.
+    public async Task FinalizeAsync(
+        TicketId ticketId, string comment, string? doneStatus, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(doneStatus))
+            await CloseTicketAsync(ticketId, comment, cancellationToken);
+        else
+        {
+            await UpdateStatusAsync(ticketId, comment, cancellationToken);
+            await TransitionToAsync(ticketId, doneStatus, cancellationToken);
+        }
+    }
+
     private string IssueUrl(TicketId ticketId) =>
         $"{_baseUrl}/api/v4/projects/{_projectPath}/issues/{ticketId.Value}";
 

--- a/src/AgentSmith.Infrastructure/Services/Providers/Tickets/JiraTicketProvider.cs
+++ b/src/AgentSmith.Infrastructure/Services/Providers/Tickets/JiraTicketProvider.cs
@@ -97,4 +97,17 @@ public sealed class JiraTicketProvider : ITicketProvider
 
     public Task TransitionToAsync(TicketId ticketId, string statusName, CancellationToken cancellationToken)
         => _transitioner.TransitionAsync(ticketId, statusName, null, cancellationToken);
+
+    // Jira issues have no rev-guard on comments + transitions; sequential is safe.
+    public async Task FinalizeAsync(
+        TicketId ticketId, string comment, string? doneStatus, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(doneStatus))
+            await CloseTicketAsync(ticketId, comment, cancellationToken);
+        else
+        {
+            await UpdateStatusAsync(ticketId, comment, cancellationToken);
+            await TransitionToAsync(ticketId, doneStatus, cancellationToken);
+        }
+    }
 }

--- a/tests/AgentSmith.Tests/Commands/CommitAndPRHandlerTests.cs
+++ b/tests/AgentSmith.Tests/Commands/CommitAndPRHandlerTests.cs
@@ -64,9 +64,10 @@ public class CommitAndPRHandlerTests
             It.Is<Step>(st => st.Command == "git" && st.Args!.Contains("push")),
             It.IsAny<IProgress<StepEvent>?>(), It.IsAny<CancellationToken>()), Times.Once);
 
-        _ticketProviderMock.Verify(t => t.CloseTicketAsync(
+        _ticketProviderMock.Verify(t => t.FinalizeAsync(
             It.Is<TicketId>(id => id.Value == "123"),
             It.Is<string>(s => s.Contains("Agent Smith") && s.Contains("pull/42")),
+            null,
             It.IsAny<CancellationToken>()), Times.Once);
     }
 
@@ -85,8 +86,9 @@ public class CommitAndPRHandlerTests
     [Fact]
     public async Task ExecuteAsync_TicketCloseFailure_StillReturnsPRSuccess()
     {
-        _ticketProviderMock.Setup(t => t.CloseTicketAsync(
-                It.IsAny<TicketId>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        _ticketProviderMock.Setup(t => t.FinalizeAsync(
+                It.IsAny<TicketId>(), It.IsAny<string>(), It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()))
             .ThrowsAsync(new Exception("API error"));
 
         var context = CreateContext();
@@ -100,9 +102,10 @@ public class CommitAndPRHandlerTests
     public async Task ExecuteAsync_IncludesChangeListInSummary()
     {
         string? postedSummary = null;
-        _ticketProviderMock.Setup(t => t.CloseTicketAsync(
-                It.IsAny<TicketId>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .Callback<TicketId, string, CancellationToken>((_, summary, _) => postedSummary = summary)
+        _ticketProviderMock.Setup(t => t.FinalizeAsync(
+                It.IsAny<TicketId>(), It.IsAny<string>(), It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<TicketId, string, string?, CancellationToken>((_, summary, _, _) => postedSummary = summary)
             .Returns(Task.CompletedTask);
 
         var context = CreateContext();
@@ -114,7 +117,7 @@ public class CommitAndPRHandlerTests
     }
 
     [Fact]
-    public async Task ExecuteAsync_WithDoneStatus_TransitionsInsteadOfClosing()
+    public async Task ExecuteAsync_WithDoneStatus_FinalizesAtomicallyWithStatus()
     {
         var pipeline = NewPipelineWithSandbox();
         pipeline.Set(ContextKeys.DoneStatus, "In Review");
@@ -124,32 +127,27 @@ public class CommitAndPRHandlerTests
 
         result.IsSuccess.Should().BeTrue();
 
-        _ticketProviderMock.Verify(t => t.TransitionToAsync(
-            It.Is<TicketId>(id => id.Value == "123"),
-            "In Review",
-            It.IsAny<CancellationToken>()), Times.Once);
-
-        _ticketProviderMock.Verify(t => t.UpdateStatusAsync(
+        // Comment + status transition collapsed into ONE provider call so AzDO
+        // can emit a single PATCH and avoid the TF26071 rev race.
+        _ticketProviderMock.Verify(t => t.FinalizeAsync(
             It.Is<TicketId>(id => id.Value == "123"),
             It.Is<string>(s => s.Contains("Agent Smith")),
+            "In Review",
             It.IsAny<CancellationToken>()), Times.Once);
-
-        _ticketProviderMock.Verify(t => t.CloseTicketAsync(
-            It.IsAny<TicketId>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
-    public async Task ExecuteAsync_WithoutDoneStatus_ClosesTicket()
+    public async Task ExecuteAsync_WithoutDoneStatus_FinalizesAtomicallyWithNullStatus()
     {
         var context = CreateContext();
 
         await _sut.ExecuteAsync(context, CancellationToken.None);
 
-        _ticketProviderMock.Verify(t => t.CloseTicketAsync(
-            It.IsAny<TicketId>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
-
-        _ticketProviderMock.Verify(t => t.TransitionToAsync(
-            It.IsAny<TicketId>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        _ticketProviderMock.Verify(t => t.FinalizeAsync(
+            It.IsAny<TicketId>(),
+            It.IsAny<string>(),
+            null,
+            It.IsAny<CancellationToken>()), Times.Once);
     }
 
     private CommitAndPRContext CreateContext(PipelineContext? pipeline = null)

--- a/tests/AgentSmith.Tests/Commands/InitCommitHandlerLifecycleTests.cs
+++ b/tests/AgentSmith.Tests/Commands/InitCommitHandlerLifecycleTests.cs
@@ -64,17 +64,14 @@ public sealed class InitCommitHandlerLifecycleTests
         result.IsSuccess.Should().BeTrue();
         result.Message.Should().Contain("pull/7");
 
-        _ticketProviderMock.Verify(t => t.UpdateStatusAsync(
-            It.IsAny<TicketId>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
-        _ticketProviderMock.Verify(t => t.TransitionToAsync(
-            It.IsAny<TicketId>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
-        _ticketProviderMock.Verify(t => t.CloseTicketAsync(
-            It.IsAny<TicketId>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        _ticketProviderMock.Verify(t => t.FinalizeAsync(
+            It.IsAny<TicketId>(), It.IsAny<string>(), It.IsAny<string?>(),
+            It.IsAny<CancellationToken>()), Times.Never);
         _ticketFactoryMock.Verify(f => f.Create(It.IsAny<TrackerConnection>()), Times.Never);
     }
 
     [Fact]
-    public async Task ExecuteAsync_TicketIdWithDoneStatus_TransitionsAndPostsPRLinkSummary()
+    public async Task ExecuteAsync_TicketIdWithDoneStatus_FinalizesAtomicallyWithStatus()
     {
         var pipeline = NewPipelineWithSandbox();
         pipeline.Set(ContextKeys.TicketId, new TicketId("42"));
@@ -82,68 +79,66 @@ public sealed class InitCommitHandlerLifecycleTests
         var context = CreateContext(pipeline);
 
         string? postedSummary = null;
-        _ticketProviderMock.Setup(t => t.UpdateStatusAsync(
-                It.IsAny<TicketId>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .Callback<TicketId, string, CancellationToken>((_, s, _) => postedSummary = s)
+        _ticketProviderMock.Setup(t => t.FinalizeAsync(
+                It.IsAny<TicketId>(), It.IsAny<string>(), It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<TicketId, string, string?, CancellationToken>((_, s, _, _) => postedSummary = s)
             .Returns(Task.CompletedTask);
 
         var result = await _sut.ExecuteAsync(context, CancellationToken.None);
 
         result.IsSuccess.Should().BeTrue();
 
-        _ticketProviderMock.Verify(t => t.UpdateStatusAsync(
+        // Comment + transition collapsed into ONE provider call so AzDO can
+        // land both as a single PATCH (no TF26071 rev race).
+        _ticketProviderMock.Verify(t => t.FinalizeAsync(
             It.Is<TicketId>(id => id.Value == "42"),
             It.Is<string>(s => s.Contains("pull/7")),
+            "closed",
             It.IsAny<CancellationToken>()), Times.Once);
-        _ticketProviderMock.Verify(t => t.TransitionToAsync(
-            It.Is<TicketId>(id => id.Value == "42"), "closed",
-            It.IsAny<CancellationToken>()), Times.Once);
-        _ticketProviderMock.Verify(t => t.CloseTicketAsync(
-            It.IsAny<TicketId>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
 
         postedSummary.Should().Contain("pull/7");
         postedSummary.Should().Contain("Init Complete");
     }
 
     [Fact]
-    public async Task ExecuteAsync_TicketIdWithoutDoneStatus_ClosesTicketWithPRLinkSummary()
+    public async Task ExecuteAsync_TicketIdWithoutDoneStatus_FinalizesAtomicallyWithNullStatus()
     {
         var pipeline = NewPipelineWithSandbox();
         pipeline.Set(ContextKeys.TicketId, new TicketId("99"));
         var context = CreateContext(pipeline);
 
         string? postedSummary = null;
-        _ticketProviderMock.Setup(t => t.CloseTicketAsync(
-                It.IsAny<TicketId>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .Callback<TicketId, string, CancellationToken>((_, s, _) => postedSummary = s)
+        _ticketProviderMock.Setup(t => t.FinalizeAsync(
+                It.IsAny<TicketId>(), It.IsAny<string>(), It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<TicketId, string, string?, CancellationToken>((_, s, _, _) => postedSummary = s)
             .Returns(Task.CompletedTask);
 
         var result = await _sut.ExecuteAsync(context, CancellationToken.None);
 
         result.IsSuccess.Should().BeTrue();
 
-        _ticketProviderMock.Verify(t => t.CloseTicketAsync(
+        _ticketProviderMock.Verify(t => t.FinalizeAsync(
             It.Is<TicketId>(id => id.Value == "99"),
             It.Is<string>(s => s.Contains("pull/7")),
+            null,
             It.IsAny<CancellationToken>()), Times.Once);
-        _ticketProviderMock.Verify(t => t.TransitionToAsync(
-            It.IsAny<TicketId>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
-        _ticketProviderMock.Verify(t => t.UpdateStatusAsync(
-            It.IsAny<TicketId>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
 
         postedSummary.Should().Contain("pull/7");
     }
 
     [Fact]
-    public async Task ExecuteAsync_TicketTransitionFails_StillReturnsPRSuccess()
+    public async Task ExecuteAsync_TicketFinalizeFails_StillReturnsPRSuccess()
     {
         var pipeline = NewPipelineWithSandbox();
         pipeline.Set(ContextKeys.TicketId, new TicketId("42"));
         pipeline.Set(ContextKeys.DoneStatus, "closed");
         var context = CreateContext(pipeline);
 
-        _ticketProviderMock.Setup(t => t.TransitionToAsync(
-                It.IsAny<TicketId>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        _ticketProviderMock.Setup(t => t.FinalizeAsync(
+                It.IsAny<TicketId>(), It.IsAny<string>(), It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()))
             .ThrowsAsync(new Exception("API error"));
 
         var result = await _sut.ExecuteAsync(context, CancellationToken.None);


### PR DESCRIPTION
## Summary
- `TicketLifecycle.FinalizeAsync` used to issue two sequential AzDO PATCHes (comment via `System.History`, then transition via `System.State`). AzDO bumps `System.Rev` after each write, so any concurrent observer between them — parallel run, operator UI edit, server-side automation rule — makes the second PATCH crash with `TF26071: This work item has been changed by someone else`.
- New `ITicketProvider.FinalizeAsync(ticketId, comment, doneStatus?, ct)` contract: in one provider-native step, post the summary AND move the ticket.
- AzDO override: single PATCH with both ops (same shape as `CloseTicketAsync` already used). Race gone.
- GitHub/GitLab/Jira: delegate to existing `UpdateStatusAsync` + `TransitionToAsync` (or `CloseTicketAsync`). Those backends have no rev guard on issues; sequential is safe.

## Why
Observed in production on a 5-repo `init-project` run against AuthPort: the multi-run amplifier (old fan-out image still deployed) made the race visible immediately. Image-bump alone fixes the amplifier but the latent bug stays — any external writer (operator, ServiceHook, automation rule) reintroduces it.

## Out of scope (deferred)
- `AzureDevOpsTicketProvider.PatchAsync` still has no rev-test op + retry on 412 (sites: `PipelineErrorHandler.PostTicketStatusAsync`, `PlanOpenQuestionsPoster`, `WebhookSpawnDispatcher`). Those are single-PATCH paths, so they don't race against themselves — but an external writer still crashes them. Separate follow-up.
- `TicketAwarePipelineLifecycleCoordinator.DisposeAsync` still does its own `InProgress→Done` Tag transition after `TicketLifecycle.FinalizeAsync` sets `System.State`. Two different fields, two different PATCHes — small remaining surface for an external write to interfere. Worth revisiting once production stabilises.

## Test plan
- [x] 1992 main + 83 sandbox tests passing locally
- [x] Handler tests (`CommitAndPRHandlerTests`, `InitCommitHandlerLifecycleTests`) verify the single `FinalizeAsync` call instead of the prior two-method pair
- [ ] After deploy: confirm a multi-repo `init-project` and a `fix-bug` finalize cleanly without `TF26071` in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)