### PR TITLE
feat(server): version in banner + raw-API diagnostic in Azure ListDirectoryAsync

### DIFF
--- a/src/backend/AgentSmith.Infrastructure/Services/Providers/Source/AzureReposSourceProvider.cs
+++ b/src/backend/AgentSmith.Infrastructure/Services/Providers/Source/AzureReposSourceProvider.cs
@@ -129,9 +129,6 @@ public sealed class AzureReposSourceProvider(
         logger.LogInformation("Posted comment on PR #{PrId}", prId);
     }
 
-    private static string Normalise(string path) =>
-        path.StartsWith('/') ? path : "/" + path;
-
     private async Task<string> GetDefaultBranchAsync(CancellationToken cancellationToken)
     {
         if (_configuredDefaultBranch is not null)
@@ -258,14 +255,32 @@ public sealed class AzureReposSourceProvider(
                 recursionLevel: VersionControlRecursionType.OneLevel,
                 versionDescriptor: descriptor,
                 cancellationToken: cancellationToken);
-            var prefix = "/" + path.Trim('/') + "/";
-            return items
-                .Where(i => i.Path != null)
-                .Select(i => Normalise(i.Path))
-                .Where(p => p.StartsWith(prefix, StringComparison.Ordinal))
-                .Select(p => p[prefix.Length..])
-                .Where(n => !string.IsNullOrEmpty(n) && !n.Contains('/'))
-                .ToList();
+            logger.LogInformation(
+                "ListDirectoryAsync raw: project={Project} repo={Repo} path={Path} branch={Branch} items={Count} sample=[{Sample}]",
+                _project, _repoName, path, branch, items?.Count ?? 0,
+                items is null
+                    ? ""
+                    : string.Join(", ", items.Take(8).Select(i => $"{i.Path}|folder={i.IsFolder}")));
+            if (items is null || items.Count == 0) return [];
+
+            var normPath = "/" + path.Trim('/');
+            var prefix = normPath + "/";
+            var result = new List<string>();
+            foreach (var item in items)
+            {
+                if (item.Path is null) continue;
+                var p = item.Path.StartsWith('/') ? item.Path : "/" + item.Path;
+                if (string.Equals(p, normPath, StringComparison.Ordinal)) continue;
+                string leaf;
+                if (p.StartsWith(prefix, StringComparison.Ordinal))
+                    leaf = p[prefix.Length..];
+                else
+                    leaf = p.TrimStart('/');
+                if (string.IsNullOrEmpty(leaf) || leaf.Contains('/')) continue;
+                if (item.IsFolder != true) continue;
+                result.Add(leaf);
+            }
+            return result;
         }
         catch (VssServiceException ex) when (ex.Message.Contains("could not be found", StringComparison.OrdinalIgnoreCase)
                                           || ex.Message.Contains("does not exist", StringComparison.OrdinalIgnoreCase))

--- a/src/backend/AgentSmith.Server/Dockerfile
+++ b/src/backend/AgentSmith.Server/Dockerfile
@@ -41,6 +41,11 @@ RUN groupadd --gid 1000 dispatcher && \
     useradd --uid 1000 --gid 1000 --create-home dispatcher
 
 COPY --from=build /app/publish .
+# Release version (release-please's source of truth). Read by
+# DispatcherBanner at startup so the running binary's version is
+# visible in the log — operators no longer have to guess whether a
+# pulled image actually carries the fix they expected.
+COPY version.txt /app/version.txt
 
 # Config is NOT baked into the image (p0107a). Mount agentsmith.yml at
 # /app/config/agentsmith.yml via a K8s ConfigMap volume or a Docker bind-mount.

--- a/src/backend/AgentSmith.Server/Services/DispatcherBanner.cs
+++ b/src/backend/AgentSmith.Server/Services/DispatcherBanner.cs
@@ -1,7 +1,11 @@
 namespace AgentSmith.Server.Services;
 
 /// <summary>
-/// Prints the Agent Smith Dispatcher ASCII banner to the console on startup.
+/// Prints the Agent Smith Dispatcher ASCII banner to the console on startup,
+/// followed by the binary's release version (read from /app/version.txt,
+/// release-please's source of truth, copied into the image by the Dockerfile).
+/// Operators read the version off the startup log to confirm a pulled image
+/// actually carries the expected release.
 /// </summary>
 internal static class DispatcherBanner
 {
@@ -17,7 +21,31 @@ internal static class DispatcherBanner
  ██║  ██║╚██████╔╝███████╗██║ ╚████║   ██║       ███████║██║ ╚═╝ ██║██║   ██║   ██║  ██║
  ╚═╝  ╚═╝ ╚═════╝ ╚══════╝╚═╝  ╚═══╝  ╚═╝       ╚══════╝╚═╝     ╚═╝╚═╝   ╚═╝   ╚═╝  ╚═╝");
         Console.ForegroundColor = ConsoleColor.DarkGreen;
-        Console.WriteLine("  Dispatcher · Slack / Teams · Redis Streams · Docker / K8s Jobs\n");
+        Console.WriteLine($"  Dispatcher · v{ReadVersion()} · Slack / Teams · Redis Streams · Docker / K8s Jobs\n");
         Console.ForegroundColor = original;
+    }
+
+    private static string ReadVersion()
+    {
+        // Production: /app/version.txt (copied by Dockerfile).
+        // Local dev: walk up from the binary dir until version.txt is found
+        // (repo root). Unknown returns "<unknown>" so the banner never
+        // throws.
+        try
+        {
+            const string fileName = "version.txt";
+            if (File.Exists(Path.Combine("/app", fileName)))
+                return File.ReadAllText(Path.Combine("/app", fileName)).Trim();
+            var dir = AppContext.BaseDirectory;
+            for (var i = 0; i < 6 && !string.IsNullOrEmpty(dir); i++)
+            {
+                var candidate = Path.Combine(dir, fileName);
+                if (File.Exists(candidate))
+                    return File.ReadAllText(candidate).Trim();
+                dir = Path.GetDirectoryName(dir)!;
+            }
+        }
+        catch { /* fall through to unknown */ }
+        return "<unknown>";
     }
 }


### PR DESCRIPTION
## Summary

Two operator-visibility wins after a v0.68.1 deployment where the discovery STILL returned empty for multi-context Azure DevOps repos — and we couldn't tell whether the running binary was actually 0.68.1.

### 1. Version on the banner

\`DispatcherBanner\` reads \`/app/version.txt\` (copied into the image by the Dockerfile; release-please's source of truth) and prints it on the banner line:

\`\`\`
  Dispatcher · v0.68.1 · Slack / Teams · Redis Streams · Docker / K8s Jobs
\`\`\`

Operators read the version off the startup log to confirm a pulled image actually carries the expected release. No more \"is this actually 0.68.1 or did the image cache trick me?\"

### 2. Raw-API diagnostic on Azure list

\`AzureReposSourceProvider.ListDirectoryAsync\` logs the raw API response shape (item count + first 8 items with their full \`Path\` + \`IsFolder\`) right before filtering:

\`\`\`
ListDirectoryAsync raw: project=Cloud Development repo=RHS.AuthPort.Server path=.agentsmith/contexts branch=develop items=5 sample=[/.agentsmith/contexts/api|folder=True, ...]
\`\`\`

If the discovery returns empty for a repo the operator KNOWS has contexts on the branch, the raw log tells us whether Azure returned \`[]\` or returned items whose path shape the filter doesn't recognise.

### Filter also harder to fool

Same call site is now:
- Tolerates \`GitItem.Path\` with or without leading \`/\`.
- Tolerates Azure not echoing the scopePath prefix (falls back to leaf-name extraction).
- Requires \`IsFolder == true\` (skips files \`recursionLevel=OneLevel\` might return inside the scopePath).

Existing list-directory tests still pin the Azure-shape happy path; the additions are robustness, not replacement.

## Test plan

- [x] \`dotnet build\` zero errors
- [x] \`dotnet test\` green: 2215 / 2215

🤖 Generated with [Claude Code](https://claude.com/claude-code)