### PR TITLE
fix: render agent-smith's HTML comment subset as real ADF on Jira (p0290)

### DIFF
--- a/src/backend/AgentSmith.Infrastructure/Services/Providers/Tickets/JiraAdfRenderer.cs
+++ b/src/backend/AgentSmith.Infrastructure/Services/Providers/Tickets/JiraAdfRenderer.cs
@@ -1,42 +1,81 @@
+using System.Net;
+using System.Text.RegularExpressions;
+
 namespace AgentSmith.Infrastructure.Services.Providers.Tickets;
 
 /// <summary>
 /// p0147f: builds the Atlassian Document Format (ADF) envelope a Jira
 /// REST v3 endpoint expects for body content (e.g. <c>POST /comment</c>).
-/// Plain comment text is wrapped into a doc -> paragraph -> text tree.
 /// </summary>
 /// <remarks>
 /// ADF is the only sane way to post a comment to Jira Cloud — the legacy
-/// wiki-markup body field is rejected. <see cref="JiraAdfParser"/> reverses
-/// this for incoming descriptions; this class is the outbound counterpart.
+/// wiki-markup body field is rejected, and HTML is NOT rendered (it shows as
+/// literal text). agent-smith's status/error comments are authored in a small
+/// HTML subset (<c>&lt;b&gt;</c>, <c>&lt;br/&gt;</c>, HTML-encoded text) for the
+/// GitHub/ADO providers; <see cref="FromCommentText"/> converts that subset into
+/// real ADF (strong marks + hard breaks + decoded entities) so Jira renders it
+/// like the others. <see cref="JiraAdfParser"/> reverses ADF for incoming
+/// descriptions; this class is the outbound counterpart.
 /// </remarks>
-internal static class JiraAdfRenderer
+internal static partial class JiraAdfRenderer
 {
+    /// <summary>Wraps verbatim text as an ADF doc with a single text node.</summary>
+    public static object FromPlainText(string text) =>
+        Doc(new object[] { new { type = "text", text = EmptyToSpace(text) } });
+
     /// <summary>
-    /// Wraps plain comment text as an ADF doc with a single paragraph.
-    /// Returned object is anonymous so it serialises straight to JSON
-    /// via System.Text.Json without an intermediate DTO.
+    /// Converts agent-smith's HTML-subset comment text into ADF: <c>&lt;b&gt;…&lt;/b&gt;</c>
+    /// → a <c>strong</c>-marked text node, <c>&lt;br/&gt;</c> → a hard break, and HTML
+    /// entities (<c>&amp;#39;</c>, <c>&amp;lt;</c>, …) decoded. Structural tags are
+    /// tokenised BEFORE entity decoding so an error message containing a literal
+    /// <c>&lt;</c> (encoded as <c>&amp;lt;</c>) is never mistaken for a tag.
     /// </summary>
-    public static object FromPlainText(string text) => new
+    public static object FromCommentText(string text)
+    {
+        var nodes = new List<object>();
+        var bold = false;
+
+        foreach (var token in TagSplitter().Split(text ?? string.Empty))
+        {
+            if (string.IsNullOrEmpty(token)) continue;
+            if (LineBreakTag().IsMatch(token)) { nodes.Add(new { type = "hardBreak" }); continue; }
+            if (BoldOpenTag().IsMatch(token)) { bold = true; continue; }
+            if (BoldCloseTag().IsMatch(token)) { bold = false; continue; }
+
+            var decoded = WebUtility.HtmlDecode(token);
+            if (decoded.Length == 0) continue;
+            nodes.Add(bold
+                ? new { type = "text", text = decoded, marks = new[] { new { type = "strong" } } }
+                : (object)new { type = "text", text = decoded });
+        }
+
+        if (nodes.Count == 0) nodes.Add(new { type = "text", text = " " });
+        return Doc(nodes.ToArray());
+    }
+
+    /// <summary>Builds the full comment request body for <c>POST /comment</c>.</summary>
+    public static object CommentBody(string text) => new { body = FromCommentText(text) };
+
+    private static object Doc(object[] inlineContent) => new
     {
         type = "doc",
         version = 1,
-        content = new[]
-        {
-            new
-            {
-                type = "paragraph",
-                content = new[]
-                {
-                    new { type = "text", text }
-                }
-            }
-        }
+        content = new[] { new { type = "paragraph", content = inlineContent } }
     };
 
-    /// <summary>
-    /// Convenience: builds the full comment request body
-    /// (<c>{ "body": &lt;adf-doc&gt; }</c>) for <c>POST /comment</c>.
-    /// </summary>
-    public static object CommentBody(string text) => new { body = FromPlainText(text) };
+    // ADF rejects an empty text node — substitute a single space for an empty body.
+    private static string EmptyToSpace(string text) => string.IsNullOrEmpty(text) ? " " : text;
+
+    // Split on (and keep) the structural tags agent-smith emits.
+    [GeneratedRegex(@"(</?b>|<br\s*/?>)", RegexOptions.IgnoreCase)]
+    private static partial Regex TagSplitter();
+
+    [GeneratedRegex(@"^<br\s*/?>$", RegexOptions.IgnoreCase)]
+    private static partial Regex LineBreakTag();
+
+    [GeneratedRegex(@"^<b>$", RegexOptions.IgnoreCase)]
+    private static partial Regex BoldOpenTag();
+
+    [GeneratedRegex(@"^</b>$", RegexOptions.IgnoreCase)]
+    private static partial Regex BoldCloseTag();
 }

--- a/tests/AgentSmith.Tests/Providers/Tickets/JiraAdfRendererTests.cs
+++ b/tests/AgentSmith.Tests/Providers/Tickets/JiraAdfRendererTests.cs
@@ -1,0 +1,64 @@
+using System.Text.Json;
+using AgentSmith.Infrastructure.Services.Providers.Tickets;
+using FluentAssertions;
+
+namespace AgentSmith.Tests.Providers.Tickets;
+
+public sealed class JiraAdfRendererTests
+{
+    // The status/error comment agent-smith authors for the GitHub/ADO providers —
+    // HTML bold + line breaks + an HTML-encoded apostrophe and angle brackets.
+    private const string HtmlComment =
+        "<b>Agent Smith — Failed</b><br/><b>Step:</b> Creating pull request (16/17)<br/>"
+        + "<b>Error:</b> the agent&#39;s output &lt;empty&gt;";
+
+    [Fact]
+    public void CommentBody_ConvertsHtmlSubsetToAdf_NoLiteralTagsOrEntities()
+    {
+        var json = JsonSerializer.Serialize(JiraAdfRenderer.CommentBody(HtmlComment));
+
+        using var doc = JsonDocument.Parse(json);
+        var inline = doc.RootElement
+            .GetProperty("body").GetProperty("content")[0].GetProperty("content");
+
+        var texts = new List<string>();
+        var types = new List<string>();
+        var strongTexts = new List<string>();
+        foreach (var node in inline.EnumerateArray())
+        {
+            var type = node.GetProperty("type").GetString()!;
+            types.Add(type);
+            if (type != "text") continue;
+            var text = node.GetProperty("text").GetString()!;
+            texts.Add(text);
+            if (node.TryGetProperty("marks", out var marks)
+                && marks.EnumerateArray().Any(m => m.GetProperty("type").GetString() == "strong"))
+                strongTexts.Add(text);
+        }
+
+        // No literal HTML tags or entities leak into the rendered text.
+        var allText = string.Concat(texts);
+        allText.Should().NotContain("<b>").And.NotContain("<br").And.NotContain("&#39;").And.NotContain("&lt;");
+
+        // Bold segments became strong-marked text nodes.
+        strongTexts.Should().Contain("Agent Smith — Failed");
+        strongTexts.Should().Contain("Step:");
+        strongTexts.Should().Contain("Error:");
+
+        // <br/> became hard breaks.
+        types.Should().Contain("hardBreak");
+
+        // Entities decoded.
+        allText.Should().Contain("the agent's output <empty>");
+    }
+
+    [Fact]
+    public void FromPlainText_EmptyBody_SubstitutesSpace_AdfRejectsEmptyTextNode()
+    {
+        var json = JsonSerializer.Serialize(JiraAdfRenderer.FromPlainText(""));
+        using var doc = JsonDocument.Parse(json);
+        var text = doc.RootElement.GetProperty("content")[0].GetProperty("content")[0]
+            .GetProperty("text").GetString();
+        text.Should().Be(" ");
+    }
+}


### PR DESCRIPTION
## Problem
Jira comments posted by agent-smith showed **raw HTML**:

> `<b>Agent Smith — Failed</b><br/><b>Step:</b> Creating pull request (16/17)<br/>… the agent&#39;s reasoning is in result.md`

Jira Cloud comments are **ADF** (Atlassian Document Format), not HTML/markdown — and `JiraAdfRenderer` wrapped the whole comment as a **single ADF text node**, so the `<b>`/`<br/>` tags and HTML entities (`&#39;`) rendered literally. agent-smith authors status/error comments in a small HTML subset (good for the GitHub/ADO providers, which render HTML); Jira was the odd one out. The team had already flagged this as a follow-up in `JiraOpenQuestionsCommentTemplate` ("Multi-paragraph ADF marshalling is a follow-up").

## Fix
`JiraAdfRenderer.FromCommentText` converts the HTML subset to real ADF:
- `<b>…</b>` → a `strong`-marked text node
- `<br/>` → a `hardBreak`
- HTML entities (`&#39;`, `&lt;`, …) decoded

Structural tags are tokenised **before** entity decoding, so an error body containing a literal `<` (encoded as `&lt;`) is never mistaken for a tag. `CommentBody` routes through it. Plain comments (no tags/entities) are unchanged.

## Verification
- Full suite: **2610 passed** (1 unrelated flaky `ProjectResolverAmbiguousMetrics` — shared meter state, passes in isolation).
- New test: the failed-run comment renders with strong marks + hard breaks and no literal `<b>`/`<br/>`/`&#39;`/`&lt;` leaking through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)