### PR TITLE
fix: replay run execution from durable DB trail when Redis stream is gone (p0286)

### DIFF
--- a/src/backend/AgentSmith.Infrastructure/Services/Events/EventEnvelopeSerializer.cs
+++ b/src/backend/AgentSmith.Infrastructure/Services/Events/EventEnvelopeSerializer.cs
@@ -34,6 +34,22 @@ public static class EventEnvelopeSerializer
         return (RunEvent?)JsonSerializer.Deserialize(payload, concrete, Options);
     }
 
+    /// <summary>
+    /// Deserialises the DURABLE DB trail's bare payload back to a typed RunEvent,
+    /// given the stored EventType NAME. The trail (RunDbProjector) stores the raw
+    /// <c>JsonSerializer.Serialize(ev, ev.GetType())</c> — default STJ casing, NOT
+    /// the camelCase <c>{t,p}</c> envelope above — plus the type in its own column.
+    /// Used to replay a run's execution after the Redis stream's 24h TTL expires
+    /// or a Redis flush/restart loses it.
+    /// </summary>
+    public static RunEvent? DeserializeRaw(string typeName, string? payloadJson)
+    {
+        if (string.IsNullOrEmpty(payloadJson)) return null;
+        if (!Enum.TryParse<EventType>(typeName, out var type)) return null;
+        var concrete = ResolveType(type);
+        return concrete is null ? null : (RunEvent?)JsonSerializer.Deserialize(payloadJson, concrete);
+    }
+
     // p0173a: parallel envelope path for SystemEvent. Same JSON shape
     // ({"t":<code>,"p":<payload>}) — a separate top-level method keeps the
     // run-event path type-narrow at the call sites and lets ResolveType

--- a/src/backend/AgentSmith.Server/Hubs/JobsHub.cs
+++ b/src/backend/AgentSmith.Server/Hubs/JobsHub.cs
@@ -87,19 +87,13 @@ public sealed class JobsHub(
     public async Task SubscribeRun(string runId)
     {
         await Groups.AddToGroupAsync(Context.ConnectionId, HubGroups.Run(runId));
-        var db = redis.GetDatabase();
-        var entries = await db.StreamRangeAsync(EventStreamKeys.RunStream(runId), "-", "+");
-        foreach (var entry in entries)
-        {
-            foreach (var pair in entry.Values)
-            {
-                var payload = pair.Value.ToString();
-                if (string.IsNullOrEmpty(payload)) continue;
-                var runEvent = EventEnvelopeSerializer.Deserialize(payload);
-                if (runEvent is null) continue;
-                await Clients.Caller.SendAsync("RunEvent", runEvent);
-            }
-        }
+        // Replay the retained window before the live tail. TrailReader serves the
+        // Redis stream and, once that's gone (24h TTL / flush / restart), falls
+        // back to the durable DB trail so a finished run keeps its full execution
+        // view. ReadAllAsync returns object-typed elements so STJ serialises each
+        // by its runtime subtype (p0175-fix).
+        foreach (var runEvent in await trailReader.ReadAllAsync(runId))
+            await Clients.Caller.SendAsync("RunEvent", runEvent);
     }
 
     public async Task ExpandSandbox(string runId, string repo)

--- a/src/backend/AgentSmith.Server/Services/Events/TrailReader.cs
+++ b/src/backend/AgentSmith.Server/Services/Events/TrailReader.cs
@@ -1,6 +1,9 @@
 using AgentSmith.Contracts.Events;
+using AgentSmith.Infrastructure.Persistence.Contracts;
 using AgentSmith.Infrastructure.Services.Events;
 using AgentSmith.Server.Hubs;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using StackExchange.Redis;
 
 namespace AgentSmith.Server.Services.Events;
@@ -21,17 +24,13 @@ namespace AgentSmith.Server.Services.Events;
 /// the <see cref="ReadAllTypedAsync"/> seam exposes them strongly-typed
 /// for unit tests.</para>
 /// </summary>
-public sealed class TrailReader(IConnectionMultiplexer redis)
+public sealed class TrailReader(IConnectionMultiplexer redis, IServiceScopeFactory scopeFactory)
 {
     public const int DefaultPageCount = 500;
     public const int MaxPageCount = 2000;
 
-    public async Task<IReadOnlyList<object>> ReadAllAsync(string runId)
-    {
-        var db = redis.GetDatabase();
-        var entries = await db.StreamRangeAsync(EventStreamKeys.RunStream(runId), "-", "+");
-        return ToEvents(entries);
-    }
+    public async Task<IReadOnlyList<object>> ReadAllAsync(string runId) =>
+        (await ReadAllTypedAsync(runId)).Cast<object>().ToList();
 
     public async Task<TrailPage> ReadPageAsync(string runId, string? fromId, int? count)
     {
@@ -56,7 +55,31 @@ public sealed class TrailReader(IConnectionMultiplexer redis)
     {
         var db = redis.GetDatabase();
         var entries = await db.StreamRangeAsync(EventStreamKeys.RunStream(runId), "-", "+");
-        return ToTypedEvents(entries);
+        if (entries.Length > 0) return ToTypedEvents(entries);
+
+        // Redis stream gone — 24h TTL expired (p0169j-a) or a flush/restart lost
+        // it. Replay the durable DB trail so a finished run keeps its full
+        // execution view instead of collapsing to the structured snapshot.
+        return await ReadDbTrailAsync(runId);
+    }
+
+    private async Task<IReadOnlyList<RunEvent>> ReadDbTrailAsync(string runId)
+    {
+        using var scope = scopeFactory.CreateScope();
+        var uow = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+        var rows = await uow.Set<Infrastructure.Persistence.Entities.RunEvent>()
+            .AsNoTracking()
+            .Where(e => e.RunId == runId)
+            .OrderBy(e => e.Seq)
+            .ToListAsync();
+
+        var events = new List<RunEvent>(rows.Count);
+        foreach (var row in rows)
+        {
+            var ev = EventEnvelopeSerializer.DeserializeRaw(row.Type, row.PayloadJson);
+            if (ev is not null) events.Add(ev);
+        }
+        return events;
     }
 
     private static IReadOnlyList<object> ToEvents(StreamEntry[] entries) =>

--- a/tests/AgentSmith.Tests/Hubs/TrailReaderTests.cs
+++ b/tests/AgentSmith.Tests/Hubs/TrailReaderTests.cs
@@ -1,7 +1,13 @@
+using System.Text.Json;
 using AgentSmith.Contracts.Events;
+using AgentSmith.Infrastructure.Persistence;
+using AgentSmith.Infrastructure.Persistence.Contracts;
 using AgentSmith.Infrastructure.Services.Events;
 using AgentSmith.Server.Services.Events;
 using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using StackExchange.Redis;
 
@@ -14,16 +20,69 @@ namespace AgentSmith.Tests.Hubs;
 ///   (2) ReadPageAsync clamps the count to [1, 2000]
 ///   (3) Pagination sets HasMore when the stream has more than `count`
 ///       entries and returns the last id as NextCursor
+/// p0286: when the Redis stream is gone the reader falls back to the durable DB
+/// trail — exercised on a real in-memory SQLite engine.
 /// </summary>
-public sealed class TrailReaderTests
+public sealed class TrailReaderTests : IDisposable
 {
     private readonly Mock<IConnectionMultiplexer> _redis = new();
     private readonly Mock<IDatabase> _db = new();
+    private readonly SqliteConnection _connection;
+    private readonly IServiceScopeFactory _scopes;
     private readonly string _runId = "2026-05-27T12-00-00-aaaa";
 
     public TrailReaderTests()
     {
         _redis.Setup(r => r.GetDatabase(It.IsAny<int>(), It.IsAny<object?>())).Returns(_db.Object);
+        _connection = new SqliteConnection("Data Source=:memory:");
+        _connection.Open();
+        using (var ctx = new AgentSmithDbContext(Options())) ctx.Database.Migrate();
+        var services = new ServiceCollection();
+        services.AddScoped<IUnitOfWork>(_ => new AgentSmithDbContext(Options()));
+        _scopes = services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
+    }
+
+    public void Dispose() => _connection.Dispose();
+
+    private DbContextOptions<AgentSmithDbContext> Options() =>
+        new DbContextOptionsBuilder<AgentSmithDbContext>().UseSqlite(_connection).Options;
+
+    // Mirrors RunDbProjector.BuildTrail: raw STJ payload + the EventType name, so
+    // the reader's DeserializeRaw path matches what the projector actually writes.
+    private void SeedDbTrail(params RunEvent[] events)
+    {
+        using var ctx = new AgentSmithDbContext(Options());
+        long seq = 0;
+        foreach (var ev in events)
+            ctx.RunEvents.Add(new AgentSmith.Infrastructure.Persistence.Entities.RunEvent
+            {
+                RunId = _runId,
+                Seq = seq++,
+                Type = ev.Type.ToString(),
+                Timestamp = ev.Timestamp,
+                PayloadJson = JsonSerializer.Serialize((object)ev, ev.GetType()),
+            });
+        ctx.SaveChanges();
+    }
+
+    private void StubEmptyRedis() => _db.Setup(d => d.StreamRangeAsync(
+            (RedisKey)EventStreamKeys.RunStream(_runId), "-", "+", null, Order.Ascending, CommandFlags.None))
+        .ReturnsAsync(Array.Empty<StreamEntry>());
+
+    [Fact]
+    public async Task ReadAllTypedAsync_RedisEmpty_FallsBackToDurableDbTrail()
+    {
+        StubEmptyRedis();
+        SeedDbTrail(
+            new RunStartedEvent(_runId, "ticket", "fix-bug", new[] { "server" }, DateTimeOffset.UtcNow),
+            new StepStartedEvent(_runId, 1, "CheckoutSource", 10, DateTimeOffset.UtcNow),
+            new RunFinishedEvent(_runId, "success", null, "ok", DateTimeOffset.UtcNow));
+
+        var sut = new TrailReader(_redis.Object, _scopes);
+        var result = await sut.ReadAllTypedAsync(_runId);
+
+        result.Select(e => e.Type).Should().ContainInOrder(
+            EventType.RunStarted, EventType.StepStarted, EventType.RunFinished);
     }
 
     [Fact]
@@ -40,7 +99,7 @@ public sealed class TrailReaderTests
             (RedisKey)EventStreamKeys.RunStream(_runId), "-", "+", null, Order.Ascending, CommandFlags.None))
             .ReturnsAsync(entries);
 
-        var sut = new TrailReader(_redis.Object);
+        var sut = new TrailReader(_redis.Object, _scopes);
         var result = await sut.ReadAllTypedAsync(_runId);
 
         result.Should().HaveCount(3);
@@ -55,7 +114,7 @@ public sealed class TrailReaderTests
             (RedisKey)EventStreamKeys.RunStream(_runId), "-", "+", null, Order.Ascending, CommandFlags.None))
             .ReturnsAsync(Array.Empty<StreamEntry>());
 
-        var sut = new TrailReader(_redis.Object);
+        var sut = new TrailReader(_redis.Object, _scopes);
         var result = await sut.ReadAllTypedAsync(_runId);
 
         result.Should().BeEmpty();
@@ -69,7 +128,7 @@ public sealed class TrailReaderTests
             It.IsAny<int?>(), It.IsAny<Order>(), It.IsAny<CommandFlags>()))
             .ReturnsAsync(Array.Empty<StreamEntry>());
 
-        var sut = new TrailReader(_redis.Object);
+        var sut = new TrailReader(_redis.Object, _scopes);
         await sut.ReadPageAsync(_runId, fromId: null, count: 0);
 
         _db.Verify(d => d.StreamRangeAsync(
@@ -91,7 +150,7 @@ public sealed class TrailReaderTests
             Order.Ascending, CommandFlags.None))
             .ReturnsAsync(entries);
 
-        var sut = new TrailReader(_redis.Object);
+        var sut = new TrailReader(_redis.Object, _scopes);
         var page = await sut.ReadPageAsync(_runId, fromId: null, count: 2);
 
         page.Events.Should().HaveCount(2);
@@ -111,7 +170,7 @@ public sealed class TrailReaderTests
             Order.Ascending, CommandFlags.None))
             .ReturnsAsync(entries);
 
-        var sut = new TrailReader(_redis.Object);
+        var sut = new TrailReader(_redis.Object, _scopes);
         var page = await sut.ReadPageAsync(_runId, fromId: null, count: null);
 
         page.HasMore.Should().BeFalse();
@@ -127,7 +186,7 @@ public sealed class TrailReaderTests
             2001, Order.Ascending, CommandFlags.None))
             .ReturnsAsync(Array.Empty<StreamEntry>());
 
-        var sut = new TrailReader(_redis.Object);
+        var sut = new TrailReader(_redis.Object, _scopes);
         await sut.ReadPageAsync(_runId, fromId: null, count: 999_999);
 
         _db.Verify(d => d.StreamRangeAsync(


### PR DESCRIPTION
## Why it "worked before, now doesn't" (regression)
A finished run's **execution view collapses** to the coarse structured snapshot when revisited. Root cause: the replay reads **only the Redis stream** `run:{id}:events`, which:
- carries a **24h TTL** ([RedisEventPublisher](src/backend/AgentSmith.Infrastructure/Services/Events/RedisEventPublisher.cs#L33), `StreamTtl` since p0169j-a), and
- is **lost on any Redis flush/restart/recreate**.

Meanwhile `RunDbProjector` has persisted **every** event to the durable `RunEvent` table since p0246c — but **no reader ever surfaced it**. So once Redis drops the stream (24h elapsed, or — common during local rebuilds — a redis recreate), the replay is empty and the view falls back to the structured `RunStep`/`RunLlmCall` snapshot.

## Fix (backend-only — frontend already renders `RunEvent`)
`TrailReader` falls back to the durable DB trail when the Redis stream is empty:
- **`EventEnvelopeSerializer.DeserializeRaw(typeName, payloadJson)`** — reconstructs a typed `RunEvent` from the trail's bare payload (raw STJ casing, not the camelCase `{t,p}` envelope) + its `Type` column.
- **`TrailReader`** gains an `IServiceScopeFactory`; `ReadAllAsync`/`ReadAllTypedAsync` read Redis first, else the `RunEvent` rows (ordered by `Seq`) over a scoped UoW.
- **`JobsHub.SubscribeRun`** now replays through `TrailReader` (object-typed for polymorphic STJ, per p0175) instead of an inline Redis read — inheriting the fallback. This realises the documented p0246f intent ("run detail survives a Redis flush") for the event trail too.

## Verification
- Full suite: **2612 passed** (added: empty-Redis + seeded DB rows replay the full trail, on real in-memory SQLite)
- Note: `ReadPageAsync` (paginated Trail tab) stays Redis-only for now — the full-window execution replay is what collapsed; paginated DB replay can follow if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)