### PR TITLE
fix: ListOpenAsync across all ticket providers + remove dead ListByLabelsInOpenStatesAsync (p0285)

### DIFF
--- a/src/backend/AgentSmith.Contracts/Providers/ITicketProvider.cs
+++ b/src/backend/AgentSmith.Contracts/Providers/ITicketProvider.cs
@@ -89,17 +89,6 @@ public interface ITicketProvider : ITypedProvider
         => Task.FromResult<IReadOnlyList<Ticket>>(Array.Empty<Ticket>());
 
     /// <summary>
-    /// Lists tickets in open states whose label set matches ANY of the given labels.
-    /// Used by the poller's discovery pass to find newly-tagged tickets that have not
-    /// yet entered the lifecycle (no agent-smith:* tag). The provider populates the
-    /// returned ticket's Labels so the caller can filter by lifecycle in-process.
-    /// Default: empty list — providers that don't support label-search don't participate.
-    /// </summary>
-    Task<IReadOnlyList<Ticket>> ListByLabelsInOpenStatesAsync(
-        IReadOnlyCollection<string> labels, CancellationToken cancellationToken)
-        => Task.FromResult<IReadOnlyList<Ticket>>(Array.Empty<Ticket>());
-
-    /// <summary>
     /// Returns attachment references found on the ticket.
     /// Default: empty list (providers that have no attachments skip this).
     /// </summary>

--- a/src/backend/AgentSmith.Infrastructure/Services/Providers/Tickets/AzureDevOpsTicketProvider.cs
+++ b/src/backend/AgentSmith.Infrastructure/Services/Providers/Tickets/AzureDevOpsTicketProvider.cs
@@ -65,14 +65,6 @@ public sealed class AzureDevOpsTicketProvider : ITicketProvider
             $"[System.Tags] CONTAINS '{LifecycleLabels.For(status)}'",
             $"lifecycle={status}", cancellationToken);
 
-    public Task<IReadOnlyList<Ticket>> ListByLabelsInOpenStatesAsync(
-        IReadOnlyCollection<string> labels, CancellationToken cancellationToken)
-    {
-        if (labels.Count == 0) return Task.FromResult<IReadOnlyList<Ticket>>([]);
-        var tagOr = string.Join(" OR ", labels.Select(l => $"[System.Tags] CONTAINS '{EscapeWiql(l)}'"));
-        return _lister.ListAsync($"({tagOr})", $"labels=[{string.Join(", ", labels)}]", cancellationToken);
-    }
-
     public Task<IReadOnlyList<AttachmentRef>> GetAttachmentRefsAsync(
         TicketId ticketId, CancellationToken cancellationToken)
         => int.TryParse(ticketId.Value, out var id)
@@ -140,6 +132,4 @@ public sealed class AzureDevOpsTicketProvider : ITicketProvider
 
     private static string ToHtml(string markdown) =>
         string.IsNullOrEmpty(markdown) ? markdown : Markdown.ToHtml(markdown, MarkdownPipeline);
-
-    private static string EscapeWiql(string s) => s.Replace("'", "''");
 }

--- a/src/backend/AgentSmith.Infrastructure/Services/Providers/Tickets/GitHubIssueLister.cs
+++ b/src/backend/AgentSmith.Infrastructure/Services/Providers/Tickets/GitHubIssueLister.cs
@@ -58,6 +58,32 @@ internal sealed class GitHubIssueLister
         }
     }
 
+    /// <summary>
+    /// Lists all OPEN issues (no label filter) for the poller's discovery pass and
+    /// the dashboard/chat ticket listing. Pull requests come back from the issues
+    /// endpoint too — they are excluded.
+    /// </summary>
+    public async Task<IReadOnlyList<Ticket>> ListOpenAsync(CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("GitHub List: repo={Owner}/{Repo} open-discovery", _owner, _repo);
+        try
+        {
+            var issues = await _client.Issue.GetAllForRepository(
+                _owner, _repo, new RepositoryIssueRequest { State = ItemStateFilter.Open });
+            var tickets = issues
+                .Where(issue => issue.PullRequest is null)
+                .Select(issue => _mapper.Map(new TicketId(issue.Number.ToString()), issue))
+                .ToList();
+            _logger.LogInformation("GitHub List: returned {Count} ticket(s)", tickets.Count);
+            return tickets;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "GitHub List (open) failed for {Owner}/{Repo}", _owner, _repo);
+            return [];
+        }
+    }
+
     private static (string owner, string repo) ParseGitHubUrl(string url)
     {
         var segments = new Uri(url).AbsolutePath.Trim('/').Split('/');

--- a/src/backend/AgentSmith.Infrastructure/Services/Providers/Tickets/GitHubTicketProvider.cs
+++ b/src/backend/AgentSmith.Infrastructure/Services/Providers/Tickets/GitHubTicketProvider.cs
@@ -72,6 +72,11 @@ public sealed class GitHubTicketProvider : ITicketProvider
         await _client.Issue.Update(_owner, _repo, n, new IssueUpdate { State = ItemState.Closed });
     }
 
+    // Open-state discovery for the poller + dashboard/chat listing. Without this
+    // GitHub fell back to ITicketProvider's empty default (see JiraTicketProvider).
+    public Task<IReadOnlyList<Ticket>> ListOpenAsync(CancellationToken cancellationToken)
+        => _lister.ListOpenAsync(cancellationToken);
+
     public Task<IReadOnlyList<Ticket>> ListByLifecycleStatusAsync(
         TicketLifecycleStatus status, CancellationToken cancellationToken)
         => _lister.ListByLabelsAsync(

--- a/src/backend/AgentSmith.Infrastructure/Services/Providers/Tickets/GitHubTicketProvider.cs
+++ b/src/backend/AgentSmith.Infrastructure/Services/Providers/Tickets/GitHubTicketProvider.cs
@@ -82,13 +82,6 @@ public sealed class GitHubTicketProvider : ITicketProvider
         => _lister.ListByLabelsAsync(
             [LifecycleLabels.For(status)], ItemStateFilter.All, $"lifecycle={status}", cancellationToken);
 
-    public Task<IReadOnlyList<Ticket>> ListByLabelsInOpenStatesAsync(
-        IReadOnlyCollection<string> labels, CancellationToken cancellationToken)
-        => labels.Count == 0
-            ? Task.FromResult<IReadOnlyList<Ticket>>([])
-            : _lister.ListByLabelsAsync(
-                labels, ItemStateFilter.Open, $"labels=[{string.Join(", ", labels)}]", cancellationToken);
-
     public async Task TransitionToAsync(TicketId ticketId, string statusName, CancellationToken cancellationToken)
     {
         if (!TryParseIssueNumber(ticketId, out var n)) return;

--- a/src/backend/AgentSmith.Infrastructure/Services/Providers/Tickets/GitLabIssueLister.cs
+++ b/src/backend/AgentSmith.Infrastructure/Services/Providers/Tickets/GitLabIssueLister.cs
@@ -39,4 +39,27 @@ internal sealed class GitLabIssueLister(
         logger.LogInformation("GitLab List: returned {Count} ticket(s)", deduped.Count);
         return [.. deduped.Values];
     }
+
+    /// <summary>
+    /// Lists all OPEN issues (no label filter) for the poller's discovery pass and
+    /// the dashboard/chat ticket listing — the label-fan-out SearchAsync returns
+    /// nothing when given no labels.
+    /// </summary>
+    public async Task<IReadOnlyList<Ticket>> ListOpenAsync(CancellationToken cancellationToken)
+    {
+        logger.LogInformation("GitLab List: project={Project} open-discovery", _projectPath);
+        var url = $"{_baseUrl}/api/v4/projects/{_projectPath}/issues?state=opened&per_page=100";
+        try
+        {
+            using var doc = await http.SendForJsonOrThrowAsync(HttpMethod.Get, url, null, cancellationToken);
+            var tickets = mapper.MapMany(doc.RootElement);
+            logger.LogInformation("GitLab List: returned {Count} ticket(s)", tickets.Count);
+            return tickets;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "GitLab List (open) failed for project={Project}", _projectPath);
+            return [];
+        }
+    }
 }

--- a/src/backend/AgentSmith.Infrastructure/Services/Providers/Tickets/GitLabTicketProvider.cs
+++ b/src/backend/AgentSmith.Infrastructure/Services/Providers/Tickets/GitLabTicketProvider.cs
@@ -60,12 +60,6 @@ public sealed class GitLabTicketProvider : ITicketProvider
         TicketLifecycleStatus status, CancellationToken cancellationToken)
         => _lister.SearchAsync([LifecycleLabels.For(status)], $"lifecycle={status}", cancellationToken);
 
-    public Task<IReadOnlyList<Ticket>> ListByLabelsInOpenStatesAsync(
-        IReadOnlyCollection<string> labels, CancellationToken cancellationToken)
-        => labels.Count == 0
-            ? Task.FromResult<IReadOnlyList<Ticket>>([])
-            : _lister.SearchAsync(labels, $"labels=[{string.Join(", ", labels)}]", cancellationToken);
-
     public async Task<IReadOnlyList<AttachmentRef>> GetAttachmentRefsAsync(
         TicketId ticketId, CancellationToken cancellationToken)
     {

--- a/src/backend/AgentSmith.Infrastructure/Services/Providers/Tickets/GitLabTicketProvider.cs
+++ b/src/backend/AgentSmith.Infrastructure/Services/Providers/Tickets/GitLabTicketProvider.cs
@@ -51,6 +51,11 @@ public sealed class GitLabTicketProvider : ITicketProvider
         using (doc) return _mapper.Map(ticketId, doc.RootElement);
     }
 
+    // Open-state discovery for the poller + dashboard/chat listing. Without this
+    // GitLab fell back to ITicketProvider's empty default (see JiraTicketProvider).
+    public Task<IReadOnlyList<Ticket>> ListOpenAsync(CancellationToken cancellationToken)
+        => _lister.ListOpenAsync(cancellationToken);
+
     public Task<IReadOnlyList<Ticket>> ListByLifecycleStatusAsync(
         TicketLifecycleStatus status, CancellationToken cancellationToken)
         => _lister.SearchAsync([LifecycleLabels.For(status)], $"lifecycle={status}", cancellationToken);

--- a/src/backend/AgentSmith.Infrastructure/Services/Providers/Tickets/JiraTicketProvider.cs
+++ b/src/backend/AgentSmith.Infrastructure/Services/Providers/Tickets/JiraTicketProvider.cs
@@ -61,6 +61,14 @@ public sealed class JiraTicketProvider : ITicketProvider
             $"labels = \"{LifecycleLabels.For(status)}\"",
             $"lifecycle={status}", cancellationToken);
 
+    // Open-state discovery query for the poller. Without this Jira fell back to
+    // ITicketProvider's empty default, so the poller only ever saw lifecycle-tagged
+    // tickets and NEVER discovered a fresh ticket — only AzDO implemented ListOpenAsync.
+    // "Open" matches ListByLabelsInOpenStatesAsync's definition (statusCategory != Done);
+    // per-ticket routing + trigger_statuses gating run downstream in TrackerPoller.
+    public Task<IReadOnlyList<Ticket>> ListOpenAsync(CancellationToken cancellationToken)
+        => _searcher.SearchAsync("statusCategory != Done", "open-discovery", cancellationToken);
+
     public Task<IReadOnlyList<Ticket>> ListByLabelsInOpenStatesAsync(
         IReadOnlyCollection<string> labels, CancellationToken cancellationToken)
     {

--- a/src/backend/AgentSmith.Infrastructure/Services/Providers/Tickets/JiraTicketProvider.cs
+++ b/src/backend/AgentSmith.Infrastructure/Services/Providers/Tickets/JiraTicketProvider.cs
@@ -64,20 +64,10 @@ public sealed class JiraTicketProvider : ITicketProvider
     // Open-state discovery query for the poller. Without this Jira fell back to
     // ITicketProvider's empty default, so the poller only ever saw lifecycle-tagged
     // tickets and NEVER discovered a fresh ticket — only AzDO implemented ListOpenAsync.
-    // "Open" matches ListByLabelsInOpenStatesAsync's definition (statusCategory != Done);
-    // per-ticket routing + trigger_statuses gating run downstream in TrackerPoller.
+    // "Open" = statusCategory != Done; per-ticket routing + trigger_statuses gating
+    // run downstream in TrackerPoller.
     public Task<IReadOnlyList<Ticket>> ListOpenAsync(CancellationToken cancellationToken)
         => _searcher.SearchAsync("statusCategory != Done", "open-discovery", cancellationToken);
-
-    public Task<IReadOnlyList<Ticket>> ListByLabelsInOpenStatesAsync(
-        IReadOnlyCollection<string> labels, CancellationToken cancellationToken)
-    {
-        if (labels.Count == 0) return Task.FromResult<IReadOnlyList<Ticket>>([]);
-        var quoted = string.Join(", ", labels.Select(l => $"\"{l.Replace("\"", "\\\"")}\""));
-        return _searcher.SearchAsync(
-            $"labels in ({quoted}) AND statusCategory != Done",
-            $"labels=[{string.Join(", ", labels)}]", cancellationToken);
-    }
 
     public async Task<IReadOnlyList<AttachmentRef>> GetAttachmentRefsAsync(
         TicketId ticketId, CancellationToken cancellationToken)

--- a/tests/AgentSmith.Tests/Providers/Tickets/JiraTicketProviderListByLifecycleTests.cs
+++ b/tests/AgentSmith.Tests/Providers/Tickets/JiraTicketProviderListByLifecycleTests.cs
@@ -120,6 +120,23 @@ public sealed class JiraTicketProviderListByLifecycleTests
         tickets.Should().BeEmpty();
     }
 
+    [Fact]
+    public async Task ListOpenAsync_QueriesOpenTicketsForDiscovery()
+    {
+        var handler = new RecordingHandler
+        {
+            Responder = _ => JsonResponse("""{"issues":[]}""")
+        };
+        var sut = BuildSut(handler, projectKey: null);
+
+        await sut.ListOpenAsync(CancellationToken.None);
+
+        handler.LastRequest!.Method.Should().Be(HttpMethod.Post);
+        handler.LastRequest.RequestUri!.AbsolutePath.Should().Be("/rest/api/3/search/jql");
+        using var doc = JsonDocument.Parse(handler.LastRequestBody!);
+        doc.RootElement.GetProperty("jql").GetString().Should().Be("statusCategory != Done");
+    }
+
     private static JiraTicketProvider BuildSut(HttpMessageHandler handler, string? projectKey)
     {
         var httpClient = new HttpClient(handler);


### PR DESCRIPTION
## Problem
A fresh ticket in an open status was **never discovered by polling**, and the dashboard/chat "list tickets" feature returned empty — for **Jira, GitHub, and GitLab**.

`ListOpenAsync` is the real discovery method (called by `TrackerPoller`, `CachedTicketSearch`, `ListTicketsIntentHandler`) and has an **empty default body** on `ITicketProvider`. An audit of all four implementations found only **AzureDevOps** overrode it.

| Provider | ListOpenAsync before | after |
|----------|----------------------|-------|
| AzureDevOps | ✓ implemented | ✓ |
| Jira | ✗ empty default | ✓ `statusCategory != Done` |
| GitHub | ✗ empty default | ✓ open issues (PRs excluded) |
| GitLab | ✗ empty default | ✓ `issues?state=opened` |

## Fix
Each provider implements `ListOpenAsync` as an open-state list; per-ticket routing (`project_resolution`) + `trigger_statuses` gating run downstream in `TrackerPoller`, unchanged.

## Dead-code cleanup (same PR)
`ListByLabelsInOpenStatesAsync` had **zero callers** — the poller's discovery pass was switched to `ListOpenAsync`, leaving its "used by the poller" doc stale. Removed the interface method and all four overrides, plus the now-orphaned `EscapeWiql` helper in the AzDO provider. No behavioural change.

## Verification
- `dotnet build` green, no warnings
- Full suite: **2610 passed** (one unrelated flaky `SandboxResourceResolver` test, passes in isolation; untouched by this PR)
- Reproduced live on Jira: before, every poll logged only `lifecycle=Pending → 0` / `0 polled`; a To-Do ticket never appeared in `poll-claimable`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)