### PR TITLE
feat(p0261): --context scan flag + fix release Docker cache race

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -10,6 +10,17 @@ on:
 env:
   DOCKER_NAMESPACE: holgerleichsenring
 
+# Serialise builds per ref so two pushes to main in quick succession (e.g. a
+# feature merge immediately followed by the release-please merge) don't run two
+# Docker builds concurrently against the SAME shared gha cache. That race
+# corrupted a layer ref and failed the release build with
+# ".next/standalone: not found" / "Unable to reserve cache ... another job may be
+# creating this cache". cancel-in-progress: false → queue (never drop a main
+# publish); different refs (PRs) still run in parallel.
+concurrency:
+  group: docker-publish-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -148,8 +159,12 @@ jobs:
           push: ${{ github.event_name != 'pull_request' && (matrix.publish == 'always' || (matrix.publish == 'tags' && startsWith(github.ref, 'refs/tags/v'))) }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # Scope the cache per image so the matrix legs (server / dashboard /
+          # cli) don't read+write one shared gha cache key within a run — that
+          # cross-image contention is the same race the concurrency group guards
+          # across runs. Per-image scope also raises the cache hit-rate.
+          cache-from: type=gha,scope=${{ matrix.image }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.image }}
 
   update-dockerhub-description:
     needs: docker

--- a/src/backend/AgentSmith.Application/Services/PipelineSandboxCoordinator.cs
+++ b/src/backend/AgentSmith.Application/Services/PipelineSandboxCoordinator.cs
@@ -68,10 +68,16 @@ public sealed class PipelineSandboxCoordinator(
         ResolvedProject projectConfig, PipelineContext context, CancellationToken cancellationToken)
     {
         _runId ??= context.TryGet<string>(ContextKeys.RunId, out var rid) ? rid : null;
+        // p0261: `--context NAME` pins every repo to one named context instead of
+        // the per-repo discovery / synthetic-default fallback. Unset → unchanged.
+        var contextOverride = context.TryGet<string>(ContextKeys.SourceContext, out var ctxName)
+            && !string.IsNullOrWhiteSpace(ctxName) ? ctxName : null;
         var repos = context.Get<IReadOnlyList<RepoConnection>>(ContextKeys.Repos);
         foreach (var repo in repos)
         {
-            var discoveries = await sandboxLanguageResolver.ResolveAllAsync(repo, cancellationToken);
+            var discoveries = contextOverride is null
+                ? await sandboxLanguageResolver.ResolveAllAsync(repo, cancellationToken)
+                : await sandboxLanguageResolver.ResolveContextAsync(repo, contextOverride, cancellationToken);
             // p0180: group by toolchain image. Multiple same-image discoveries
             // share one container; the contexts-by-sandbox map carries the
             // full list per sandbox for per-context probes.

--- a/src/backend/AgentSmith.Application/Services/Sandbox/ISandboxLanguageResolver.cs
+++ b/src/backend/AgentSmith.Application/Services/Sandbox/ISandboxLanguageResolver.cs
@@ -12,4 +12,16 @@ public interface ISandboxLanguageResolver
 {
     Task<IReadOnlyList<RemoteContextDiscovery>> ResolveAllAsync(
         RepoConnection source, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// p0261: resolve a SINGLE named context (.agentsmith/contexts/&lt;name&gt;),
+    /// bypassing discovery and the synthetic-default fallback. Used by the CLI
+    /// `--context NAME` flag so a monorepo source whose real contexts discovery
+    /// would otherwise collapse to "default" can target one of them directly.
+    /// Reads that context's context.yaml for the toolchain; falls back to a
+    /// named synthetic (workdir ".", generic image) if it can't be read/parsed,
+    /// so the bootstrap probe still hits contexts/&lt;name&gt;/.
+    /// </summary>
+    Task<IReadOnlyList<RemoteContextDiscovery>> ResolveContextAsync(
+        RepoConnection source, string contextName, CancellationToken cancellationToken);
 }

--- a/src/backend/AgentSmith.Application/Services/Sandbox/SandboxLanguageResolver.cs
+++ b/src/backend/AgentSmith.Application/Services/Sandbox/SandboxLanguageResolver.cs
@@ -82,6 +82,31 @@ public sealed class SandboxLanguageResolver(
         return discoveries;
     }
 
+    // p0261: `--context NAME` path — one explicit context, no discovery, no
+    // synthetic-default. Reads contexts/NAME/context.yaml for the real toolchain;
+    // if that read/parse fails (e.g. the name is wrong, or the local provider has
+    // no file there) we still return a NAMED synthetic so the bootstrap probe
+    // hits contexts/NAME/ rather than the misleading "default".
+    public async Task<IReadOnlyList<RemoteContextDiscovery>> ResolveContextAsync(
+        RepoConnection source, string contextName, CancellationToken cancellationToken)
+    {
+        var repoTag = FormatRepoTag(source);
+        var summary = await TryParseContextYamlAsync(source, repoTag, contextName, cancellationToken);
+        if (summary is null)
+        {
+            logger.LogWarning(
+                "Context override {Repo}/{Context}: context.yaml not readable — using a named synthetic " +
+                "(workdir=. lang=null). Probe will hit /work/.agentsmith/contexts/{Context}/.",
+                repoTag, contextName);
+            return [new RemoteContextDiscovery(contextName, ".", null)];
+        }
+        logger.LogInformation(
+            "Context override {Repo}: pinned to '{Context}' (workdir={Workdir} lang={Lang})",
+            repoTag, contextName, summary.Workdir, summary.Language ?? "null");
+        return [new RemoteContextDiscovery(
+            contextName, summary.Workdir, summary.Language, summary.Prerequisites, summary.Image)];
+    }
+
     private async Task<ContextYamlSummary?> TryParseContextYamlAsync(
         RepoConnection source, string repoTag, string contextName, CancellationToken ct)
     {

--- a/src/backend/AgentSmith.Cli/Commands/SourceOptions.cs
+++ b/src/backend/AgentSmith.Cli/Commands/SourceOptions.cs
@@ -19,6 +19,10 @@ internal sealed class SourceOptions
     public Option<string?> Path { get; } = new("--source-path", "Local repository path");
     public Option<string?> Url { get; } = new("--source-url", "Remote repository URL");
     public Option<string?> Auth { get; } = new("--source-auth", "Source auth method override");
+    // p0261: pin the run to one bootstrapped context (.agentsmith/contexts/NAME)
+    // — e.g. `--context api` on a monorepo whose contexts the single-source
+    // discovery would otherwise collapse to a synthetic "default".
+    public Option<string?> Context { get; } = new("--context", "Use a specific .agentsmith/contexts/NAME instead of context discovery");
 
     public void AddTo(Command command)
     {
@@ -27,6 +31,7 @@ internal sealed class SourceOptions
         command.Add(Path);
         command.Add(Url);
         command.Add(Auth);
+        command.Add(Context);
     }
 
     public void ApplyTo(InvocationContext ctx, Dictionary<string, object> context)
@@ -36,6 +41,7 @@ internal sealed class SourceOptions
         var path = ctx.ParseResult.GetValueForOption(Path);
         var url = ctx.ParseResult.GetValueForOption(Url);
         var auth = ctx.ParseResult.GetValueForOption(Auth);
+        var contextName = ctx.ParseResult.GetValueForOption(Context);
 
         if (!string.IsNullOrWhiteSpace(repo))
             context[ContextKeys.SourceOverrideRepo] = repo;
@@ -47,5 +53,7 @@ internal sealed class SourceOptions
             context[ContextKeys.SourceUrl] = url;
         if (!string.IsNullOrWhiteSpace(auth))
             context[ContextKeys.SourceAuth] = auth;
+        if (!string.IsNullOrWhiteSpace(contextName))
+            context[ContextKeys.SourceContext] = contextName;
     }
 }

--- a/src/backend/AgentSmith.Contracts/Commands/ContextKeys.cs
+++ b/src/backend/AgentSmith.Contracts/Commands/ContextKeys.cs
@@ -100,6 +100,11 @@ public static partial class ContextKeys
     public const string SourcePath = "SourcePath";
     public const string SourceUrl = "SourceUrl";
     public const string SourceAuth = "SourceAuth";
+    // p0261: CLI `--context NAME` pins the run to ONE named context
+    // (.agentsmith/contexts/NAME) instead of the multi-context discovery /
+    // synthetic-default fallback. Set → PipelineSandboxCoordinator resolves that
+    // single context; unset → unchanged discovery behaviour.
+    public const string SourceContext = "SourceContext";
 
     public const string SwaggerSpecFull = "SwaggerSpecFull";
     public const string CheckoutBranch = "CheckoutBranch";

--- a/tests/AgentSmith.Tests/Sandbox/SandboxLanguageResolverTests.cs
+++ b/tests/AgentSmith.Tests/Sandbox/SandboxLanguageResolverTests.cs
@@ -123,6 +123,49 @@ public sealed class SandboxLanguageResolverTests
             .Which.Should().Be(new RemoteContextDiscovery("default", ".", null));
     }
 
+    [Fact]
+    public async Task ResolveContextAsync_NamedContext_ReadsThatContextYaml()
+    {
+        // p0261: `--context api` pins to exactly that context, reading its toolchain.
+        SetupContextYaml("api", "src/Api", "csharp");
+
+        var result = await _sut.ResolveContextAsync(_source, "api", CancellationToken.None);
+
+        result.Should().ContainSingle()
+            .Which.Should().Be(new RemoteContextDiscovery("api", "src/Api", "csharp"));
+    }
+
+    [Fact]
+    public async Task ResolveContextAsync_Unreadable_NamedSyntheticNotDefault()
+    {
+        // Falls back to a NAMED synthetic so the probe hits contexts/api/, never
+        // the misleading "default".
+        _sourceProviderMock.Setup(p => p.TryReadFileAsync(
+                ".agentsmith/contexts/api/context.yaml", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string?)null);
+
+        var result = await _sut.ResolveContextAsync(_source, "api", CancellationToken.None);
+
+        result.Should().ContainSingle()
+            .Which.Should().Be(new RemoteContextDiscovery("api", ".", null));
+    }
+
+    [Fact]
+    public async Task ResolveContextAsync_LocalSourceEmptyUrl_StillResolvesNamedContext()
+    {
+        // The exact bug the flag fixes: ResolveAllAsync short-circuits to "default"
+        // when Url is empty (a local --source-path checkout), never discovering the
+        // real contexts. The override path must NOT short-circuit — it reads the
+        // named context directly so a local monorepo can target one of its contexts.
+        var localSource = new RepoConnection { Url = null };
+        SetupContextYaml("api", "src/Api", "csharp");
+
+        var result = await _sut.ResolveContextAsync(localSource, "api", CancellationToken.None);
+
+        result.Should().ContainSingle()
+            .Which.Should().Be(new RemoteContextDiscovery("api", "src/Api", "csharp"));
+    }
+
     private void SetupContextYaml(string contextName, string workdir, string language)
     {
         var yaml = $"yaml-content-{contextName}";


### PR DESCRIPTION
Two changes, both surfaced by running real scans against a customer API:

## 1. `--context NAME` flag (p0261)
A CLI `--source-path` on a single-repo stub project (e.g. `api-security-scan` with `cicd-noop-source`) collapsed a monorepo source's real `.agentsmith/contexts/*` to a synthetic `default` context, so the **BootstrapGate aborted** before any LLM work.

**Root cause:** `SandboxLanguageResolver.ResolveAllAsync` short-circuits to the synthetic default when `source.Url` is empty (a local checkout has a path, not a URL), never discovering the local contexts.

**Fix:** new `--context NAME` in the shared `SourceOptions` (so every source-aware verb gets it) pins the run to `.agentsmith/contexts/NAME` via a new `ISandboxLanguageResolver.ResolveContextAsync` — reads that context's `context.yaml` for the real toolchain, bypassing the URL guard, falling back to a *named* synthetic if unreadable. **Unset → discovery / synthetic-default behaviour is unchanged.**

Verified end-to-end: with `--context api` the BootstrapGate passes (context.yaml + principles found) and the api context loads, where the bare source-path run aborted. 3 new resolver tests incl. the local-empty-URL case.

## 2. Fix release Docker cache race (CI)
The release-please merge's Docker Build failed with `".next/standalone": not found` / `"Unable to reserve cache ... another job may be creating this cache"`. Two pushes to main 36s apart (feature merge + release merge) ran two builds concurrently against the same shared `type=gha,mode=max` cache → corrupted layer ref. The single branch build had passed — contention, not a Dockerfile defect.

- `concurrency` group per ref, `cancel-in-progress: false` → main builds queue, never race; PRs stay parallel.
- per-image cache `scope` so matrix legs don't contend within a run either.

## Tests
2507 backend green. Dashboard unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)