### PR TITLE
fix: AzDO discovery no longer requires agent-smith tag on every ticket (p0300c regression)

### DIFF
--- a/src/backend/AgentSmith.Infrastructure/Services/Providers/Tickets/AzureDevOpsDiscoveryWiqlBuilder.cs
+++ b/src/backend/AgentSmith.Infrastructure/Services/Providers/Tickets/AzureDevOpsDiscoveryWiqlBuilder.cs
@@ -1,6 +1,5 @@
 using AgentSmith.Contracts.Models.Configuration;
 using AgentSmith.Contracts.Models.Triggers;
-using AgentSmith.Contracts.Tickets;
 
 namespace AgentSmith.Infrastructure.Services.Providers.Tickets;
 
@@ -19,10 +18,18 @@ public sealed class AzureDevOpsDiscoveryWiqlBuilder : IAzureDevOpsDiscoveryWiqlB
             ? BroadClause(query.ParkingStatuses, openStates)
             : string.Join(" OR ",
                 query.Branches.Select(b => BranchClause(b, query.ParkingStatuses, openStates)));
-        // Only tickets carrying an agent-smith trigger/lifecycle label are ever claimable —
-        // CONTAINS is a substring match, so the prefix guard covers every agent-smith:* tag and
-        // stops discovery from hydrating + event-spamming every project-tagged ticket each poll.
-        return $"({routing}) AND [System.Tags] CONTAINS '{LifecycleLabels.Prefix}'";
+        // p0300c-hotfix: guard by the tracker's configured trigger labels (the
+        // pipeline_from_label keys, carried on DiscoveryQuery.TriggerLabels) ONLY when the
+        // tracker uses label opt-in — mirrors the Jira builder. A tracker that triggers on
+        // area_path/status has NO trigger labels → NO guard; the original unconditional
+        // `CONTAINS 'agent-smith:'` prefix excluded every fresh, un-lifecycle-tagged work item
+        // and broke AzDO reception. Full-tag CONTAINS (not a bare prefix) is AzDO's reliable
+        // tag filter; a label-gated ticket that lacks a trigger label is dropped in-process
+        // anyway, so this never hides a claimable ticket.
+        if (query.TriggerLabels.Count == 0) return routing;
+        var labelGuard = string.Join(" OR ",
+            query.TriggerLabels.Select(l => $"[System.Tags] CONTAINS '{Escape(l)}'"));
+        return $"({routing}) AND ({labelGuard})";
     }
 
     private static string BranchClause(

--- a/tests/AgentSmith.Tests/Services/Providers/Tickets/AzureDevOpsDiscoveryWiqlBuilderTests.cs
+++ b/tests/AgentSmith.Tests/Services/Providers/Tickets/AzureDevOpsDiscoveryWiqlBuilderTests.cs
@@ -10,9 +10,8 @@ public sealed class AzureDevOpsDiscoveryWiqlBuilderTests
     private static readonly AzureDevOpsDiscoveryWiqlBuilder Builder = new();
     private static readonly string[] OpenStates = ["New", "Active"];
 
-    // Every emitted WHERE is now wrapped and guarded by the agent-smith tag prefix
-    // so discovery never hydrates a ticket that carries no agent-smith:* label.
-    private const string Guard = " AND [System.Tags] CONTAINS 'agent-smith:'";
+    // p0300c-hotfix: with no configured trigger labels (area_path/status trackers), the WHERE
+    // is just the routing clause — NO tag guard, so a fresh untagged work item is still found.
 
     [Fact]
     public void BuildWhere_TagBranch_EmitsStateInAndTagsContains()
@@ -23,8 +22,7 @@ public sealed class AzureDevOpsDiscoveryWiqlBuilderTests
 
         var where = Builder.BuildWhere(query, OpenStates);
 
-        where.Should().Be(
-            "(([System.State] IN ('Active') AND [System.Tags] CONTAINS 'alpha-tag'))" + Guard);
+        where.Should().Be("([System.State] IN ('Active') AND [System.Tags] CONTAINS 'alpha-tag')");
     }
 
     [Fact]
@@ -36,8 +34,7 @@ public sealed class AzureDevOpsDiscoveryWiqlBuilderTests
 
         var where = Builder.BuildWhere(query, OpenStates);
 
-        where.Should().Be(
-            "(([System.State] IN ('New') AND [System.AreaPath] UNDER 'Org\\Team'))" + Guard);
+        where.Should().Be("([System.State] IN ('New') AND [System.AreaPath] UNDER 'Org\\Team')");
     }
 
     [Fact]
@@ -49,8 +46,7 @@ public sealed class AzureDevOpsDiscoveryWiqlBuilderTests
 
         var where = Builder.BuildWhere(query, OpenStates);
 
-        where.Should().Be(
-            "(([System.State] IN ('New', 'Active') AND [System.State] NOT IN ('Closed')))" + Guard);
+        where.Should().Be("([System.State] IN ('New', 'Active') AND [System.State] NOT IN ('Closed'))");
     }
 
     [Fact]
@@ -66,20 +62,42 @@ public sealed class AzureDevOpsDiscoveryWiqlBuilderTests
         var where = Builder.BuildWhere(query, OpenStates);
 
         where.Should().Be(
-            "(([System.State] IN ('Active') AND [System.Tags] CONTAINS 'a') OR "
-            + "([System.State] IN ('New') AND [System.Tags] CONTAINS 'b'))" + Guard);
+            "([System.State] IN ('Active') AND [System.Tags] CONTAINS 'a') OR "
+            + "([System.State] IN ('New') AND [System.Tags] CONTAINS 'b')");
     }
 
     [Fact]
-    public void BuildWhere_AzDo_AppendsAgentSmithTriggerLabelGuard()
+    public void BuildWhere_NoTriggerLabels_NoTagGuard()
     {
+        // The regression that broke AzDO reception: an area_path/status tracker (no
+        // pipeline_from_label → empty TriggerLabels) must NOT get a tag guard, or every
+        // fresh untagged work item is excluded.
         var query = new DiscoveryQuery(
-            [new DiscoveryBranch(["Active"], new DiscoveryCriterion(ResolutionStrategy.Tag, "alpha-tag"))],
+            [new DiscoveryBranch(["New"], new DiscoveryCriterion(ResolutionStrategy.AreaPath, "TodoList"))],
             []);
 
         var where = Builder.BuildWhere(query, OpenStates);
 
-        where.Should().EndWith(Guard);
-        where.Should().StartWith("(");
+        where.Should().NotContain("agent-smith");
+        where.Should().Be("([System.State] IN ('New') AND [System.AreaPath] UNDER 'TodoList')");
+    }
+
+    [Fact]
+    public void BuildWhere_WithTriggerLabels_GuardsBySpecificLabels()
+    {
+        // A label-opt-in tracker (pipeline_from_label) guards by the CONCRETE trigger labels
+        // (full-tag CONTAINS OR'd), not a bare 'agent-smith:' prefix.
+        var query = new DiscoveryQuery(
+            [new DiscoveryBranch(["Active"], new DiscoveryCriterion(ResolutionStrategy.Tag, "component-x"))],
+            [])
+        {
+            TriggerLabels = ["agent-smith:bug", "agent-smith:feature"],
+        };
+
+        var where = Builder.BuildWhere(query, OpenStates);
+
+        where.Should().Be(
+            "(([System.State] IN ('Active') AND [System.Tags] CONTAINS 'component-x')) "
+            + "AND ([System.Tags] CONTAINS 'agent-smith:bug' OR [System.Tags] CONTAINS 'agent-smith:feature')");
     }
 }


### PR DESCRIPTION
## Regression
p0300c added an **unconditional** `AND [System.Tags] CONTAINS 'agent-smith:'` to every AzDO discovery WIQL. That excluded every fresh work item lacking an `agent-smith:*` lifecycle tag → an area_path/status-triggered AzDO tracker received **zero tickets**. Ticket reception was broken.

## Fix
Mirror the Jira builder — guard by the tracker's **configured** trigger labels (`DiscoveryQuery.TriggerLabels` = the `pipeline_from_label` keys), and only when they exist:
- **no** trigger labels (area_path/status tracker) → **no guard** (reception restored);
- **with** trigger labels (label-opt-in tracker) → `AND ([System.Tags] CONTAINS 'agent-smith:bug' OR …)` using the concrete labels — full-tag CONTAINS is AzDO's reliable tag filter, not a bare prefix.

A label-gated ticket lacking a trigger label is dropped in-process anyway, so this never hides a claimable ticket.

## Scope
GitHub/GitLab never got a server-side guard (in-process filter) → unaffected. Jira already did this correctly.

## Tests
The old WIQL builder tests asserted the guard's *presence* (they codified the bug as expected). Replaced with tests asserting the *requirement*: no-trigger-labels → no guard; with-labels → specific-label guard. **2751/2751**.

⚠️ Needs redeploy for the running server to pick it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)