### PR TITLE
fix: surface ticket-provider HTTP errors instead of swallowing to null (p0283)

### DIFF
--- a/src/backend/AgentSmith.Infrastructure/Services/Providers/Tickets/GitLabIssueLister.cs
+++ b/src/backend/AgentSmith.Infrastructure/Services/Providers/Tickets/GitLabIssueLister.cs
@@ -27,8 +27,7 @@ internal sealed class GitLabIssueLister(
                 + $"?labels={Uri.EscapeDataString(rawLabel)}&state=opened&per_page=100";
             try
             {
-                using var doc = await http.TrySendForJsonAsync(HttpMethod.Get, url, null, cancellationToken);
-                if (doc is null) continue;
+                using var doc = await http.SendForJsonOrThrowAsync(HttpMethod.Get, url, null, cancellationToken);
                 foreach (var t in mapper.MapMany(doc.RootElement)) deduped[t.Id.Value] = t;
             }
             catch (Exception ex)

--- a/src/backend/AgentSmith.Infrastructure/Services/Providers/Tickets/JiraIssueSearcher.cs
+++ b/src/backend/AgentSmith.Infrastructure/Services/Providers/Tickets/JiraIssueSearcher.cs
@@ -27,14 +27,9 @@ internal sealed class JiraIssueSearcher(
         logger.LogInformation("Jira Search: project={Project} {Descriptor}", project, descriptor);
         try
         {
-            using var doc = await http.TrySendForJsonAsync(
+            using var doc = await http.SendForJsonOrThrowAsync(
                 HttpMethod.Post, $"{_baseUrl}/rest/api/3/search",
                 new { jql, fields = StandardFields, maxResults = 100 }, cancellationToken);
-            if (doc is null)
-            {
-                logger.LogWarning("Jira Search: non-success for project={Project}", project);
-                return [];
-            }
             var tickets = mapper.MapSearchResponse(doc.RootElement);
             logger.LogInformation("Jira Search: returned {Count} ticket(s)", tickets.Count);
             return tickets;

--- a/src/backend/AgentSmith.Infrastructure/Services/Providers/Tickets/JiraTicketProvider.cs
+++ b/src/backend/AgentSmith.Infrastructure/Services/Providers/Tickets/JiraTicketProvider.cs
@@ -26,6 +26,7 @@ public sealed class JiraTicketProvider : ITicketProvider
     private readonly JiraTransitioner _transitioner;
     private readonly string _doneStatus;
     private readonly string _closeTransitionName;
+    private readonly ILogger<JiraTicketProvider> _logger;
 
     public string ProviderType => "Jira";
 
@@ -40,6 +41,7 @@ public sealed class JiraTicketProvider : ITicketProvider
         _mapper = mapper;
         _doneStatus = doneStatus ?? "Done";
         _closeTransitionName = closeTransitionName ?? "Close";
+        _logger = logger;
         _attachmentLoader = new JiraAttachmentLoader(httpClient, logger);
         _searcher = new JiraIssueSearcher(_http, mapper, connection, logger);
         _transitioner = new JiraTransitioner(_http, _baseUrl, logger);
@@ -73,9 +75,20 @@ public sealed class JiraTicketProvider : ITicketProvider
         TicketId ticketId, CancellationToken cancellationToken)
     {
         var url = $"{_baseUrl}/rest/api/3/issue/{ticketId.Value}?fields=attachment";
-        using var doc = await _http.TrySendForJsonAsync(HttpMethod.Get, url, null, cancellationToken);
-        if (doc is null || !doc.RootElement.TryGetProperty("fields", out var fields)) return [];
-        return JiraAttachmentLoader.ParseRefs(fields);
+        try
+        {
+            using var doc = await _http.SendForJsonOrThrowAsync(HttpMethod.Get, url, null, cancellationToken);
+            return doc.RootElement.TryGetProperty("fields", out var fields)
+                ? JiraAttachmentLoader.ParseRefs(fields)
+                : [];
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Jira attachment-ref fetch failed for {TicketId} — continuing without attachments",
+                ticketId.Value);
+            return [];
+        }
     }
 
     public async Task<IReadOnlyList<TicketImageAttachment>> DownloadImageAttachmentsAsync(

--- a/src/backend/AgentSmith.Infrastructure/Services/Providers/Tickets/TicketProviderHttpClient.cs
+++ b/src/backend/AgentSmith.Infrastructure/Services/Providers/Tickets/TicketProviderHttpClient.cs
@@ -75,17 +75,20 @@ internal sealed class TicketProviderHttpClient
     }
 
     /// <summary>
-    /// Like <see cref="SendForJsonAsync"/> but returns <c>null</c> on ANY
-    /// non-2xx response (callers that want empty-list semantics on errors).
+    /// Sends a request and returns the parsed <see cref="JsonDocument"/> on 2xx.
+    /// On ANY non-2xx response (including 404) reads the response body and throws
+    /// an <see cref="HttpRequestException"/> carrying the status code plus the
+    /// provider's error message, so callers surface the real Jira/GitLab failure
+    /// instead of silently degrading to an empty result. List-style callers wrap
+    /// this in a try/catch to log the cause and fall back to an empty collection.
     /// </summary>
-    public async Task<JsonDocument?> TrySendForJsonAsync(
+    public async Task<JsonDocument> SendForJsonOrThrowAsync(
         HttpMethod method, string url, object? body, CancellationToken cancellationToken)
     {
         using var request = BuildRequest(method, url, body);
         using var response = await _httpClient.SendAsync(request, cancellationToken);
 
-        if (!response.IsSuccessStatusCode)
-            return null;
+        await response.EnsureSuccessWithBodyAsync(cancellationToken);
 
         var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
         return await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken);


### PR DESCRIPTION
## Problem
`TicketProviderHttpClient.TrySendForJsonAsync` returned `null` on **any** non-2xx response. Jira/GitLab search and list calls silently degraded to empty results, and the real provider error (auth failure, rate limit, malformed JQL, 404) was lost — operators saw "0 tickets" with no clue why.

## Change
- Replace `TrySendForJsonAsync` (silent-null) with **`SendForJsonOrThrowAsync`**: reads the response body and throws `HttpRequestException` with status code + provider message on every non-2xx (incl. 404), via the existing `EnsureSuccessWithBodyAsync`.
- Migrate all three callers:
  - **JiraIssueSearcher** / **GitLabIssueLister** — already had `catch (Exception)` + degrade-to-empty; they now log the **real** error message instead of a generic "non-success".
  - **JiraTicketProvider.GetAttachmentRefsAsync** — gains a `try/catch`; attachment listing stays best-effort (`[]`) but logs the actual cause.

## Notes
- `SendForJsonAsync` (404 → `null` → `TicketNotFoundException`) is intentionally left untouched — `GetTicketAsync` maps 404 to a domain exception.
- Renamed `Try…` → `…OrThrow` because a "Try" prefix on a throwing method is misleading.

## Verification
- `dotnet build` green
- Full suite: **2610 passed, 0 failed** (incl. `ListByLifecycleStatusAsync_HttpError_ReturnsEmptyList`, which still passes — the searcher's catch preserves the empty-list contract while surfacing the cause in logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)