### PR TITLE
fix: scrub customer fingerprints from redesign mockup HTML

### DIFF
--- a/.agentsmith/phases/done/p0205-redesign-ui.html
+++ b/.agentsmith/phases/done/p0205-redesign-ui.html
@@ -134,9 +134,9 @@
   </div>
   <div class="head">
     <a class="back">← runs</a>
-    <h1 class="title">agent smith: Korrigieren der Antwort-Typen der Controller</h1>
-    <div class="submeta">#18794 · fix-bug · 2026-06-03T15-09-54-4683 · step 14/17 · agent azure_openai</div>
-    <div class="repos"><code>rhs-authport-server</code><code>rhs-authport-background-worker</code><code>rhs-authport-client</code><code>rhs-authport-consumer-api</code><code>rhs-authport-docs</code></div>
+    <h1 class="title">agent smith: Fix the controller response types</h1>
+    <div class="submeta">#1042 · fix-bug · 2026-06-03T15-09-54-4683 · step 14/17 · agent azure_openai</div>
+    <div class="repos"><code>sample-server</code><code>sample-background-worker</code><code>sample-client</code><code>sample-consumer-api</code><code>sample-docs</code></div>
     <div class="failbar"><span class="x">✕</span><span class="msg">Run tests failed — 0 passed / 3 no-tests / 1 failed · exit -1 · sandbox disposed</span></div>
   </div>
   <div class="panes"><div class="rail" id="rail"></div><div class="detail" id="detail"></div></div>
@@ -163,15 +163,15 @@
     {id:'s1',label:'Publish pipeline name',st:'ok',durLabel:'3ms',time:'15:09:55',
       header:{sum:'PipelineNameInitializer publishes the resolved pipeline name so later steps can branch on it.',dl:[['Handler','PipelineNameInitializer'],['pipeline_name','fix-bug']]}},
     {id:'s2',label:'Fetch ticket',st:'ok',durLabel:'284ms',time:'15:10:05',
-      header:{sum:'FetchTicket pulls #18794 from Azure DevOps and creates the sandbox set for the run.',
-        dl:[['Ticket','#18794'],['Tracker','azuredevops/rhenus-cloud-dev'],['Title','Korrigieren der Antwort-Typen der Controller'],['State','Active']],
+      header:{sum:'FetchTicket pulls #1042 from Azure DevOps and creates the sandbox set for the run.',
+        dl:[['Ticket','#1042'],['Tracker','azuredevops/sample-cloud-dev'],['Title','Fix the controller response types'],['State','Active']],
         attach:['🖼️ controller-types.png','📄 review-notes.md']}},
     {id:'s3',label:'Check out source',st:'ok',durLabel:'11.4s',time:'15:10:16',
       header:{sum:'CheckoutSource clones all five repos onto the work branch — one sandbox per discovered context.',
         rows:[['…server','contexts/api → sandbox[server]'],['…background-worker','contexts/default → sandbox[bg-worker]'],['…client','contexts/web → sandbox[client]'],['…consumer-api','contexts/pythonapi → sandbox[consumer-api]'],['…docs','contexts/default → sandbox[docs]']],
-        dl:[['Branch','agentsmith/ticket-18794'],['Repos','5']]}},
+        dl:[['Branch','agentsmith/ticket-1042'],['Repos','5']]}},
     {id:'s4',label:'Set up private-feed credentials',st:'ok',durLabel:'3.4s',time:'15:10:20',
-      header:{sum:'Stages registry credentials into each sandbox so package restores can reach private feeds.',dl:[['Credentials','4'],['Sandboxes','5'],['Feeds','nuget.rhenus, npm-internal']]}},
+      header:{sum:'Stages registry credentials into each sandbox so package restores can reach private feeds.',dl:[['Credentials','4'],['Sandboxes','5'],['Feeds','nuget.sample, npm-internal']]}},
     {id:'s5',label:'Check bootstrap files',st:'ok',durLabel:'5.1s',time:'15:10:30',
       header:{sum:'BootstrapCheck probes each repo for the agent-smith bootstrap files and records which contexts exist.',dl:[['context.yaml','present'],['coding-principles','present'],['missing','0']]}},
     {id:'s6',label:'Verify bootstrap files',st:'ok',durLabel:'10ms',time:'15:10:30',
@@ -184,19 +184,19 @@
       header:{sum:'AnalyzeCode runs the project-analyzer across all five contexts to locate the controllers whose response types must change. Per-context probes run in parallel sandboxes; the analyzer LLM loop drives 190 calls.',
         dl:[['Contexts','5 (parallel)'],['LLM calls','190'],['Cost','$1.7324']]},
       children:[
-        {id:'an-srv',label:'rhs-authport-server',st:'ok',durLabel:'258ms',
-          header:{cmd:'cat RHS.AuthPort.Domain/Entities/Role.cs',ec:0,durLabel:'258ms',sum:'Read the domain entity to confirm the controller response shape.'},
-          evs:[mk('15:11:42','tool',null,'ReadFile <code>RHS.AuthPort.Domain/Entities/Role.cs</code> → exit 0'),mk('15:11:41','obs','info','<span class="sev">Info</span> · response DTO diverges from entity in 2 controllers')]},
-        {id:'an-bg',label:'rhs-authport-background-worker',st:'ok',durLabel:'252ms',
-          header:{cmd:'cat …/Installers/AuthPortBackgroundWorkerInfrastructureEmailingInstaller.cs',ec:0,durLabel:'252ms',sum:'No controller surface; scoped read-only.'},
+        {id:'an-srv',label:'sample-server',st:'ok',durLabel:'258ms',
+          header:{cmd:'cat Sample.Domain/Entities/Role.cs',ec:0,durLabel:'258ms',sum:'Read the domain entity to confirm the controller response shape.'},
+          evs:[mk('15:11:42','tool',null,'ReadFile <code>Sample.Domain/Entities/Role.cs</code> → exit 0'),mk('15:11:41','obs','info','<span class="sev">Info</span> · response DTO diverges from entity in 2 controllers')]},
+        {id:'an-bg',label:'sample-background-worker',st:'ok',durLabel:'252ms',
+          header:{cmd:'cat …/Installers/SampleBackgroundWorkerInfrastructureEmailingInstaller.cs',ec:0,durLabel:'252ms',sum:'No controller surface; scoped read-only.'},
           evs:[mk('15:11:40','obs','info','<span class="sev">Info</span> · worker has no HTTP controllers; skipped')]},
-        {id:'an-cli',label:'rhs-authport-client',st:'ok',durLabel:'271ms',
-          header:{cmd:"sh -c \"find 'RHS.AuthPort.Client' -type f -path 'src/app/*.spec.ts' 2>/dev/null | head -3\"",ec:0,durLabel:'271ms',sum:'Located the client specs that assert controller response shapes.'},
+        {id:'an-cli',label:'sample-client',st:'ok',durLabel:'271ms',
+          header:{cmd:"sh -c \"find 'Sample.Client' -type f -path 'src/app/*.spec.ts' 2>/dev/null | head -3\"",ec:0,durLabel:'271ms',sum:'Located the client specs that assert controller response shapes.'},
           evs:[mk('15:11:39','tool',null,'RunCommand <code>find … *.spec.ts</code> → 3 paths'),mk('15:11:38','find','med','<span class="sev">Medium</span> · client expects fields the API no longer returns')]},
-        {id:'an-con',label:'rhs-authport-consumer-api',st:'ok',durLabel:'251ms',
-          header:{cmd:'cat ./RHS.AuthPort.ConsumerApi.Tests.Integration/External/PositiveTokenAccessControllerTests.cs',ec:0,durLabel:'251ms',sum:'Read the integration test that pins the controller contract.'},
+        {id:'an-con',label:'sample-consumer-api',st:'ok',durLabel:'251ms',
+          header:{cmd:'cat ./Sample.ConsumerApi.Tests.Integration/External/PositiveTokenAccessControllerTests.cs',ec:0,durLabel:'251ms',sum:'Read the integration test that pins the controller contract.'},
           evs:[mk('15:11:37','tool',null,'ReadFile <code>PositiveTokenAccessControllerTests.cs</code> → exit 0')]},
-        {id:'an-doc',label:'rhs-authport-docs',st:'ok',durLabel:'251ms',
+        {id:'an-doc',label:'sample-docs',st:'ok',durLabel:'251ms',
           header:{cmd:'cat .agentsmith/contexts/docs/coding-principles.md',ec:0,durLabel:'251ms',sum:'Docs only; no code findings.'},
           evs:[mk('15:11:36','obs','info','<span class="sev">Info</span> · docs context, no actionable findings')]},
         {id:'an-proj',label:'project-analyzer',st:'ok',durLabel:'2m19s',metric:'$1.73 · 190 LLM',
@@ -223,12 +223,12 @@
         dl:[['Passed','0'],['No tests','3'],['Failed','1'],['Exit','-1']],
         cmdfail:'Tests failed (0 passed / 3 no-tests / 1 failed; 0/0 test cases, 0 failed, exit -1)\nSandboxDisposed'},
       children:[
-        {id:'rt-srv',label:'rhs-authport-server',st:'ok',durLabel:'256ms',header:{cmd:'git diff --cached',ec:0,durLabel:'256ms',sum:'No staged changes to test.'},evs:[mk('15:18:50','tool',null,'RunCommand <code>git diff --cached</code> → exit 0 · empty')]},
-        {id:'rt-bg',label:'rhs-authport-background-worker',st:'ok',durLabel:'1.0s',header:{cmd:'git -c credential.helper=!f() { echo "username=x-access-token"; echo "password=$GIT_TOKEN"; }; f …',ec:0,durLabel:'1.0s',sum:'Credential helper invocation; no test project present.'},evs:[mk('15:18:49','tool',null,'RunCommand credential.helper → exit 0'),mk('15:18:48','obs','info','<span class="sev">Info</span> · no test project detected')]},
-        {id:'rt-cli',label:'rhs-authport-client',st:'ok',durLabel:'524ms',header:{cmd:'git diff --cached',ec:0,durLabel:'524ms',sum:'No staged changes to test.'},evs:[mk('15:18:47','tool',null,'RunCommand <code>git diff --cached</code> → exit 0')]},
-        {id:'rt-con',label:'rhs-authport-consumer-api',st:'fail',durLabel:'3m10s',header:{cmd:'dotnet test ./RHS.AuthPort.ConsumerApi.Tests.Integration',ec:-1,durLabel:'3m10s',fail:true,sum:'The integration suite failed: the controller still returns TokenResponse where the test expects TokenResponseV2.'},
+        {id:'rt-srv',label:'sample-server',st:'ok',durLabel:'256ms',header:{cmd:'git diff --cached',ec:0,durLabel:'256ms',sum:'No staged changes to test.'},evs:[mk('15:18:50','tool',null,'RunCommand <code>git diff --cached</code> → exit 0 · empty')]},
+        {id:'rt-bg',label:'sample-background-worker',st:'ok',durLabel:'1.0s',header:{cmd:'git -c credential.helper=!f() { echo "username=x-access-token"; echo "password=$GIT_TOKEN"; }; f …',ec:0,durLabel:'1.0s',sum:'Credential helper invocation; no test project present.'},evs:[mk('15:18:49','tool',null,'RunCommand credential.helper → exit 0'),mk('15:18:48','obs','info','<span class="sev">Info</span> · no test project detected')]},
+        {id:'rt-cli',label:'sample-client',st:'ok',durLabel:'524ms',header:{cmd:'git diff --cached',ec:0,durLabel:'524ms',sum:'No staged changes to test.'},evs:[mk('15:18:47','tool',null,'RunCommand <code>git diff --cached</code> → exit 0')]},
+        {id:'rt-con',label:'sample-consumer-api',st:'fail',durLabel:'3m10s',header:{cmd:'dotnet test ./Sample.ConsumerApi.Tests.Integration',ec:-1,durLabel:'3m10s',fail:true,sum:'The integration suite failed: the controller still returns TokenResponse where the test expects TokenResponseV2.'},
           evs:[mk('15:18:46','find','high','<span class="sev">High</span> · PositiveTokenAccessControllerTests expected <code>TokenResponseV2</code>, got <code>TokenResponse</code>'),mk('15:18:30','tool',null,'RunCommand <code>dotnet test</code> → exit -1'),mk('15:16:02','obs','med','<span class="sev">Medium</span> · master skill changed 0 files; contract drift unresolved')]},
-        {id:'rt-doc',label:'rhs-authport-docs',st:'ok',durLabel:'252ms',header:{cmd:'git diff --cached',ec:0,durLabel:'252ms',sum:'Docs repo; nothing to test.'},evs:[mk('15:18:45','tool',null,'RunCommand <code>git diff --cached</code> → exit 0')]}]},
+        {id:'rt-doc',label:'sample-docs',st:'ok',durLabel:'252ms',header:{cmd:'git diff --cached',ec:0,durLabel:'252ms',sum:'Docs repo; nothing to test.'},evs:[mk('15:18:45','tool',null,'RunCommand <code>git diff --cached</code> → exit 0')]}]},
     // not reached (real preset tail: WriteRunResult, CommitAndPR, PrCrossLink)
     {id:'s15',label:'Write run result',st:'skip',header:{skip:'WriteRunResult — would record the run outcome and post it to the ticket.'}},
     {id:'s16',label:'Commit & open PR',st:'skip',header:{skip:'CommitAndPR — would commit changes and open a pull request per repo.'}},
@@ -321,7 +321,7 @@
     detail.innerHTML=`<div class="dh-crumb">Overview ›</div><div class="dh-title">Architecture</div><div class="dh-sum">Five repositories, six sandboxes (one per discovered context). The <b>what ran where</b> view — orthogonal to the timeline on the left.</div><div class="hr"></div>`;
     const repos=['server','background-worker','client','consumer-api','docs'];const svg=document.createElementNS('http://www.w3.org/2000/svg','svg');
     svg.setAttribute('viewBox','0 0 940 235');svg.setAttribute('class','graph');const cx=470,gap=940/(repos.length+1);
-    let s=`<rect x="${cx-90}" y="12" width="180" height="44" rx="10" fill="var(--rose-bg)" stroke="var(--rose-border)"/><text x="${cx}" y="31" text-anchor="middle" font-size="13" font-weight="600" fill="#9f1239" font-family="var(--mono)">fix-bug</text><text x="${cx}" y="47" text-anchor="middle" font-size="9" fill="var(--rose)" font-family="var(--mono)">#18794</text>`;
+    let s=`<rect x="${cx-90}" y="12" width="180" height="44" rx="10" fill="var(--rose-bg)" stroke="var(--rose-border)"/><text x="${cx}" y="31" text-anchor="middle" font-size="13" font-weight="600" fill="#9f1239" font-family="var(--mono)">fix-bug</text><text x="${cx}" y="47" text-anchor="middle" font-size="9" fill="var(--rose)" font-family="var(--mono)">#1042</text>`;
     repos.forEach((r,i)=>{const x=gap*(i+1),y=155,f=(r==='consumer-api');
       s+=`<path d="M${cx} 56 C${cx} 108 ${x} 98 ${x} ${y}" fill="none" stroke="var(--line)" stroke-width="1.5"/><rect x="${x-80}" y="${y}" width="160" height="46" rx="9" fill="${f?'var(--rose-bg)':'var(--green-bg)'}" stroke="${f?'var(--rose-border)':'#bfe6cd'}"/><text x="${x}" y="${y+19}" text-anchor="middle" font-size="9.5" font-weight="600" fill="${f?'#9f1239':'var(--primary-deep)'}" font-family="var(--mono)">…${r}</text><text x="${x}" y="${y+34}" text-anchor="middle" font-size="9" fill="${f?'var(--rose)':'var(--primary-deep)'}" font-family="var(--mono)">${f?'tests failed':'ok'}</text>`;});
     svg.innerHTML=s;detail.appendChild(svg);

--- a/.agentsmith/phases/done/p0208-redesign-job-list.html
+++ b/.agentsmith/phases/done/p0208-redesign-job-list.html
@@ -88,8 +88,8 @@
   // status: ok | fail | run | wait
   const runs=[
     {st:'run', title:'Fix-no-test: AuthController coverage', id:'#18803', preset:'fix-no-test', repos:'2 repos', agent:'azure_openai', branch:'agentsmith/ticket-18803', step:7, total:16, ago:'just now', dur:'1m 04s'},
-    {st:'fail',title:'agent smith: Korrigieren der Antwort-Typen der Controller', id:'#18794', preset:'fix-bug', repos:'5 repos', agent:'azure_openai', branch:'agentsmith/ticket-18794', step:11,total:18, ago:'2h ago', dur:'4m 18s'},
-    {st:'ok',  title:'Security scan: RHS.AuthPort', id:'#18712', preset:'security-scan', repos:'1 repo', agent:'claude', branch:'agentsmith/scan-18712', step:14,total:14, ago:'5h ago', dur:'6m 02s'},
+    {st:'fail',title:'agent smith: Fix the controller response types', id:'#1042', preset:'fix-bug', repos:'5 repos', agent:'azure_openai', branch:'agentsmith/ticket-1042', step:11,total:18, ago:'2h ago', dur:'4m 18s'},
+    {st:'ok',  title:'Security scan: Sample', id:'#18712', preset:'security-scan', repos:'1 repo', agent:'claude', branch:'agentsmith/scan-18712', step:14,total:14, ago:'5h ago', dur:'6m 02s'},
     {st:'ok',  title:'Add feature: bulk token revocation', id:'#18698', preset:'add-feature', repos:'3 repos', agent:'azure_openai', branch:'agentsmith/ticket-18698', step:18,total:18, ago:'8h ago', dur:'8m 44s'},
     {st:'fail',title:'API scan: ConsumerApi swagger drift', id:'#18655', preset:'api-scan', repos:'1 repo', agent:'claude', branch:'agentsmith/api-18655', step:5, total:13, ago:'11h ago', dur:'2m 11s'},
     {st:'ok',  title:'Legal analysis: vendor DPA review', id:'#18540', preset:'legal-analysis', repos:'—', agent:'claude', branch:'—', step:9, total:9, ago:'1d ago', dur:'3m 20s'},

--- a/.agentsmith/phases/planned/p0209-redesign-system.html
+++ b/.agentsmith/phases/planned/p0209-redesign-system.html
@@ -95,13 +95,13 @@
   // ---- subsystem model ----
   const subsystems={
     tracker:{label:'Tracker · ticket polling', live:true, fresh:'42s ago',
-      tail:['19:09:30','poll done · rhenus-cloud-dev · 49 polled · 0 matched · 0 spawned · 269ms'],
+      tail:['19:09:30','poll done · sample-cloud-dev · 49 polled · 0 matched · 0 spawned · 269ms'],
       evs:[
-        mk('19:09:30','poll','poll done · <code>rhenus-cloud-dev</code> · 49 polled · 0 matched · 269ms'),
-        mk('19:09:30','obs','scan · rhenus-cloud-dev/#13815 · [Pair-Programming, RAST, Refinement]'),
-        mk('19:09:30','obs','skip · #13815 · no project trigger matched'),
-        mk('19:09:30','obs','scan · rhenus-cloud-dev/#16056 · [APPDEV5-Intern, Weekly]'),
-        mk('19:09:30','obs','skip · #16056 · no project trigger matched'),
+        mk('19:09:30','poll','poll done · <code>sample-cloud-dev</code> · 49 polled · 0 matched · 269ms'),
+        mk('19:09:30','obs','scan · sample-cloud-dev/#1043 · [Pair-Programming, Triage, Refinement]'),
+        mk('19:09:30','obs','skip · #1043 · no project trigger matched'),
+        mk('19:09:30','obs','scan · sample-cloud-dev/#1044 · [Internal, Weekly]'),
+        mk('19:09:30','obs','skip · #1044 · no project trigger matched'),
         mk('19:08:30','poll','poll done · 49 polled · 0 matched · 271ms'),
         mk('19:07:30','poll','poll done · 49 polled · 0 matched · 264ms'),
         mk('19:06:30','poll','poll done · 49 polled · 0 matched · 258ms'),
@@ -128,8 +128,8 @@
   // ---- runs (for the Runs item) ----
   const runs=[
     {st:'run', t:'Fix-no-test: AuthController coverage', id:'#18803', meta:'fix-no-test · 2 repos', step:'7/16', ago:'now', dur:'running'},
-    {st:'fail',t:'agent smith: Korrigieren der Antwort-Typen der Controller', id:'#18794', meta:'fix-bug · 5 repos', step:'failed 11/18', ago:'2h ago', dur:'4m 18s'},
-    {st:'ok',  t:'Security scan: RHS.AuthPort', id:'#18712', meta:'security-scan · 1 repo', step:'done', ago:'5h ago', dur:'6m 02s'},
+    {st:'fail',t:'agent smith: Fix the controller response types', id:'#1042', meta:'fix-bug · 5 repos', step:'failed 11/18', ago:'2h ago', dur:'4m 18s'},
+    {st:'ok',  t:'Security scan: Sample', id:'#18712', meta:'security-scan · 1 repo', step:'done', ago:'5h ago', dur:'6m 02s'},
     {st:'ok',  t:'Add feature: bulk token revocation', id:'#18698', meta:'add-feature · 3 repos', step:'done', ago:'8h ago', dur:'8m 44s'},
     {st:'fail',t:'API scan: ConsumerApi swagger drift', id:'#18655', meta:'api-scan · 1 repo', step:'failed 5/13', ago:'11h ago', dur:'2m 11s'},
   ];


### PR DESCRIPTION
**Urgent leak fix.** The UI-redesign mockups (`p0205-redesign-ui.html`, `p0208-redesign-job-list.html`, `p0209-redesign-system.html`) embedded **real customer data** as example content:

- company / product: `RHS.AuthPort.*`, `rhs-authport-*`, `Rhenus`, `RhenusITPD`
- a real ticket title, real ticket IDs (`#18794`, `#13815`, `#16056`)
- internal tracker labels (`APPDEV5-Intern`, `RAST`)

All anonymized (`Sample.*` / `sample-*` / generic title + IDs + labels). Static mockups — no behaviour change. Verified clean: `grep -niE "rhs|authport|rhenus|…"` → 0 matches across the three files.

⚠️ These files were merged earlier (#266 / #277), so the fingerprints **remain in git history**. Removing them from history needs a `git filter-repo` rewrite — your call (you've done this before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)