### PR TITLE
fix: docker-tier harness — git config + GeneratePlan seed alignment (p0281); plan p0282

### DIFF
--- a/.agentsmith/phases/planned/p0282-docker-tier-write-fidelity-and-gate.yaml
+++ b/.agentsmith/phases/planned/p0282-docker-tier-write-fidelity-and-gate.yaml
@@ -1,0 +1,90 @@
+# yaml-language-server: $schema=../../phase-spec.schema.json
+phase: p0282
+goal: |
+  Fix the silently-red docker-tier code-changing presets, then gate on them. The master's
+  edits never reach the working tree the pipeline commits, so fix-bug / fix-no-test /
+  add-feature record FAILED ("recorded edits but git committed NOTHING"). This reds the
+  whole code-changing docker tier — and nobody sees it, because those tests are docker-
+  opt-in and never run in default `dotnet test`. Two halves: (A) bridge the write so the
+  tier is genuinely green; (B) wire the blocking phase-commit gate that runs this now-
+  trustworthy tier as the real "does fix-bug actually work?" check.
+
+applies_to: "backend (test harness) + repo tooling (.claude gate)"
+
+requires:
+  - p0281   # prerequisite harness fixes (git safe.bareRepository override + GeneratePlan seed alignment) — without them this symptom is masked by an earlier FAIL
+  - p0276   # introduced GeneratePlan before the master; the regression that masked half A
+
+context_for_executor: |
+  Live evidence (isolated --docker run, 2026-06-22, current main WITH the p0281 fixes):
+   - Master writes host-side: log `AgenticMasterHandler tool_call: WriteFile path=primary/NOTE.md bytes=22`.
+   - Repo is checked out INSIDE the container: `CheckoutSourceHandler: Checking out primary ... at /work`
+     — a fresh `git clone file:///bare-remote` in the sandbox (LocalGitSourceProvider).
+   - CommitAndPR sees nothing: `commit-sandbox key=default ... hasCode=False staged=[]`
+     → keystone FAIL: "recorded edits but git committed NOTHING".
+   - LEADING HYPOTHESIS (verify, do not assume): the docker preset harness drives the master
+     loop host-side (RealCompositionHarness + FilesystemToolHost → session.WorkingCopyPath,
+     DockerPresetRunner.cs:105-106), but checkout/commit run in-container at /work; only the
+     BARE is bind-mounted (DockerHarnessSession.ExtraBind = bare:inSandboxBare), not the working
+     copy. Host write and in-container /work diverge → nothing to commit.
+   - DIAGNOSE FIRST: `git log` DockerPresetRunner + the per-preset docker tests; establish
+     whether the code-changing tier was EVER green and what committed the master's edit at
+     p0199c. The fix follows from how it was meant to work, not from patching the symptom.
+
+  The breakage is silent: Docker_FixBug/FixNoTest/AddFeature_GreenPath_PipelineSucceeds all
+  assert IsSuccess.BeTrue() but carry [Trait Tier=Docker] + SkipIfUnavailable() — opt-in via
+  AGENTSMITH_HARNESS_DOCKER=1 + a reachable daemon, so they never run in default `dotnet test`.
+  Whatever the fix, these three must become a real, runnable green.
+
+  NOT a production bug: prod writes via the in-container Sandbox.Agent into /work. This is a
+  harness-fidelity gap — how the preset harness bridges a host-side master edit into the
+  in-container repo. Do NOT weaken the keystone guard; it is the false-green detector working.
+
+decisions:
+  - key: "Fix the harness write→commit bridge, NOT the keystone. 'recorded edits but git committed NOTHING' is correct and must stay strict — it is exactly the false-green detector. The bug is that the docker preset harness does not land the master's edits in the tree git commits."
+  - key: "p0282 owns BOTH halves: (A) make the 3 code-changing docker presets genuinely green; (B) wire the blocking phase-commit gate on top. The gate is meaningless until the tier is trustworthy, so they ship together. If (A) proves large, slice the gate to a successor (p0283) OPENLY — never drop it silently."
+  - key: "Gate isolation is SETTLED from this session's proof: own docker network + throwaway redis via env overrides (HARNESS_SANDBOX_NETWORK / HARNESS_SANDBOX_REDIS_URL / REDIS_URL), never deploy_default / deploy-redis-1 — proven zero-leak + clean teardown. Scripted LLM → no API cost. Rebuild the agent-smith-sandbox-agent image ONLY when Sandbox.Agent / Sandbox.Wire are in the diff (Dockerfile-enforced closure), else reuse. Docker/redis absent → BLOCK with a visible override, never silent green (matches DockerAvailability's own rule)."
+
+steps:
+  - id: diagnose-write-bridge
+    action: "Trace how the master's host-side write_file is meant to reach the in-container /work tree (FilesystemToolHost LocalPath vs sandbox exec vs bind mount), and via git history whether/when the code-changing docker tier was green. Pin the root cause into decisions/p0282.yaml before editing."
+  - id: fix-write-commit-fidelity
+    action: "Make the master's edits land in the working tree the pipeline commits — per the diagnosed root cause (e.g. bind-mount/sync the working copy as /work, or route the master's writes through the sandbox). Keystone stays strict."
+    modify:
+      - "tests/AgentSmith.PipelineHarness/Composition: DockerHarnessSession / DockerPresetRunner / DockerHarnessRegistrations — the write/checkout bridge"
+  - id: green-the-docker-tier
+    action: "fix-bug / fix-no-test / add-feature `--preset <name> --docker` reach IsSuccess (real change shipped). Prove via the isolated fixture (own net + throwaway redis). The 3 docker xUnit tests pass."
+  - id: gate-docker-tier
+    action: "Upgrade the phase-commit gate: the 3 code-changing presets run the docker tier requiring exit 0 (the 'does it work' check), inside the isolated fixture (own net + throwaway redis, env-overridden), torn down after. Rebuild the sandbox-agent image only when Sandbox.Agent/Sandbox.Wire are in the diff (or image missing)."
+    modify:
+      - ".claude/hooks/phase-gate.sh — isolated docker-tier step for code-changing presets + image-rebuild-when-touched"
+      - ".claude/settings.json — already wires the PreToolUse gate"
+  - id: gate-fail-loud
+    action: "Docker daemon / redis / sandbox-agent image unavailable → the gate BLOCKS the phase commit with a clear, explicitly-overridable message — never a silent pass (per DockerAvailability)."
+    modify:
+      - ".claude/hooks/phase-gate.sh"
+  - id: close
+    action: "decisions/p0282.yaml, context.yaml update, move spec to done, single backend PR. The .claude gate is repo tooling, not shipped product."
+
+tests:
+  - "Docker_FixBug_GreenPath_PipelineSucceeds"      # un-rots — must actually pass with docker
+  - "Docker_FixNoTest_GreenPath_PipelineSucceeds"
+  - "Docker_AddFeature_GreenPath_PipelineSucceeds"
+  - "PhaseGate_CodeChangingPreset_RequiresDockerTierSuccess"
+  - "PhaseGate_DockerUnavailable_BlocksWithOverride_NotSilentPass"
+
+done:
+  - "fix-bug / fix-no-test / add-feature complete end-to-end through the real DockerSandbox with a shipped change (IsSuccess), proven by the 3 docker xUnit tests + an isolated --docker run."
+  - "The keystone guard is unchanged and still strict — the fix bridged the write, it did not weaken the check."
+  - "The phase-commit gate runs the code-changing presets through the isolated docker tier (own net + throwaway redis, zero deploy-stack contact, no LLM cost), requires exit 0, rebuilds the sandbox-agent image only when Sandbox.Agent/Wire change, and blocks-with-visible-override when docker/redis is absent."
+  - "A single phase commit demonstrably runs the gate green without touching deploy_default / deploy-redis-1."
+
+notes: |
+  p0281 is hard-required: without the git safe.bareRepository override and the GeneratePlan
+  seed alignment, this symptom hides behind an earlier FAIL. A gate draft is committed on the
+  p0281 branch (.claude/hooks/phase-gate.sh — currently the fast tier: build + dotnet test +
+  CLI dry-runs + crash-only stub presets — and .claude/settings.json wiring the PreToolUse
+  hook) — start from it, do not rebuild from scratch. It is INERT until merged; this phase
+  adds the docker tier for code-changing presets. Whether the model then
+  finds real bugs per slice is a separate quality question; this phase only guarantees the tier
+  is a trustworthy "does it work?" signal.

--- a/.claude/hooks/phase-gate.sh
+++ b/.claude/hooks/phase-gate.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Blocking phase-commit gate (PreToolUse on Bash).
+#
+# Fires on every Bash call but only gates a `git commit` whose message carries a
+# phase id, e.g. `feat: ... (p0272)` — the format produced by execute-phase
+# Step 10. Any other command passes through instantly.
+#
+# When it gates, the deterministic phase checks must all be green or the commit
+# is blocked (exit 2, stderr fed back to Claude):
+#   1. build           — dotnet build (errors fail)
+#   2. unit + harness xUnit tests — dotnet test (this is the harness pass/fail gate)
+#   3. CLI dry-runs    — <command> --help for each pipeline
+#   4. harness presets — every preset from `--list`, stub tier, CRASH-ONLY check
+#
+# Step 4 note: the console `--preset` runner returns the *pipeline result* as its
+# exit code — exit 1 (pipeline FAIL, e.g. fix-bug "no code changes") is a valid
+# outcome, NOT a test failure. So step 4 only fails the gate on a real crash
+# (exit >= 2 or an unhandled exception), which catches composition-root / DI
+# wiring breakage in RealCompositionHarness. The actual harness pass/fail
+# assertions live in the xUnit tests run by step 2.
+#
+# The --docker harness tier is intentionally NOT in the blocking gate: it needs
+# a docker daemon + redis and is too heavy/flaky for a commit hook. Run it
+# manually via `/smoke all` when you want the full end-to-end matrix.
+set -uo pipefail
+
+input=$(cat)
+cmd=$(printf '%s' "$input" \
+  | python3 -c 'import sys,json; print(json.load(sys.stdin).get("tool_input",{}).get("command",""))' 2>/dev/null) || exit 0
+
+# Only gate an actual `git commit` invocation (command word at start or after a
+# shell separator) whose message names a phase, e.g. (p0272) / (p73a). This
+# deliberately ignores commands that merely *mention* git commit (grep, echo,
+# this script's own tests).
+printf '%s' "$cmd" | grep -Eq '(^|[;&|]|&&)[[:space:]]*git[[:space:]]+commit\b' || exit 0
+printf '%s' "$cmd" | grep -Eq '\(p[0-9]+[a-z]?\)' || exit 0
+
+cd "${CLAUDE_PROJECT_DIR:-.}" || { echo "phase-gate: cannot cd to project dir" >&2; exit 2; }
+
+tmp=$(mktemp -d 2>/dev/null || echo /tmp)
+log()  { echo "[phase-gate] $*" >&2; }
+fail() { echo "" >&2; echo "PHASE GATE BLOCKED COMMIT — $1 failed. Fix it before committing the phase." >&2; exit 2; }
+
+log "phase commit detected — running blocking gate (build, tests, dry-runs, harness presets)"
+
+log "1/4 build..."
+if ! dotnet build AgentSmith.sln -clp:ErrorsOnly >"$tmp/build.log" 2>&1; then
+  tail -40 "$tmp/build.log" >&2; fail "build"
+fi
+
+log "2/4 unit + harness xUnit tests..."
+if ! dotnet test AgentSmith.sln --no-build >"$tmp/test.log" 2>&1; then
+  tail -50 "$tmp/test.log" >&2; fail "dotnet test"
+fi
+
+log "3/4 CLI dry-runs..."
+for c in api-scan security-scan fix feature; do
+  if ! dotnet run --no-build --project src/backend/AgentSmith.Cli -- "$c" --help >/dev/null 2>"$tmp/dry-$c.log"; then
+    cat "$tmp/dry-$c.log" >&2; fail "dry-run: $c --help"
+  fi
+done
+
+log "4/4 harness presets (stub tier, crash-only)..."
+if ! presets=$(dotnet run --no-build --project tests/AgentSmith.PipelineHarness -- --list 2>"$tmp/harness-list.log"); then
+  cat "$tmp/harness-list.log" >&2; fail "harness --list"
+fi
+while IFS= read -r p; do
+  [ -z "$p" ] && continue
+  out=$(dotnet run --no-build --project tests/AgentSmith.PipelineHarness -- --preset "$p" 2>&1); rc=$?
+  # exit 1 = pipeline returned FAIL (valid outcome); >=2 or an unhandled
+  # exception = a real crash in the harness composition.
+  if [ "$rc" -ge 2 ] || printf '%s' "$out" | grep -qiE 'unhandled exception|System\.[A-Za-z.]+Exception'; then
+    printf '%s\n' "$out" | tail -30 >&2; fail "harness preset crashed: $p"
+  fi
+  log "    preset ran: $p (rc=$rc)"
+done <<< "$presets"
+
+log "all green — commit allowed"
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/phase-gate.sh",
+            "timeout": 900
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/AgentSmith.PipelineHarness/Composition/DockerHarnessSession.cs
+++ b/tests/AgentSmith.PipelineHarness/Composition/DockerHarnessSession.cs
@@ -94,7 +94,7 @@ public sealed class DockerHarnessSession : IAsyncDisposable
 
     public bool BareHasBranch(string branchName)
     {
-        var psi = new ProcessStartInfo("git", $"-C \"{BareRepoPath}\" branch --list {branchName}")
+        var psi = new ProcessStartInfo("git", $"-c safe.bareRepository=all -C \"{BareRepoPath}\" branch --list {branchName}")
         {
             RedirectStandardOutput = true,
             UseShellExecute = false,
@@ -107,7 +107,7 @@ public sealed class DockerHarnessSession : IAsyncDisposable
 
     public IReadOnlyList<string> BareBranches()
     {
-        var psi = new ProcessStartInfo("git", $"-C \"{BareRepoPath}\" branch --list")
+        var psi = new ProcessStartInfo("git", $"-c safe.bareRepository=all -C \"{BareRepoPath}\" branch --list")
         {
             RedirectStandardOutput = true,
             UseShellExecute = false,
@@ -129,6 +129,14 @@ public sealed class DockerHarnessSession : IAsyncDisposable
             RedirectStandardError = true,
             UseShellExecute = false,
         };
+        // The ambient environment injects safe.bareRepository=explicit (GIT_CONFIG_*),
+        // which makes git refuse to operate on the per-test bare remote. Override it
+        // on our own invocations so the harness is immune to the operator's git config.
+        if (command == "git")
+        {
+            psi.ArgumentList.Add("-c");
+            psi.ArgumentList.Add("safe.bareRepository=all");
+        }
         foreach (var arg in args) psi.ArgumentList.Add(arg);
         using var p = Process.Start(psi)!;
         await p.WaitForExitAsync();

--- a/tests/AgentSmith.PipelineHarness/Presets/DockerPresetScripts.cs
+++ b/tests/AgentSmith.PipelineHarness/Presets/DockerPresetScripts.cs
@@ -58,17 +58,29 @@ internal static class DockerPresetScripts
         }
     }
 
+    // p0276 re-introduced GeneratePlanCommand before the master in the
+    // fix-bug / fix-no-test / add-feature presets; it consumes one scripted
+    // response. Without a plan in front of it, GeneratePlan eats the master's
+    // write_file tool-call, the master then makes no change, and the keystone
+    // records the run FAILED ("produced no code changes"). Prepend a minimal
+    // plan so the write_file still reaches the master and the change ships.
+    private const string PlanForGeneratePlan =
+        """{"summary":"harness plan","steps":[]}""";
+
     private static void SeedFixBug(ScriptedChatClient client) => client
+        .EnqueueText(PlanForGeneratePlan)
         .EnqueueToolCall("write_file",
             """{"path":"primary/NOTE.md","content":"docker-harness-fix-bug"}""")
         .EnqueueText("Edit applied.");
 
     private static void SeedFixNoTest(ScriptedChatClient client) => client
+        .EnqueueText(PlanForGeneratePlan)
         .EnqueueToolCall("write_file",
             """{"path":"primary/QUICK.md","content":"docker-harness-fix-no-test"}""")
         .EnqueueText("Quick fix applied.");
 
     private static void SeedAddFeature(ScriptedChatClient client) => client
+        .EnqueueText(PlanForGeneratePlan)
         .EnqueueToolCall("write_file",
             """{"path":"primary/FEATURE.md","content":"docker-harness-add-feature"}""")
         .EnqueueText("Feature added.");


### PR DESCRIPTION
Renumbered from an earlier p0280 draft (p0280 was already taken). Replaces the closed #327.

## What

Two verified fixes to the docker-tier preset harness, uncovered while wiring a docker-tier phase-commit gate, plus the plan + secured draft for finishing the job.

### p0281 — two harness fixes (verified)
1. **git `safe.bareRepository`** — the ambient `GIT_CONFIG_*` injects `safe.bareRepository=explicit`, which made the harness's host-side bare-repo git operations fatal. Pin `-c safe.bareRepository=all` on the harness's own git invocations so it's immune to the operator/CI git config.
2. **GeneratePlan seed alignment** — p0276 re-introduced `GeneratePlanCommand` before the master in fix-bug/fix-no-test/add-feature; it consumes one scripted response, which ate the master's `write_file`. Prepend a minimal plan to the three code-changing docker seeds so the edit reaches the master again.

Symptom progression (isolated `--docker` run) proves both: `safe.bareRepository` fatal gone, master now writes the file.

### Honest status
These advance the tier past two failures but do **not** make it green. A third, previously-masked breakage remains: the harness drives the master loop host-side while git checkout/commit run in-container at `/work`, so master edits never reach the committed tree (`recorded edits but git committed NOTHING`). This silently reds the **entire** code-changing docker tier — `Docker_FixBug/FixNoTest/AddFeature_GreenPath` all assert `IsSuccess` but are docker-opt-in, never in CI.

### p0282 — planned
`.agentsmith/phases/planned/p0282-...yaml` specs the fix (write→commit fidelity, keystone stays strict) **and** the blocking phase-commit gate (isolated fixture: own net + throwaway redis, no LLM cost, rebuild-when-`Sandbox.Agent`/`Wire`, fail-loud-not-silent). Carries the live evidence as anchors.

### Gate draft (inert)
`.claude/hooks/phase-gate.sh` (fast tier: build + `dotnet test` + CLI dry-runs + crash-only stub presets) + `.claude/settings.json` (PreToolUse hook, fires only on a phase-id commit). Force-added past the `.claude` gitignore so it's not lost. **Inert until merged**; p0282 adds the docker tier on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)