### PR TITLE
chore(runtime): upgrade to .NET 10 (LTS) + harden container images (CVE-2026-55200)

### DIFF
--- a/.github/workflows/agent-smith.yml
+++ b/.github/workflows/agent-smith.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '10.0.x'
 
       - name: Build Agent Smith
         run: dotnet build --configuration Release --verbosity quiet

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '10.0.x'
 
       - name: Restore
         run: dotnet restore

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -52,7 +52,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '10.0.x'
 
       - name: Publish
         run: >-

--- a/src/backend/AgentSmith.Application/AgentSmith.Application.csproj
+++ b/src/backend/AgentSmith.Application/AgentSmith.Application.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/backend/AgentSmith.Cli/AgentSmith.Cli.csproj
+++ b/src/backend/AgentSmith.Cli/AgentSmith.Cli.csproj
@@ -16,7 +16,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/backend/AgentSmith.Cli/Dockerfile
+++ b/src/backend/AgentSmith.Cli/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
 
 # Copy project files for restore caching
@@ -26,14 +26,26 @@ RUN dotnet publish src/backend/AgentSmith.Cli -c Release -o /app/publish --no-re
 # TODO p4x: dotnet SDK required until TestCommand spawns ephemeral job containers.
 # Target: aspnet:8.0 base + job-based test execution (see DockerJobSpawner).
 # Agent Smith is language-agnostic — hardcoding SDK is technical debt.
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS runtime
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS runtime
 WORKDIR /app
 
-# Install git for LibGit2Sharp operations, gosu for permission dropping
-RUN apt-get update && apt-get install -y --no-install-recommends git libgit2-dev gosu && rm -rf /var/lib/apt/lists/*
+# Install git for LibGit2Sharp operations, gosu for permission dropping.
+# apt-get upgrade pulls current OS security patches at build time (defense-in-
+# depth). git/libgit2 bring in libssh2, the component behind CVE-2026-55200 (RCE);
+# the .NET 10 base is Ubuntu 24.04, which is flagged "not affected" for that CVE,
+# so the exposure is closed by the base itself — the fix was never a .NET TFM bump.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git libgit2-dev gosu \
+    && apt-get upgrade -y \
+    && rm -rf /var/lib/apt/lists/*
 
-# Create non-root user
-RUN groupadd --gid 1000 agentsmith && \
+# Create non-root user at UID/GID 1000. .NET 10 base images pre-seed a user at
+# UID 1000 (e.g. `ubuntu`); remove it first so `agentsmith` owns 1000 — the
+# entrypoint drops to `agentsmith` by name via gosu, and k8s/fsGroup convention
+# expects 1000.
+RUN if getent passwd 1000 >/dev/null; then userdel -r "$(getent passwd 1000 | cut -d: -f1)" 2>/dev/null || true; fi && \
+    if getent group 1000 >/dev/null; then groupdel "$(getent group 1000 | cut -d: -f1)" 2>/dev/null || true; fi && \
+    groupadd --gid 1000 agentsmith && \
     useradd --uid 1000 --gid agentsmith --create-home agentsmith && \
     mkdir -p /home/agentsmith/.ssh && \
     chown -R agentsmith:agentsmith /home/agentsmith

--- a/src/backend/AgentSmith.Contracts/AgentSmith.Contracts.csproj
+++ b/src/backend/AgentSmith.Contracts/AgentSmith.Contracts.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/backend/AgentSmith.Domain/AgentSmith.Domain.csproj
+++ b/src/backend/AgentSmith.Domain/AgentSmith.Domain.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/backend/AgentSmith.Infrastructure.Core/AgentSmith.Infrastructure.Core.csproj
+++ b/src/backend/AgentSmith.Infrastructure.Core/AgentSmith.Infrastructure.Core.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/backend/AgentSmith.Infrastructure.Persistence/AgentSmith.Infrastructure.Persistence.csproj
+++ b/src/backend/AgentSmith.Infrastructure.Persistence/AgentSmith.Infrastructure.Persistence.csproj
@@ -1,23 +1,27 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- EF Core 8 (net8 lockstep). Provider packages: the installer calls
-         Use{Sqlite|Npgsql|MySql} per persistence.provider. Design is needed for
-         migrations + the IDesignTimeDbContextFactory. -->
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.13" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.13">
+    <!-- EF Core 9: highest line with full provider coverage on net10. EF Core 8
+         breaks on the net10 runtime (LINQ interpreter / ReadOnlySpan overload
+         resolution), and EF Core 10 has no MySQL provider yet (Pomelo tops out
+         at 9.0.0). Npgsql 9.x + Pomelo 9.0.0 cover Postgres + MySQL. Provider
+         packages: the installer calls Use{Sqlite|Npgsql|MySql} per
+         persistence.provider. Design is needed for migrations + the
+         IDesignTimeDbContextFactory. -->
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.17" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.17">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.13" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11" />
-    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.17" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/backend/AgentSmith.Infrastructure/AgentSmith.Infrastructure.csproj
+++ b/src/backend/AgentSmith.Infrastructure/AgentSmith.Infrastructure.csproj
@@ -49,7 +49,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/backend/AgentSmith.Infrastructure/Services/Persistence/RedisProjectMapStore.cs
+++ b/src/backend/AgentSmith.Infrastructure/Services/Persistence/RedisProjectMapStore.cs
@@ -49,7 +49,7 @@ public sealed class RedisProjectMapStore : IProjectMapStore
         Envelope? envelope;
         try
         {
-            envelope = JsonSerializer.Deserialize<Envelope>(value!, JsonOptions);
+            envelope = JsonSerializer.Deserialize<Envelope>((string)value!, JsonOptions);
         }
         catch (JsonException ex)
         {

--- a/src/backend/AgentSmith.Sandbox.Agent/AgentSmith.Sandbox.Agent.csproj
+++ b/src/backend/AgentSmith.Sandbox.Agent/AgentSmith.Sandbox.Agent.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>AgentSmith.Sandbox.Agent</RootNamespace>
     <AssemblyName>AgentSmith.Sandbox.Agent</AssemblyName>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/backend/AgentSmith.Sandbox.Agent/Dockerfile
+++ b/src/backend/AgentSmith.Sandbox.Agent/Dockerfile
@@ -6,7 +6,7 @@
 # See docs/concepts/sandbox-agent.md for the init-container injection pattern.
 
 # Stage 1: build the self-contained binary
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 ARG TARGETARCH
 WORKDIR src
 
@@ -35,7 +35,7 @@ RUN dotnet publish src/backend/AgentSmith.Sandbox.Agent/AgentSmith.Sandbox.Agent
 # pod lifetime model — the extraction stays around for the full pipeline.
 
 # Stage 2: minimal carrier — Microsoft's official runtime-deps image, which is
-# the documented minimal base for self-contained .NET 8 binaries (provides
+# the documented minimal base for self-contained .NET binaries (provides
 # glibc + libgcc + libstdc++ + libz + libssl + ICU stubs). Distroless variants
 # were tried and rejected: distroless/cc lacks libz which self-contained .NET
 # needs at startup; distroless/base lacks libgcc and libstdc++. ENTRYPOINT is
@@ -43,7 +43,7 @@ RUN dotnet publish src/backend/AgentSmith.Sandbox.Agent/AgentSmith.Sandbox.Agent
 # conventional emptyDir mount point the Server pod creates in p0116). USER is
 # deliberately unset — the Server pod chooses the runtime UID (typically
 # matched to the toolchain main container's UID via fsGroup).
-FROM mcr.microsoft.com/dotnet/runtime-deps:8.0-bookworm-slim
+FROM mcr.microsoft.com/dotnet/runtime-deps:10.0
 COPY --from=build --chmod=755 /publish/AgentSmith.Sandbox.Agent /agent
 ENTRYPOINT ["/agent"]
 CMD ["--inject", "/shared/agent"]

--- a/src/backend/AgentSmith.Sandbox.Wire/AgentSmith.Sandbox.Wire.csproj
+++ b/src/backend/AgentSmith.Sandbox.Wire/AgentSmith.Sandbox.Wire.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>AgentSmith.Sandbox.Wire</RootNamespace>
     <AssemblyName>AgentSmith.Sandbox.Wire</AssemblyName>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/backend/AgentSmith.Server/AgentSmith.Server.csproj
+++ b/src/backend/AgentSmith.Server/AgentSmith.Server.csproj
@@ -22,7 +22,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>AgentSmith.Server</RootNamespace>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/backend/AgentSmith.Server/Dockerfile
+++ b/src/backend/AgentSmith.Server/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
 
 # Copy project files for restore (layer caching)
@@ -25,20 +25,28 @@ RUN dotnet publish src/backend/AgentSmith.Server -c Release -o /app/publish --no
 # ---
 
 # Stage 2: Runtime
-FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime
 WORKDIR /app
 
-# Install curl for health check
-RUN apt-get update && apt-get install -y --no-install-recommends curl \
+# Install curl for the health check. apt-get upgrade pulls current OS security
+# patches at build time (defense-in-depth). Note: this image ships no libssh2
+# (only curl; Ubuntu's libcurl is built without it), so it carries no exposure
+# to CVE-2026-55200 (libssh2 RCE) regardless.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl \
+    && apt-get upgrade -y \
     && rm -rf /var/lib/apt/lists/*
 
-# Non-root user with a real home directory — DefaultPaths.ComputeCacheRoot
-# falls back to $HOME/.cache/agentsmith when XDG_CACHE_HOME is unset, and
-# AnalyzeProjectHandler.PersistCacheAsync writes the project-map cache there.
-# Without --create-home, /home/dispatcher exists in /etc/passwd but the
-# directory itself is missing and /home is root-owned — Directory.CreateDirectory
-# fails with "Access to the path '/home/dispatcher' is denied".
-RUN groupadd --gid 1000 dispatcher && \
+# Non-root user at UID/GID 1000 (matches k8s runAsUser: 1000) with a real home
+# dir — DefaultPaths.ComputeCacheRoot falls back to $HOME/.cache/agentsmith when
+# XDG_CACHE_HOME is unset, and AnalyzeProjectHandler.PersistCacheAsync writes the
+# project-map cache there ($HOME is resolved from /etc/passwd by the runtime).
+# .NET 10 base images pre-seed a user at UID 1000 (e.g. `ubuntu`, which carries
+# sudo/adm group membership); remove it first so we run as a clean, dedicated
+# user with no extra group memberships.
+RUN if getent passwd 1000 >/dev/null; then userdel -r "$(getent passwd 1000 | cut -d: -f1)" 2>/dev/null || true; fi && \
+    if getent group 1000 >/dev/null; then groupdel "$(getent group 1000 | cut -d: -f1)" 2>/dev/null || true; fi && \
+    groupadd --gid 1000 dispatcher && \
     useradd --uid 1000 --gid 1000 --create-home dispatcher
 
 COPY --from=build /app/publish .

--- a/src/backend/AgentSmith.Server/Services/ClarificationStateManager.cs
+++ b/src/backend/AgentSmith.Server/Services/ClarificationStateManager.cs
@@ -44,7 +44,7 @@ public sealed class ClarificationStateManager(
 
         try
         {
-            return JsonSerializer.Deserialize<PendingClarification>(json!, JsonOptions);
+            return JsonSerializer.Deserialize<PendingClarification>((string)json!, JsonOptions);
         }
         catch (JsonException)
         {

--- a/src/backend/AgentSmith.Server/Services/ConversationStateRepository.cs
+++ b/src/backend/AgentSmith.Server/Services/ConversationStateRepository.cs
@@ -93,7 +93,7 @@ internal sealed class ConversationStateRepository(
 
         try
         {
-            return JsonSerializer.Deserialize<ConversationState>(json!, JsonOptions);
+            return JsonSerializer.Deserialize<ConversationState>((string)json!, JsonOptions);
         }
         catch (JsonException ex)
         {

--- a/src/backend/AgentSmith.Server/Services/Sandbox/SandboxRedisChannel.cs
+++ b/src/backend/AgentSmith.Server/Services/Sandbox/SandboxRedisChannel.cs
@@ -89,7 +89,7 @@ public sealed class SandboxRedisChannel : IAsyncDisposable
         {
             var raw = entry["data"];
             if (raw.IsNullOrEmpty) return;
-            var ev = JsonSerializer.Deserialize<StepEvent>(raw!, WireFormat.Json);
+            var ev = JsonSerializer.Deserialize<StepEvent>((string)raw!, WireFormat.Json);
             if (ev is not null && ev.StepId == stepId) progress.Report(ev);
         }
         catch (JsonException ex)
@@ -104,7 +104,7 @@ public sealed class SandboxRedisChannel : IAsyncDisposable
         var value = await _database.ListRightPopAsync(key);
         if (value.IsNull) return null;
 
-        var result = JsonSerializer.Deserialize<StepResult>(value!, WireFormat.Json);
+        var result = JsonSerializer.Deserialize<StepResult>((string)value!, WireFormat.Json);
         if (result is null) return null;
         if (result.StepId == stepId) return result;
 

--- a/tests/AgentSmith.PipelineHarness/AgentSmith.PipelineHarness.csproj
+++ b/tests/AgentSmith.PipelineHarness/AgentSmith.PipelineHarness.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/tests/AgentSmith.PipelineHarness/Fixtures/CsharpFixture/Fixture.Tests/Fixture.Tests.csproj
+++ b/tests/AgentSmith.PipelineHarness/Fixtures/CsharpFixture/Fixture.Tests/Fixture.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>

--- a/tests/AgentSmith.PipelineHarness/Fixtures/CsharpFixture/Fixture.csproj
+++ b/tests/AgentSmith.PipelineHarness/Fixtures/CsharpFixture/Fixture.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/tests/AgentSmith.Sandbox.Agent.Tests/AgentSmith.Sandbox.Agent.Tests.csproj
+++ b/tests/AgentSmith.Sandbox.Agent.Tests/AgentSmith.Sandbox.Agent.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/tests/AgentSmith.Tests/AgentSmith.Tests.csproj
+++ b/tests/AgentSmith.Tests/AgentSmith.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/tests/AgentSmith.Tests/Application/SecretPatternScannerTests.cs
+++ b/tests/AgentSmith.Tests/Application/SecretPatternScannerTests.cs
@@ -70,7 +70,7 @@ public sealed class SecretPatternScannerTests
     {
         var content = """
             <PropertyGroup>
-              <TargetFramework>net8.0</TargetFramework>
+              <TargetFramework>net10.0</TargetFramework>
             </PropertyGroup>
             """;
 

--- a/tests/AgentSmith.Tests/Integration/FixtureWorkdir.cs
+++ b/tests/AgentSmith.Tests/Integration/FixtureWorkdir.cs
@@ -29,7 +29,7 @@ internal sealed class FixtureWorkdir : IAsyncDisposable
             <Project Sdk="Microsoft.NET.Sdk">
               <PropertyGroup>
                 <OutputType>Exe</OutputType>
-                <TargetFramework>net8.0</TargetFramework>
+                <TargetFramework>net10.0</TargetFramework>
                 <Nullable>enable</Nullable>
                 <ImplicitUsings>enable</ImplicitUsings>
               </PropertyGroup>
@@ -48,7 +48,7 @@ internal sealed class FixtureWorkdir : IAsyncDisposable
             $"""
             <Project Sdk="Microsoft.NET.Sdk">
               <PropertyGroup>
-                <TargetFramework>net8.0</TargetFramework>
+                <TargetFramework>net10.0</TargetFramework>
                 <Nullable>enable</Nullable>
                 <IsPackable>false</IsPackable>
               </PropertyGroup>


### PR DESCRIPTION
## Context

Started as a .NET 8 → 9 bump prompted by [CVE-2026-55200](https://nvd.nist.gov/vuln/detail/CVE-2026-55200). Investigation changed the plan on two counts:

1. **CVE-2026-55200 is a libssh2 RCE, not a .NET vulnerability** ([GHSA-r8mh-x5qv-7gg2](https://github.com/advisories/GHSA-r8mh-x5qv-7gg2)). A .NET TFM bump does nothing for it. libssh2 only entered our images via the Debian OS layer (git/libgit2 in CLI, libcurl in Server).
2. **.NET 8 (LTS) and 9 (STS) both reach end-of-support on [2026-11-10](https://devblogs.microsoft.com/dotnet/dotnet-8-9-end-of-support/)** — 9 buys zero runway. **.NET 10 (LTS)** is supported to 2028.

So this targets **.NET 10** instead, which also resolves the CVE posture as a side effect: the .NET 10 base is **Ubuntu 24.04**, flagged **"not affected"** for CVE-2026-55200, and the Server image ships **no libssh2 at all**.

## Changes

- **`net8.0` → `net10.0`** across all projects, test fixtures, and CI (`setup-dotnet` `8.0.x` → `10.0.x`).
- **Docker base images → `10.0`** (sdk/aspnet = Ubuntu 24.04; sandbox carrier = `runtime-deps:10.0`, since no `10.0-bookworm-slim` is published).
- **EF Core `8.0.13` → `9.0.17`** (+ Npgsql `9.0.4`, Pomelo `9.0.0`). EF Core 8 breaks on the net10 LINQ interpreter; EF Core 10 has no MySQL provider yet (Pomelo tops out at 9.0.0), so 9.x is the highest line with full Sqlite/Postgres/MySQL coverage. EF Core 9 verified working on the net10 runtime.
- **`JsonSerializer.Deserialize(RedisValue)`** sites cast to `(string)` — net10 adds a `ReadOnlySpan<byte>` overload that makes `RedisValue` ambiguous (5 sites).
- **Container user model**: net10 base images pre-seed a non-root user at UID 1000 (`ubuntu`, in `sudo`/`adm` groups). The Dockerfiles now remove it and recreate the dedicated `dispatcher`/`agentsmith` user at 1000 (matches k8s `runAsUser: 1000`), so we don't run in the sudo group.
- **`apt-get upgrade`** added to shipped CLI/Server stages as defense-in-depth hardening (not the CVE fix — the base already isn't affected).

## Verification

- ✅ Solution builds on net10 (only pre-existing warnings).
- ✅ **2771 tests pass** (2685 + 86).
- ✅ All three images build and run: clean UID-1000 user, `$HOME` writable, gosu drop to `agentsmith`, Server config fail-fast, sandbox agent `--help`.
- ✅ libssh2 in CLI image = `1.11.0-4.1ubuntu0.24.04.2`; Ubuntu 24.04 = "not affected". Server image = no libssh2.

## Notes / not in scope

- The illustrative `dotnet/sdk:8.0` mentions in `README.md`/`docs/` refer to the **sandbox toolchain image for user repos** (a separate concern, LLM-resolved per p0265), not agent-smith's own runtime — left untouched.
- The `NU1903` warnings on `System.Data.SqlClient` 4.8.5 and `SQLitePCLRaw` 2.1.10 are **pre-existing** transitive advisories, unrelated to this upgrade — flag for a follow-up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)