### PR TITLE
perf: faster startup — stop eager-resolving the whole DI graph (ValidateOnBuild)

### DIFF
--- a/src/backend/AgentSmith.Server/Program.cs
+++ b/src/backend/AgentSmith.Server/Program.cs
@@ -26,12 +26,20 @@ ServerCompositionBuilder.ConfigureConsoleLogging(builder.Logging);
 // add their typed clients via AddHttpClient<T>() on top of this.
 builder.Services.AddHttpClient();
 
-// p0137b: scope validation always on; build-time validation in Development catches lifetime
-// violations (e.g. Singleton consuming Scoped) at startup instead of as confusing runtime errors.
+// Scope validation is always on (cheap, runtime). ValidateOnBuild is NOT: it eagerly
+// instantiates EVERY singleton at app.Build() to validate the graph — Redis connect, the
+// k8s client (InClusterConfig), the DbContext, the sandbox factory, every probe/reader —
+// all BEFORE the API can listen. That is a dev-only guard (DI-lifetime violations), and the
+// running server never needs it: ServerDiLifetimeTests already builds the full graph with
+// ValidateOnBuild=true. Tying it to IsDevelopment() made a Development-env production server
+// pay the whole eager-resolution cost on every startup. Now opt-in only, default off, so the
+// API comes up fast regardless of ASPNETCORE_ENVIRONMENT.
 builder.Host.UseDefaultServiceProvider(o =>
 {
     o.ValidateScopes = true;
-    o.ValidateOnBuild = builder.Environment.IsDevelopment();
+    o.ValidateOnBuild = string.Equals(
+        Environment.GetEnvironmentVariable("AGENTSMITH_VALIDATE_DI"), "true",
+        StringComparison.OrdinalIgnoreCase);
 });
 
 var configPath = Environment.GetEnvironmentVariable("CONFIG_PATH") ?? "/app/config/agentsmith.yml";


### PR DESCRIPTION
## Symptom
"A whole bunch of services spin up before the API is ready."

## Cause
`Program.cs` tied `ServiceProvider.ValidateOnBuild` to `builder.Environment.IsDevelopment()`. The production deployment runs with **`ASPNETCORE_ENVIRONMENT=Development`**, so `app.Build()` eagerly instantiates **every** registered singleton to validate the graph — Redis connect, the k8s client (`InClusterConfig`), the DbContext, the sandbox factory, every probe/reader/projector — **before Kestrel can listen**.

## Fix
`ValidateOnBuild` is a dev-time DI-lifetime guard the running server never needs (`ServerDiLifetimeTests` already builds the full graph with it on). Decouple it from `IsDevelopment()` → opt-in only via **`AGENTSMITH_VALIDATE_DI=true`**, default **off**. The API comes up fast regardless of `ASPNETCORE_ENVIRONMENT`. `ValidateScopes` stays on (cheap, runtime).

The background workers are already `BackgroundService` (non-blocking `ExecuteAsync`), so they never blocked the API — the eager resolution did.

## Tests
2751/2751.

## Also worth doing (your k8s config, not this PR)
Set `ASPNETCORE_ENVIRONMENT=Production` in the deployment — Development also enables detailed exception pages + dev middleware you don't want in prod. This PR fixes startup independently, so it's safe either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)