### PR TITLE
fix(dashboard): run header showed sandbox keys as repos (5 badges for 3 repos)

### DIFF
--- a/src/dashboard/src/app/jobs/[id]/page.tsx
+++ b/src/dashboard/src/app/jobs/[id]/page.tsx
@@ -15,7 +15,7 @@ import { PlanDetail } from "@/components/execution/PlanDetail";
 import { ResultDetail } from "@/components/execution/ResultDetail";
 import type { ExecutionNodeProps } from "@/components/execution/ExecutionNode";
 import type { NodeStatus } from "@/components/execution/TimingGutter";
-import { EventType } from "@/types/hub-events";
+import { deriveRunRepoNames } from "@/lib/runRepoNames";
 
 // p0205: two-pane master/detail run detail. Left: a single-line NavRail
 // (Execution steps + Overview = Architecture/Result). Right: a DetailPane that
@@ -52,12 +52,10 @@ function RunDetail({ runId }: { runId: string }) {
       ?? null;
   }, [overview, runId]);
 
-  const repoNames = useMemo(() => {
-    const repos = new Set<string>();
-    if (snapshot?.repos) for (const r of snapshot.repos) repos.add(r);
-    for (const e of events) if (e.type === EventType.SandboxCreated) repos.add(e.repo);
-    return [...repos].sort();
-  }, [snapshot, events]);
+  const repoNames = useMemo(
+    () => deriveRunRepoNames(snapshot?.repos, events),
+    [snapshot, events],
+  );
 
   const { nodes } = useRunExecutionTree(events, snapshot, runId);
   const resultStatus = mapResultStatus(snapshot?.status);

--- a/src/dashboard/src/lib/__tests__/runRepoNames.test.ts
+++ b/src/dashboard/src/lib/__tests__/runRepoNames.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { deriveRunRepoNames } from "@/lib/runRepoNames";
+import { EventType, type RunEvent } from "@/types/hub-events";
+
+function sandboxCreated(repo: string): RunEvent {
+  return {
+    type: EventType.SandboxCreated,
+    runId: "r1",
+    timestamp: "2026-07-06T00:00:00Z",
+    repo,
+    image: "img",
+    language: "csharp",
+  } as unknown as RunEvent;
+}
+
+function runStarted(repos: string[]): RunEvent {
+  return {
+    type: EventType.RunStarted,
+    runId: "r1",
+    timestamp: "2026-07-06T00:00:00Z",
+    trigger: "t",
+    pipeline: "fix-bug",
+    repos,
+    startedAt: "2026-07-06T00:00:00Z",
+    agentName: null,
+  } as unknown as RunEvent;
+}
+
+describe("deriveRunRepoNames", () => {
+  it("uses the snapshot repos and IGNORES SandboxCreated composite sandbox keys", () => {
+    // The regression: a repo with two toolchain/resource sandboxes emitted composite
+    // keys (Sample.Server-c#-2-2gi / -3gi); those must not appear as repo badges.
+    const events: RunEvent[] = [
+      sandboxCreated("Sample.Server-c#-2-2gi"),
+      sandboxCreated("Sample.Server-c#-2-3gi"),
+      sandboxCreated("Sample.Client"),
+    ];
+
+    const result = deriveRunRepoNames(
+      ["Sample.Server", "Sample.Client", "Sample.BackgroundWorker"],
+      events,
+    );
+
+    expect(result).toEqual(["Sample.BackgroundWorker", "Sample.Client", "Sample.Server"]);
+    expect(result).not.toContain("Sample.Server-c#-2-2gi");
+    expect(result).not.toContain("Sample.Server-c#-2-3gi");
+  });
+
+  it("falls back to the RunStarted event repos when the snapshot has none", () => {
+    const result = deriveRunRepoNames(undefined, [runStarted(["Sample.A", "Sample.B"])]);
+
+    expect(result).toEqual(["Sample.A", "Sample.B"]);
+  });
+
+  it("dedupes snapshot + RunStarted and never surfaces sandbox keys", () => {
+    const result = deriveRunRepoNames(
+      ["Sample.Server"],
+      [runStarted(["Sample.Server", "Sample.Client"]), sandboxCreated("Sample.Server-c#-2-2gi")],
+    );
+
+    expect(result).toEqual(["Sample.Client", "Sample.Server"]);
+  });
+});

--- a/src/dashboard/src/lib/runRepoNames.ts
+++ b/src/dashboard/src/lib/runRepoNames.ts
@@ -1,0 +1,22 @@
+import { EventType, type RunEvent } from "@/types/hub-events";
+
+/**
+ * The repos a run touches, for the run-detail header. Sourced from the snapshot's
+ * configured repo list, falling back to the RunStarted event's repo list when the
+ * snapshot hasn't captured it yet.
+ *
+ * Deliberately does NOT read SandboxCreatedEvent: its `repo` field carries the composite
+ * sandbox KEY (`<repo>-<lang>-<size>`, e.g. "…Server-c#-2-2gi"), so a repo with several
+ * toolchain/resource sandboxes leaked phantom per-sandbox entries into the header (a
+ * 3-repo run showed 5 badges).
+ */
+export function deriveRunRepoNames(
+  snapshotRepos: readonly string[] | undefined,
+  events: readonly RunEvent[],
+): string[] {
+  const repos = new Set<string>();
+  if (snapshotRepos) for (const r of snapshotRepos) repos.add(r);
+  for (const e of events)
+    if (e.type === EventType.RunStarted) for (const r of e.repos) repos.add(r);
+  return [...repos].sort();
+}


### PR DESCRIPTION
## Symptom
A run whose config has **3 repos** showed **5** badges in the run-detail header — the extra two were `…Server-c#-2-2gi` and `…Server-c#-2-3gi`.

## Cause
Those aren't repos — they're **composite sandbox keys** (`<repo>-<lang>-<size>`). The header's `repoNames` memo added `SandboxCreatedEvent.repo` to the badge set, but that event's `repo` field carries the sandbox key (set to `sandboxKey` at `PipelineSandboxCoordinator.cs:218`), not the repo name. A repo that spins up several toolchain/resource sandboxes (p0268 multi-group — here the Server repo got a 2 GiB and a 3 GiB C# sandbox) therefore leaked phantom entries.

## Fix
Derive the badges from `snapshot.repos`, falling back to the **RunStarted** event's real repo list — never `SandboxCreated`. Extracted to a pure `deriveRunRepoNames(snapshotRepos, events)` and added a regression test asserting sandbox composite keys never surface as repo badges (the exact "why didn't a test catch this" gap).

3/3 new tests green; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)