### PR TITLE
fix: migrate Jira search to /rest/api/3/search/jql (410 Gone)

### DIFF
--- a/src/backend/AgentSmith.Infrastructure/Services/Providers/Tickets/JiraIssueSearcher.cs
+++ b/src/backend/AgentSmith.Infrastructure/Services/Providers/Tickets/JiraIssueSearcher.cs
@@ -5,9 +5,18 @@ using Microsoft.Extensions.Logging;
 namespace AgentSmith.Infrastructure.Services.Providers.Tickets;
 
 /// <summary>
-/// p0147f: Jira search helper. Builds the JQL, POSTs to /rest/api/3/search,
-/// and hands the issues array to <see cref="JiraFieldMapper"/>. Project key
-/// is optional — when absent the search runs cross-project.
+/// p0147f: Jira search helper. Builds the JQL, POSTs to the enhanced-search
+/// endpoint <c>/rest/api/3/search/jql</c>, and hands the issues array to
+/// <see cref="JiraFieldMapper"/>. Project key is optional — when absent the
+/// search runs cross-project.
+/// <para>
+/// The legacy <c>/rest/api/3/search</c> endpoint was removed by Atlassian
+/// (CHANGE-2046) and now returns HTTP 410 Gone. The replacement keeps the same
+/// request body (<c>jql</c> / <c>fields</c> / <c>maxResults</c>) and the same
+/// <c>issues</c> response array, but paginates via an opaque <c>nextPageToken</c>
+/// instead of <c>startAt</c>/<c>total</c> — we read the first page only, which
+/// matches the prior maxResults=100 cap.
+/// </para>
 /// </summary>
 internal sealed class JiraIssueSearcher(
     TicketProviderHttpClient http, JiraFieldMapper mapper,
@@ -28,7 +37,7 @@ internal sealed class JiraIssueSearcher(
         try
         {
             using var doc = await http.SendForJsonOrThrowAsync(
-                HttpMethod.Post, $"{_baseUrl}/rest/api/3/search",
+                HttpMethod.Post, $"{_baseUrl}/rest/api/3/search/jql",
                 new { jql, fields = StandardFields, maxResults = 100 }, cancellationToken);
             var tickets = mapper.MapSearchResponse(doc.RootElement);
             logger.LogInformation("Jira Search: returned {Count} ticket(s)", tickets.Count);

--- a/tests/AgentSmith.Tests/Providers/Tickets/JiraTicketProviderListByLifecycleTests.cs
+++ b/tests/AgentSmith.Tests/Providers/Tickets/JiraTicketProviderListByLifecycleTests.cs
@@ -24,7 +24,7 @@ public sealed class JiraTicketProviderListByLifecycleTests
         await sut.ListByLifecycleStatusAsync(TicketLifecycleStatus.Pending, CancellationToken.None);
 
         handler.LastRequest!.Method.Should().Be(HttpMethod.Post);
-        handler.LastRequest.RequestUri!.AbsolutePath.Should().Be("/rest/api/3/search");
+        handler.LastRequest.RequestUri!.AbsolutePath.Should().Be("/rest/api/3/search/jql");
 
         using var doc = JsonDocument.Parse(handler.LastRequestBody!);
         var jql = doc.RootElement.GetProperty("jql").GetString();


### PR DESCRIPTION
## Problem
Jira removed the legacy `/rest/api/3/search` endpoint (Atlassian **CHANGE-2046**). It now returns **HTTP 410 Gone**, so Jira polling silently returned **zero tickets**. The error-surfacing change merged in #330 made the real cause visible in the logs:

```
warn [Tickets.JiraTicketProvider] Jira Search failed for project=SCR:
HTTP 410 Gone: {"errorMessages":["The requested API has been removed.
Please migrate to the /rest/api/3/search/jql API ... CHANGE-2046"]}
```

## Fix
Switch `JiraIssueSearcher` to the enhanced-search endpoint **`/rest/api/3/search/jql`**:
- Same request body (`jql` / `fields` / `maxResults`) and same `issues` response array → `JiraFieldMapper` is unchanged.
- First-page read (maxResults=100) preserves the prior cap; the new endpoint paginates via an opaque `nextPageToken` instead of `startAt`/`total`.
- Updated the URL assertion in `JiraTicketProviderListByLifecycleTests`.

## Verification
- `dotnet build` green
- Jira provider tests: **38 passed, 0 failed**

Builds on #330 (merged) — that PR is what surfaced this error instead of swallowing it to an empty result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)