### PR TITLE
fix(handlers): ticket summary lists all repo PRs, not just primary

### DIFF
--- a/src/AgentSmith.Application/Services/Handlers/CommitAndPRHandler.cs
+++ b/src/AgentSmith.Application/Services/Handlers/CommitAndPRHandler.cs
@@ -110,15 +110,15 @@ public sealed class CommitAndPRHandler(
     private Task FinalizeTicketAsync(
         CommitAndPRContext context, IReadOnlyList<OpenedPullRequest> opened, CancellationToken ct)
     {
-        var primary = opened.FirstOrDefault(o => o.Status == OpenStatus.Opened);
-        if (primary is null) return Task.CompletedTask;
+        if (!opened.Any(o => o.Status == OpenStatus.Opened)) return Task.CompletedTask;
 
         var changes = string.Join("\n",
             context.Changes.Select(c => $"- [{c.ChangeType}] `{c.Path}`"));
         var summary = $"""
             ## Agent Smith - Completed across {context.Configs.Count} repo(s)
 
-            **Primary PR:** {primary.Url}
+            ### Pull requests
+            {RenderPullRequestList(opened)}
 
             ### Changes
             {changes}
@@ -130,6 +130,14 @@ public sealed class CommitAndPRHandler(
             ticketFactory, context.TrackerConnection, context.Ticket.Id,
             doneStatus, summary, logger, ct);
     }
+
+    private static string RenderPullRequestList(IReadOnlyList<OpenedPullRequest> opened) =>
+        string.Join("\n", opened.Select(o => o.Status switch
+        {
+            OpenStatus.Opened => $"- **{o.RepoName}**: {o.Url}",
+            OpenStatus.SkippedNoChanges => $"- **{o.RepoName}**: _(no changes)_",
+            _ => $"- **{o.RepoName}**: _(open failed)_",
+        }));
 
     private static CommandResult BuildResult(IReadOnlyList<OpenedPullRequest> opened)
     {

--- a/src/AgentSmith.Application/Services/Handlers/InitCommitHandler.cs
+++ b/src/AgentSmith.Application/Services/Handlers/InitCommitHandler.cs
@@ -65,7 +65,7 @@ public sealed class InitCommitHandler(
             context.Pipeline.Set(ContextKeys.PullRequestUrl, primaryUrl);
 
         if (ticketId is not null && primaryUrl is not null)
-            await FinalizeTicketAsync(context, primaryUrl, ticketId, cancellationToken);
+            await FinalizeTicketAsync(context, opened, ticketId, cancellationToken);
         return BuildResult(opened);
     }
 
@@ -112,19 +112,29 @@ public sealed class InitCommitHandler(
         || ex.Message.Contains("no changes", StringComparison.OrdinalIgnoreCase);
 
     private Task FinalizeTicketAsync(
-        InitCommitContext context, string primaryUrl, TicketId ticketId, CancellationToken ct)
+        InitCommitContext context, IReadOnlyList<OpenedPullRequest> opened,
+        TicketId ticketId, CancellationToken ct)
     {
         context.Pipeline.TryGet<string>(ContextKeys.DoneStatus, out var doneStatus);
         var summary = $"""
             ## Agent Smith - Init Complete across {context.Configs.Count} repo(s)
 
-            **Primary PR:** {primaryUrl}
+            ### Pull requests
+            {RenderPullRequestList(opened)}
 
             Bootstrap files (`.agentsmith/context.yaml`, `coding-principles.md`) generated. Review and merge to enable agent-smith pipelines.
             """;
         return TicketLifecycle.FinalizeAsync(
             ticketFactory, context.TrackerConnection, ticketId, doneStatus, summary, logger, ct);
     }
+
+    private static string RenderPullRequestList(IReadOnlyList<OpenedPullRequest> opened) =>
+        string.Join("\n", opened.Select(o => o.Status switch
+        {
+            OpenStatus.Opened => $"- **{o.RepoName}**: {o.Url}",
+            OpenStatus.SkippedNoChanges => $"- **{o.RepoName}**: _(no changes)_",
+            _ => $"- **{o.RepoName}**: _(open failed)_",
+        }));
 
     private static CommandResult BuildResult(IReadOnlyList<OpenedPullRequest> opened)
     {

--- a/tests/AgentSmith.Tests/Commands/CommitAndPRHandlerTests.cs
+++ b/tests/AgentSmith.Tests/Commands/CommitAndPRHandlerTests.cs
@@ -117,6 +117,57 @@ public class CommitAndPRHandlerTests
     }
 
     [Fact]
+    public async Task ExecuteAsync_MultiRepo_SummaryListsEveryRepoNotJustPrimary()
+    {
+        // Multi-repo summary used to expose only the primary PR; operators
+        // reading the ticket then had to traverse to the primary's body for
+        // the sibling list (p0158c's cross-link). Listing each repo + its PR
+        // status in the ticket comment keeps the ticket self-contained.
+        string? postedSummary = null;
+        _ticketProviderMock.Setup(t => t.FinalizeAsync(
+                It.IsAny<TicketId>(), It.IsAny<string>(), It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<TicketId, string, string?, CancellationToken>((_, summary, _, _) => postedSummary = summary)
+            .Returns(Task.CompletedTask);
+
+        var pipeline = new PipelineContext();
+        pipeline.Set(ContextKeys.Sandbox, _sandboxMock.Object);
+        pipeline.Set<IReadOnlyDictionary<string, ISandbox>>(
+            ContextKeys.Sandboxes,
+            new Dictionary<string, ISandbox>(StringComparer.Ordinal)
+            {
+                ["server"] = _sandboxMock.Object,
+                ["client"] = _sandboxMock.Object,
+                ["docs"] = _sandboxMock.Object,
+            });
+        var repo = new Repository(new BranchName("fix/123"), "https://github.com/test/repo");
+        var ticket = new Ticket(new TicketId("123"), "Fix the bug", "Description", null, "Open", "GitHub");
+        var changes = new List<CodeChange>
+        {
+            new(new FilePath("README.md"), "content", "Created")
+        };
+        var configs = new[]
+        {
+            new RepoConnection { Name = "server" },
+            new RepoConnection { Name = "client" },
+            new RepoConnection { Name = "docs" },
+        };
+        var context = new CommitAndPRContext(repo, changes, ticket, configs, new TrackerConnection(), pipeline);
+
+        var result = await _sut.ExecuteAsync(context, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue(result.Message);
+        _sourceProviderMock.Verify(s => s.CreatePullRequestAsync(
+            It.IsAny<Repository>(), It.IsAny<string>(), It.IsAny<string>(),
+            It.IsAny<CancellationToken>(), It.IsAny<TicketId?>()), Times.Exactly(3));
+        postedSummary.Should().NotBeNull();
+        postedSummary.Should().Contain("Pull requests");
+        postedSummary.Should().Contain("**server**:");
+        postedSummary.Should().Contain("**client**:");
+        postedSummary.Should().Contain("**docs**:");
+    }
+
+    [Fact]
     public async Task ExecuteAsync_WithDoneStatus_FinalizesAtomicallyWithStatus()
     {
         var pipeline = NewPipelineWithSandbox();

--- a/tests/AgentSmith.Tests/Commands/InitCommitHandlerLifecycleTests.cs
+++ b/tests/AgentSmith.Tests/Commands/InitCommitHandlerLifecycleTests.cs
@@ -147,6 +147,50 @@ public sealed class InitCommitHandlerLifecycleTests
         result.Message.Should().Contain("pull/7");
     }
 
+    [Fact]
+    public async Task ExecuteAsync_MultiRepo_SummaryListsEveryRepoNotJustPrimary()
+    {
+        // Pre-fix the init summary only included `Primary PR: {url}`; with N
+        // repos the operator reading the ticket only saw one of the N PRs.
+        // Listing every repo + its PR keeps the ticket self-contained without
+        // forcing a traversal into the primary PR body's sibling block.
+        var pipeline = new PipelineContext();
+        pipeline.Set(ContextKeys.Sandbox, _sandboxMock.Object);
+        pipeline.Set<IReadOnlyDictionary<string, ISandbox>>(
+            ContextKeys.Sandboxes,
+            new Dictionary<string, ISandbox>(StringComparer.Ordinal)
+            {
+                ["server"] = _sandboxMock.Object,
+                ["client"] = _sandboxMock.Object,
+                ["docs"] = _sandboxMock.Object,
+            });
+        pipeline.Set(ContextKeys.TicketId, new TicketId("42"));
+        pipeline.Set(ContextKeys.DoneStatus, "closed");
+        var repo = new Repository(new BranchName("agentsmith/init"), "https://github.com/test/repo");
+        var configs = new[]
+        {
+            new RepoConnection { Name = "server" },
+            new RepoConnection { Name = "client" },
+            new RepoConnection { Name = "docs" },
+        };
+        var context = new InitCommitContext(repo, configs, new TrackerConnection(), pipeline);
+
+        string? postedSummary = null;
+        _ticketProviderMock.Setup(t => t.FinalizeAsync(
+                It.IsAny<TicketId>(), It.IsAny<string>(), It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<TicketId, string, string?, CancellationToken>((_, s, _, _) => postedSummary = s)
+            .Returns(Task.CompletedTask);
+
+        await _sut.ExecuteAsync(context, CancellationToken.None);
+
+        postedSummary.Should().NotBeNull();
+        postedSummary.Should().Contain("Pull requests");
+        postedSummary.Should().Contain("**server**:");
+        postedSummary.Should().Contain("**client**:");
+        postedSummary.Should().Contain("**docs**:");
+    }
+
     private InitCommitContext CreateContext(PipelineContext pipeline)
     {
         var repo = new Repository(new BranchName("agentsmith/init"), "https://github.com/test/repo");


### PR DESCRIPTION
## Summary
`CommitAndPRHandler` and `InitCommitHandler` posted the finalize comment with only the **primary** PR URL. On a multi-repo run (`p0158a..g`) the ticket comment turned into a dead end — operators saw 1 of N PRs and had to traverse to the primary's body to find the rest via the `p0158c` cross-link sibling block.

Now the ticket comment renders a `### Pull requests` section with one bullet per configured repo, marked by status:

```
- **server**: https://.../pull/42
- **client**: https://.../pull/43
- **docs**: _(no changes)_
- **infra**: _(open failed)_
```

Same shape in both handlers via a local `RenderPullRequestList` helper. `InitCommitHandler.FinalizeTicketAsync` now takes the full `IReadOnlyList<OpenedPullRequest>` (was previously just `primaryUrl` string).

## Why
Operator feedback from the AuthPort 5-repo run: "wenn ich n repos in einem ticket habe... dann schreibt agent smith n Kommentare dass er daran arbeitet. das macht aus ticket perspektive natürlich keinen Sinn." The N-comments symptom itself was the deploy-skew fan-out (image-bump fixes it), but even after the image-bump the single comment that DOES land only shows 1 of N PRs. This PR closes that gap.

## Test plan
- [x] 1994 main + 83 sandbox tests passing locally (+2 new)
- [x] Two new regression tests assert the multi-repo summary contains a `Pull requests` section and a bullet per repo name
- [x] Single-repo path unchanged (existing `IncludesChangeListInSummary` test still passes — the section also renders for N=1, which is harmless)
- [ ] After deploy: confirm a multi-repo `fix-bug` / `init-project` ticket shows all PR URLs in the finalize comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)