### PR TITLE
Internal LLM-timeout cancel made self-explanatory + 500k per-call token headroom (p0236)

### DIFF
--- a/.agentsmith/contexts/default/context.yaml
+++ b/.agentsmith/contexts/default/context.yaml
@@ -338,6 +338,7 @@ state:
     p0233: "Runs list updates live on a new job: fold JobUpserted into the overview inside the singleton hub client + re-emit the behavior subject, so a remounting list shows the current list (was stale until reload)."
     p0234: "Per-repo run-record: each repo writes its own .agentsmith/runs/{runId}/ scoped to itself, force-staged so it always commits; PR per changed repo, one record-PR if nothing changed; clear factual outcome message."
     p0235: "LLM NetworkTimeout fix (SDK default 100s → config 300s) — the real cause of a 139s 'A task was cancelled'; dashboard image folded into the docker-publish matrix; result view renders styled markdown + frontmatter header; plan.md cached + shown next to result.md."
+    p0236: "Pinned the cancel mechanism: SDK NetworkTimeout TaskCanceledException caught inside the skill call (one layer below p0232) → surfaced raw. BuildResult now maps it to a network_timeout_seconds message; MaxInputTokensPerSkillCall 200k→500k headroom (still observational — RecordLlmCall unwired)."
   active: {}
   planned:
     p0217: "Dashboard typography tokens: replace the 15+ ad-hoc text-[Npx] sizes with a small dense-dashboard type scale wired as tokens (dsh-h1/h2/body/body-strong/mono/label) via tailwind.config.ts + globals.css; zero raw px text sizes remain, IBM Plex Mono stays for mono surfaces"

--- a/.agentsmith/decisions/p0236.yaml
+++ b/.agentsmith/decisions/p0236.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=../decision.schema.json
+phase: p0236
+
+decisions:
+  - category: Implementation
+    chose: "Map a caught OperationCanceledException in SkillCallRuntime.BuildResult to an explicit network-timeout message."
+    over: "Passing through exception.Message (the raw .NET 'A task was canceled.')."
+    reason: |
+      An OCE reaching BuildResult can ONLY be an internal HTTP timeout: TryInvokeAsync's
+      catch `when (ex is not OperationCanceledException || !ct.IsCancellationRequested)`
+      rethrows operator/limit/watchdog cancels (run token cancelled) so they bubble to
+      the pipeline-level p0232 handler. What lands here is the SDK NetworkTimeout firing.
+      The raw .Message ("A task was canceled.") told the operator nothing and sat one
+      layer below p0232, which is why the run still showed it after p0232 shipped.
+  - category: Scope
+    chose: "Raise MaxInputTokensPerSkillCall 200k → 500k but leave RecordLlmCall unwired."
+    over: "Wiring the per-call token cap now, or touching the per-run cost cap."
+    reason: |
+      The operator asked for 500k headroom per run. The per-run budget
+      (pipeline_cost_cap) is already 500k; the per-call cap is the only other token
+      lever, so it gets the bump. But RecordLlmCall is currently dead code, so wiring
+      enforcement is a behaviour change with its own risk (it would start cancelling
+      long masters that re-send context) — out of scope for a timeout follow-up. The
+      bump is pure headroom; the actual cancel fix is p0235's NetworkTimeout.
+    alternatives:
+      - "Delete RecordLlmCall as dead code — deferred; noted as an open follow-up."

--- a/.agentsmith/phases/done/p0236-llm-timeout-message-and-token-headroom.yaml
+++ b/.agentsmith/phases/done/p0236-llm-timeout-message-and-token-headroom.yaml
@@ -1,0 +1,40 @@
+# yaml-language-server: $schema=../../phase-spec.schema.json
+phase: p0236
+goal: |
+  Follow-up to p0235's "A task was cancelled" hunt. Pinned the mechanism: the
+  cancel is a TaskCanceledException from the LLM SDK's per-request NetworkTimeout
+  (the hidden 100s), caught inside the skill call (SkillCallRuntime:122) where
+  our run token is NOT cancelled — one layer below p0232's pipeline-level
+  rewrite, so it surfaced as the raw ".NET "A task was cancelled." Make that
+  failure self-explanatory, and give the per-call input-token budget headroom.
+
+applies_to: "backend (agentic loop)"
+
+requires:
+  - p0235-llm-timeout-and-result-view
+
+decisions:
+  - key: "SkillCallRuntime.BuildResult maps a caught OperationCanceledException to an explicit message naming network_timeout_seconds (it can only be an internal HTTP timeout — operator/limit/watchdog cancels leave the run token cancelled and are rethrown by TryInvokeAsync's `when` clause to the pipeline-level p0232 handler). Other exceptions now carry their type name too, so failures stop being type-less .Message strings."
+  - key: "MaxInputTokensPerSkillCall default 200k → 500k. A coding master is one long agentic call that re-sends its growing context each iteration, so accumulated input climbs fast for legitimate multi-file work. NOTE: enforcement is currently observational — LimitEnforcer.RecordLlmCall is not wired into the loop — so this is headroom, not the cancel fix (that is p0235's NetworkTimeout). Left unwired deliberately; wiring it is a separate decision."
+
+steps:
+  - id: cancel-message
+    action: "SkillCallRuntime.DescribeException: OperationCanceledException → network-timeout message; others → 'Type: message'."
+  - id: token-headroom
+    action: "LoopLimitsConfig.MaxInputTokensPerSkillCall 200_000 → 500_000."
+  - id: tests
+    action: "Build + SkillCallRuntime/FailureReason/LimitEnforcer suites green."
+
+tests:
+  - "Existing SkillCallRuntime / FailureReason / LimitEnforcer suites stay green."
+
+done:
+  - "An internal LLM timeout surfaces as a network_timeout_seconds message, not 'A task was cancelled.'"
+  - "Per-call input-token budget is 500k."
+  - "dotnet build + targeted tests green."
+
+notes: |
+  The per-run token budget (pipeline_cost_cap) was already 500k. The bind-mounted
+  config can't fix the timeout — network_timeout_seconds is read by p0235 code, so
+  the server binary must be rebuilt + verified fresh. Open follow-up: RecordLlmCall
+  is dead code; either wire the per-call token cap or delete it.

--- a/src/backend/AgentSmith.Application/Services/Loop/SkillCallRuntime.cs
+++ b/src/backend/AgentSmith.Application/Services/Loop/SkillCallRuntime.cs
@@ -192,7 +192,7 @@ public sealed class SkillCallRuntime : ISkillCallRuntime
         SkillCallOutcome outcome, Exception? exception, LoopTraceCollector trace,
         LimitEnforcer enforcer)
     {
-        var failureReason = retryOutcome?.FailureReason ?? exception?.Message;
+        var failureReason = retryOutcome?.FailureReason ?? DescribeException(exception);
         var runtimeObs = _runtimeObservationFactory.Build(
             outcome, request.SkillName, enforcer.HitLimit, exception, failureReason);
         return new SkillCallResult
@@ -207,5 +207,23 @@ public sealed class SkillCallRuntime : ISkillCallRuntime
                 : new[] { runtimeObs },
             ReadPaths = trace.ReadSet.ToArray()
         };
+    }
+
+    // p0236: an OperationCanceledException reaching BuildResult is NEVER an
+    // operator/limit/watchdog cancel — those leave the run token cancelled and
+    // TryInvokeAsync rethrows them (its `when` clause), so they bubble to the
+    // pipeline-level p0232 handler instead. What lands here is an INTERNAL
+    // timeout: the LLM SDK's per-request NetworkTimeout fired (the hidden 100s
+    // default before p0235). Its raw .Message is the useless ".NET "A task was
+    // cancelled." — replace it with the actual lever so the operator (and we)
+    // stop guessing.
+    private static string? DescribeException(Exception? exception)
+    {
+        if (exception is null) return null;
+        if (exception is OperationCanceledException)
+            return "LLM request timed out at the HTTP layer (SDK NetworkTimeout) — "
+                + "raise the agent's network_timeout_seconds (default 300s since p0235; "
+                + "was a hidden 100s before). Not an operator/budget cancel.";
+        return $"{exception.GetType().Name}: {exception.Message}";
     }
 }

--- a/src/backend/AgentSmith.Contracts/Models/Configuration/LoopLimitsConfig.cs
+++ b/src/backend/AgentSmith.Contracts/Models/Configuration/LoopLimitsConfig.cs
@@ -11,7 +11,13 @@ public sealed class LoopLimitsConfig
     public int MaxToolCallsPerInvestigator { get; set; } = 10;
     public int MaxToolCallsPerVerifier { get; set; } = 20;
     public int MaxLlmCallsPerSkill { get; set; } = 15;
-    public int MaxInputTokensPerSkillCall { get; set; } = 200_000;
+    // p0236: per-call accumulated-input-token budget, raised 200k → 500k. A
+    // coding master is one long agentic call that re-sends its growing context
+    // each iteration, so the accumulated count climbs fast for legitimate
+    // multi-file work. (Enforcement is currently observational — RecordLlmCall
+    // is not yet wired into the loop — so this is headroom, not the fix for the
+    // "A task was cancelled" HTTP-timeout, which is AgentConfig.NetworkTimeoutSeconds.)
+    public int MaxInputTokensPerSkillCall { get; set; } = 500_000;
     public int MaxOutputTokensPerSkillCall { get; set; } = 16_000;
     public int MaxSecondsPerSkillCall { get; set; } = 300;
     public int MaxConcurrentSkillCalls { get; set; } = 10;


### PR DESCRIPTION
## Why
Follow-up to p0235. The run still showed the raw **"A task was canceled."** even though p0232 ships a friendly cancel message. Root cause pinned:

- The cancel is a `TaskCanceledException` from the LLM SDK's per-request **`NetworkTimeout`** (the hidden **100s**).
- It's caught at `SkillCallRuntime:122` where the **run token is NOT cancelled** (`ex is OperationCanceledException && !ct.IsCancellationRequested`) — i.e. an *internal* timeout, not an operator/budget cancel.
- That's **one layer below** p0232's pipeline-level rewrite, so the raw `.Message` survived. That's why it persisted after p0232.

## What
- **`SkillCallRuntime.DescribeException`** — a caught `OperationCanceledException` can only be an internal HTTP timeout (operator/limit/watchdog cancels leave the run token cancelled and are rethrown to the pipeline-level p0232 handler). Map it to a message naming **`network_timeout_seconds`**; other exceptions now carry their **type name** so failures stop being type-less.
- **`MaxInputTokensPerSkillCall` 200k → 500k** (per-call headroom, as requested). ⚠️ `RecordLlmCall` is currently **unwired**, so this cap is observational — it's headroom, **not** the cancel fix. The per-run `pipeline_cost_cap` was already 500k.

## The actual fix is still p0235
`network_timeout_seconds` (default 300s) is read by **p0235 code** — a bind-mounted config edit alone won't help. The server **binary must be rebuilt and verified fresh** (the cache-hit-ships-stale-binary trap). Once a p0235+p0236 image runs, an internal timeout will say *why* instead of "A task was canceled."

## Open follow-up
`LimitEnforcer.RecordLlmCall` is dead code — either wire the per-call token cap or delete it. Left out of scope here (wiring it would start cancelling long masters that re-send context).

## Tests
Build + `SkillCallRuntime` / `FailureReason` / `LimitEnforcer` suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)