### PR TITLE
test: de-flake AskTypedQuestionAsync_AnswerBeforeTimeout (release-blocker)

### DIFF
--- a/tests/AgentSmith.Tests/Dispatcher/SlackTypedQuestionTests.cs
+++ b/tests/AgentSmith.Tests/Dispatcher/SlackTypedQuestionTests.cs
@@ -186,12 +186,21 @@ public sealed class SlackTypedQuestionTests
         // Start the question in background
         var questionTask = adapter.AskTypedQuestionAsync("C123", question, CancellationToken.None);
 
-        // Give it a moment to register the TCS
-        await Task.Delay(50);
-
-        // Complete the question
+        // The question registers its TCS only AFTER the async chat.postMessage
+        // completes, so a fixed delay races on loaded CI runners. Poll until the
+        // completion succeeds instead — TryComplete returns false until the
+        // question is registered, then sets the answer. The 200 x 5ms window
+        // (~1s) stays well under the question's 5s timeout.
         var answer = new DialogAnswer("q-answer-test", "yes", null, DateTimeOffset.UtcNow, "U456");
-        adapter.TryCompleteTypedQuestion("q-answer-test", answer).Should().BeTrue();
+        var completed = false;
+        for (var attempt = 0; attempt < 200 && !completed; attempt++)
+        {
+            completed = adapter.TryCompleteTypedQuestion("q-answer-test", answer);
+            if (!completed)
+                await Task.Delay(5);
+        }
+
+        completed.Should().BeTrue("the question should register within the poll window");
 
         var result = await questionTask;
         result.Should().NotBeNull();


### PR DESCRIPTION
## Why
This flaky test blocked the release Docker Build **twice today** (0.77.0 and 0.79.0) — each time a green re-run was needed to publish the image.

## Root cause
`AskTypedQuestionAsync` registers its `TaskCompletionSource` only **after** the async `chat.postMessage` returns (`SlackAdapter` line 97 → 99). The test waited a fixed `await Task.Delay(50)` for that registration, then called `TryComplete` once. On loaded CI runners 50ms isn't enough → the question isn't registered yet → flaky failure.

## Fix
Poll `TryComplete` until it succeeds (`200 × 5ms`, ~1s, well under the question's 5s timeout). `TryComplete` returns `false` until the question registers, then sets the answer — deterministic, and exits as soon as ready (~70ms locally, vs the old 5s path). Verified 5/5 local runs green. Test-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)