### PR TITLE
fix: source run execution rail from the durable DB trail, not the Redis replay (p0288)

### DIFF
--- a/.agentsmith/phases/planned/p0289-structure-aware-run-buffer.yaml
+++ b/.agentsmith/phases/planned/p0289-structure-aware-run-buffer.yaml
@@ -1,0 +1,49 @@
+# yaml-language-server: $schema=../../phase-spec.schema.json
+phase: p0289
+goal: |
+  Stop live SandboxOutput from evicting the execution SKELETON in the dashboard's per-run
+  event buffer. p0288 made a reopened run durable (the rail replays the structural trail from
+  the DB), but a LIVE run still streams stdout (SandboxOutput = ~93% of a run's events) into
+  the same per-run ScopeBuffer (cap RUN_CAP=2000, oldest-first eviction). During a long live
+  watch the buffer fills with stdout and evicts the run head — RunStarted (its plannedSteps
+  seed the rail) and early StepStarted — so the live rail erodes to its tail, the same collapse
+  p0288 fixed only for the durable reopen path.
+
+applies_to: "dashboard (frontend)"
+
+requires:
+  - p0288   # rail sourced from the durable DB trail on SubscribeRun (reopen path fixed)
+
+context_for_executor: |
+  The skeleton is tiny (~one row per structural event: RunStarted, Step*, Llm*, Sandbox*,
+  Decision, PR — ~221 for a sampled run) and is what useRunExecutionTree needs. SandboxOutput
+  is high-volume, ephemeral, and only feeds the per-step terminal view. The fix is to keep the
+  two classes of events from sharing one fixed cap, so the skeleton never gets evicted by
+  stdout. Backend already keeps SandboxOutput Redis-only (live tail) — this is a CLIENT change.
+
+decisions:
+  - key: "Structure-aware retention in ScopeBuffer (recommended): never evict structural events (RunStarted/StepStarted/StepFinished/Llm*/SandboxCreated|Disposed/DecisionLogged/PullRequestOutcome); cap+evict only high-volume detail (SandboxOutput/SandboxResult/SandboxCommand/ToolResult). The skeleton survives any run length; stdout stays bounded. Alternative considered: split into a skeleton buffer + a per-step stdout buffer (cleaner separation, larger refactor of useRunEvents consumers)."
+
+steps:
+  - id: classify-events
+    action: "Add an isStructural(event) predicate (event-type set) on the run scope; high-volume detail is everything else."
+    modify: ["dashboard event-store / scopeBuffer"]
+  - id: structure-aware-evict
+    action: "ScopeBuffer trim keeps ALL structural events and only evicts oldest non-structural over the cap (run scope only; system scope unchanged). Keep the keyless run-scope dedup behaviour intact."
+    modify: ["dashboard scopeBuffer.pushMany trim path"]
+  - id: build-and-tests
+    action: "pnpm lint + vitest green; a run with > cap stdout events keeps every structural event (rail head intact); reopen path (p0288) unchanged."
+
+tests:
+  - "scopeBuffer_overCapWithStdoutFlood_retainsAllStructuralEvents"
+  - "scopeBuffer_overCap_evictsOldestNonStructuralFirst"
+  - "useRunExecutionTree_longLiveRun_railHeadSurvivesStdoutFlood"
+
+done:
+  - "A live run streaming more than RUN_CAP stdout events keeps RunStarted + every StepStarted in the client buffer; the rail shows all steps, not just the tail."
+  - "Reopen-from-DB (p0288) is unaffected; system scope retention unchanged."
+
+notes: |
+  Pure client-side. Backend already classifies events by type (EventType) and keeps stdout
+  Redis-only. If structure-aware eviction proves fiddly, the buffer-split alternative is the
+  fallback — both keep stdout from starving the skeleton.

--- a/src/backend/AgentSmith.Server/Hubs/JobsHub.cs
+++ b/src/backend/AgentSmith.Server/Hubs/JobsHub.cs
@@ -87,12 +87,14 @@ public sealed class JobsHub(
     public async Task SubscribeRun(string runId)
     {
         await Groups.AddToGroupAsync(Context.ConnectionId, HubGroups.Run(runId));
-        // Replay the retained window before the live tail. TrailReader serves the
-        // Redis stream and, once that's gone (24h TTL / flush / restart), falls
-        // back to the durable DB trail so a finished run keeps its full execution
-        // view. ReadAllAsync returns object-typed elements so STJ serialises each
-        // by its runtime subtype (p0175-fix).
-        foreach (var runEvent in await trailReader.ReadAllAsync(runId))
+        // p0288: replay the execution SKELETON from the durable DB trail, not the
+        // Redis stream. The Redis stream is dominated by live SandboxOutput (one
+        // event per stdout line — thousands per run); replaying it floods the
+        // client's per-run buffer and evicts the run's head (RunStarted + early
+        // steps), collapsing the rail to its tail. The DB trail holds the
+        // structural events only — small, complete, durable past Redis TTL/flush.
+        // Live stdout (and any newer events) still arrive via this group's tail.
+        foreach (var runEvent in await trailReader.ReadDbTrailAsync(runId))
             await Clients.Caller.SendAsync("RunEvent", runEvent);
     }
 

--- a/src/backend/AgentSmith.Server/Services/Events/TrailReader.cs
+++ b/src/backend/AgentSmith.Server/Services/Events/TrailReader.cs
@@ -60,10 +60,22 @@ public sealed class TrailReader(IConnectionMultiplexer redis, IServiceScopeFacto
         // Redis stream gone — 24h TTL expired (p0169j-a) or a flush/restart lost
         // it. Replay the durable DB trail so a finished run keeps its full
         // execution view instead of collapsing to the structured snapshot.
-        return await ReadDbTrailAsync(runId);
+        return await ReadDbTrailTypedAsync(runId);
     }
 
-    private async Task<IReadOnlyList<RunEvent>> ReadDbTrailAsync(string runId)
+    /// <summary>
+    /// p0288: the execution-tree source. ALWAYS reads the durable DB trail — the
+    /// structural skeleton (RunStarted + every StepStarted/Finished + LLM /
+    /// sandbox / decision / PR events) the dashboard needs to draw the rail.
+    /// Excludes the high-volume live SandboxOutput (kept Redis-only, by design),
+    /// so it is small (≈ one row per structural event) and complete regardless of
+    /// Redis TTL, flush, or the client's per-run cap. Object-typed for the hub so
+    /// STJ serialises each element by its runtime subtype (see p0175 note above).
+    /// </summary>
+    public async Task<IReadOnlyList<object>> ReadDbTrailAsync(string runId) =>
+        (await ReadDbTrailTypedAsync(runId)).Cast<object>().ToList();
+
+    public async Task<IReadOnlyList<RunEvent>> ReadDbTrailTypedAsync(string runId)
     {
         using var scope = scopeFactory.CreateScope();
         var uow = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();

--- a/tests/AgentSmith.Tests/Hubs/TrailReaderTests.cs
+++ b/tests/AgentSmith.Tests/Hubs/TrailReaderTests.cs
@@ -86,6 +86,28 @@ public sealed class TrailReaderTests : IDisposable
     }
 
     [Fact]
+    public async Task ReadDbTrailTypedAsync_AlwaysReadsDb_EvenWhenRedisHasEntries()
+    {
+        // Redis still holds events — but ReadDbTrail must IGNORE it and source the
+        // structural skeleton from the durable DB (p0288: the execution-tree path).
+        _db.Setup(d => d.StreamRangeAsync(
+                (RedisKey)EventStreamKeys.RunStream(_runId), "-", "+", null, Order.Ascending, CommandFlags.None))
+            .ReturnsAsync(new[] { EntryFor(new RunStartedEvent(_runId, "t", "p", new[] { "r" }, DateTimeOffset.UtcNow)) });
+        SeedDbTrail(
+            new RunStartedEvent(_runId, "ticket", "fix-bug", new[] { "server" }, DateTimeOffset.UtcNow),
+            new StepStartedEvent(_runId, 1, "CheckoutSource", 10, DateTimeOffset.UtcNow),
+            new StepStartedEvent(_runId, 2, "AnalyzeCode", 20, DateTimeOffset.UtcNow),
+            new RunFinishedEvent(_runId, "success", null, "ok", DateTimeOffset.UtcNow));
+
+        var sut = new TrailReader(_redis.Object, _scopes);
+        var result = await sut.ReadDbTrailTypedAsync(_runId);
+
+        // All 4 DB rows (not the single Redis entry) come back, ordered by Seq.
+        result.Select(e => e.Type).Should().ContainInOrder(
+            EventType.RunStarted, EventType.StepStarted, EventType.StepStarted, EventType.RunFinished);
+    }
+
+    [Fact]
     public async Task ReadAllAsync_ReturnsDeserialisedEventsInOrder()
     {
         var entries = new[]


### PR DESCRIPTION
## Root cause (empirically measured on the reported run)
The run execution rail collapsed to its **tail steps** on reopen. `SubscribeRun` replayed the **full Redis run stream**, which is dominated by live `SandboxOutput`:

| event type | count | in DB? |
|---|---|---|
| **SandboxOutput** (one per stdout line) | **2768** | no (live-only) |
| structural (RunStarted, 17×Step, 20×LLM, sandbox, decisions, PR…) | **221** | **yes** |
| Redis stream total | 2989 | — |

The dashboard's per-run buffer caps at 2000. Replaying 2989 (93 % stdout) evicts the **oldest** events first — `RunStarted` (its `plannedSteps` seed the rail) and the early `StepStarted` — so only the last few steps survive. (#337's DB fallback didn't help: Redis still *has* the stream, so the fallback never triggers; and the RUN_CAP/MAXLEN mismatch is incidental.)

## Fix — the design you asked for: read the rail from the DB
`SubscribeRun` now replays the structural **skeleton from the durable DB trail** (RunStarted + every Step + LLM/sandbox/decision/PR — ≈221 rows, no stdout), not the Redis stream. It's small, complete, and durable past Redis's 24h TTL / a flush / a restart. Live `SandboxOutput` (and any newer events) still arrive via the run group's **live tail** — kept Redis-only by design.

- `TrailReader.ReadDbTrailAsync` (object) / `ReadDbTrailTypedAsync` — **always** DB.
- `JobsHub.SubscribeRun` uses it instead of the Redis-first `ReadAllAsync`.
- `GetTrail` (Trail tab) keeps the Redis path (full window incl. stdout).

This extends the durable design the run list/detail already use (p0246f, "survives a process restart AND a Redis flush") to the event trail, superseding #337's Redis-empty-only fallback for this path.

## Scope / verification
- **Backend-only** — the dashboard renders received events unchanged; it now receives the structural skeleton instead of a stdout flood.
- Full suite: **2610 passed** (added: `ReadDbTrail` ignores a non-empty Redis stream and returns the DB skeleton).
- Known edge (pre-existing, out of scope): during a *very long live watch*, live stdout can still fill the 2000 client buffer and erode the rail head — the durable reopen path is unaffected. A structure-aware client buffer (don't co-mingle stdout with skeleton) is the follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)