### PR TITLE
fix(bootstrap): init-project never wrote context.yaml (p0193 regression)

### DIFF
--- a/src/backend/AgentSmith.Application/Services/BootstrapPromptFactory.cs
+++ b/src/backend/AgentSmith.Application/Services/BootstrapPromptFactory.cs
@@ -89,13 +89,16 @@ internal static class BootstrapPromptFactory
 
     private static string WriteInstruction(bool isReInit, string contextYamlPath, string codingPrinciplesPath)
     {
-        var verb = isReInit
-            ? "Read source files via your read-only tools to confirm the merge, then use the WriteFile tool to emit the MERGED"
-            : "Read source files via your read-only tools to ground claims for THIS component, then use the WriteFile tool to emit";
+        var lead = isReInit
+            ? "Read source files via your read-only tools to confirm the merge, then write the MERGED files:"
+            : "Read source files via your read-only tools to ground claims for THIS component, then write:";
+        // p0193-fix: context.yaml goes through write_context_yaml (write_file
+        // rejects context.yaml paths); coding-principles.md through write_file.
         return $"""
-            {verb}:
-              - `{contextYamlPath}`
-              - `{codingPrinciplesPath}`
+            {lead}
+              - `{contextYamlPath}` — use the `write_context_yaml` tool (NOT write_file;
+                the framework rejects write_file for context.yaml).
+              - `{codingPrinciplesPath}` — use the `write_file` tool.
             After both writes succeed, return a short Markdown summary of the
             choices you made (per `output_schema: bootstrap`).
             """;

--- a/src/backend/AgentSmith.Application/Services/BootstrapToolHostFactory.cs
+++ b/src/backend/AgentSmith.Application/Services/BootstrapToolHostFactory.cs
@@ -24,16 +24,26 @@ namespace AgentSmith.Application.Services;
 public sealed class BootstrapToolHostFactory(
     IDecisionLogger decisionLogger,
     IPathReadGuard readGuard,
-    IPathWriteGuard writeGuard)
+    IPathWriteGuard writeGuard,
+    IContextYamlSerializer contextYamlSerializer)
 {
-    public BootstrapToolBundle Create(ISandbox sandbox, string repoLocalPath, string contextName = "")
+    public BootstrapToolBundle Create(
+        ISandbox sandbox, string repoLocalPath, string repoName, string contextName = "")
     {
         var fs = new FilesystemToolHost(
             sandbox, repoLocalPath, readGuard, writeGuard,
             writePhase: SkillExecutionPhase.Bootstrap,
             contextName: contextName);
         var log = new LogDecisionToolHost(decisionLogger, repoLocalPath);
-        var tools = AgenticToolSurface.Bootstrap(fs, log);
+        // p0193-fix: the bootstrap round writes context.yaml through the typed
+        // write_context_yaml tool (write_file rejects context.yaml paths). Without
+        // this the round could only ever write coding-principles.md — context.yaml
+        // was silently unproducible from p0193 until this wiring.
+        var writeContextYaml = new WriteContextYamlToolHost(
+            new Dictionary<string, ISandbox> { [repoName] = sandbox },
+            defaultRepo: repoName,
+            contextYamlSerializer);
+        var tools = AgenticToolSurface.Bootstrap(fs, log, writeContextYaml);
         return new BootstrapToolBundle(tools, fs.GetChanges, log.GetDecisions);
     }
 }

--- a/src/backend/AgentSmith.Application/Services/Handlers/BootstrapRoundHandler.cs
+++ b/src/backend/AgentSmith.Application/Services/Handlers/BootstrapRoundHandler.cs
@@ -47,7 +47,7 @@ public sealed class BootstrapRoundHandler(
                 $"BootstrapRound: no ProjectMap available for repo '{context.RepoName}' " +
                 "(checked RepoProjectMaps[RepoName] and legacy ContextKeys.ProjectMap)");
 
-        var bundle = toolHostFactory.Create(sandbox, repo.LocalPath, context.ContextName);
+        var bundle = toolHostFactory.Create(sandbox, repo.LocalPath, context.RepoName, context.ContextName);
         var appliesTo = ResolveAppliesTo(pipeline);
         var (existingCtx, existingPrinciples) =
             await ReadExistingMetaFilesAsync(sandbox, context.ContextName, cancellationToken);
@@ -61,14 +61,35 @@ public sealed class BootstrapRoundHandler(
         var changes = bundle.GetChanges();
         var decisions = bundle.GetDecisions();
         if (decisions.Count > 0) pipeline.AppendDecisions(decisions);
+
+        // p0193-fix: context.yaml is written via write_context_yaml (its own
+        // sandbox Step), so it never shows up in bundle.GetChanges() (which only
+        // tracks the FilesystemToolHost writes, i.e. coding-principles.md). Verify
+        // the artifact directly on the sandbox so a skipped/failed context.yaml
+        // write FAILS loudly instead of the run reporting a silent success.
+        var (ctxPath, _) = BootstrapPromptFactory.ResolveTargetPaths(context.ContextName);
+        var contextYamlWritten =
+            await FileExistsAsync(sandbox, ctxPath, cancellationToken);
         logger.LogInformation(
-            "{Emoji} {DisplayName} [Bootstrap]: {Count} file(s) written, {Decisions} decision(s)",
-            role.Emoji, role.DisplayName, changes.Count, decisions.Count);
+            "{Emoji} {DisplayName} [Bootstrap]: {Count} file(s) written, {Decisions} decision(s), context.yaml={CtxWritten}",
+            role.Emoji, role.DisplayName, changes.Count, decisions.Count, contextYamlWritten);
+
+        if (!contextYamlWritten)
+            return CommandResult.Fail(
+                $"BootstrapRound: skill '{context.SkillName}' did not produce {ctxPath} "
+                + "— the write_context_yaml tool was not called or failed. context.yaml is required.");
         return changes.Count == 0
             ? CommandResult.Fail(
-                $"BootstrapRound: skill '{context.SkillName}' did not call WriteFile "
-                + "(0 changes). context.yaml / coding-principles.md not produced.")
+                $"BootstrapRound: skill '{context.SkillName}' did not call write_file "
+                + "(0 changes). coding-principles.md not produced.")
             : CommandResult.Ok($"{role.DisplayName} [Bootstrap]: {changes.Count} file(s) written");
+    }
+
+    private async Task<bool> FileExistsAsync(ISandbox sandbox, string path, CancellationToken ct)
+    {
+        var reader = readerFactory.Create(sandbox);
+        var content = await reader.TryReadAsync(path, ct);
+        return !string.IsNullOrEmpty(content);
     }
 
     // p0202d: read the operator's existing context.yaml + coding-principles.md

--- a/src/backend/AgentSmith.Application/Services/Tools/AgenticToolSurface.cs
+++ b/src/backend/AgentSmith.Application/Services/Tools/AgenticToolSurface.cs
@@ -51,10 +51,18 @@ public static class AgenticToolSurface
             .Cast<AITool>()
             .ToList();
 
-    /// <summary>Bootstrap surface: fs read/write/list/grep + log_decision (no run, no human, no web).</summary>
-    public static IList<AITool> Bootstrap(FilesystemToolHost fs, LogDecisionToolHost log) =>
+    /// <summary>
+    /// Bootstrap surface: fs read/write/list/grep + log_decision + (optional)
+    /// write_context_yaml (no run, no human, no web). context.yaml MUST be written
+    /// through write_context_yaml — write_file rejects context.yaml paths (p0193) —
+    /// so the producer round is handed the typed tool here.
+    /// </summary>
+    public static IList<AITool> Bootstrap(
+        FilesystemToolHost fs, LogDecisionToolHost log,
+        WriteContextYamlToolHost? writeContextYaml = null) =>
         fs.GetTools(Models.SkillExecutionPhase.Bootstrap, investigatorMode: null)
             .Concat(log.GetTools(phase: null, investigatorMode: null))
+            .Concat(writeContextYaml?.GetTools(phase: null, investigatorMode: null) ?? [])
             .Cast<AITool>()
             .ToList();
 

--- a/tests/AgentSmith.Tests/Handlers/BootstrapPerContextTests.cs
+++ b/tests/AgentSmith.Tests/Handlers/BootstrapPerContextTests.cs
@@ -68,6 +68,25 @@ public sealed class BootstrapPerContextTests
     }
 
     [Fact]
+    public void BootstrapToolHostFactory_ExposesWriteContextYamlTool()
+    {
+        // p0193-fix regression guard: context.yaml is written via the typed
+        // write_context_yaml tool (write_file rejects context.yaml paths). If this
+        // tool ever falls out of the bootstrap surface again, init silently stops
+        // producing context.yaml — the exact p0193→2026-07 regression this fixes.
+        var factory = new BootstrapToolHostFactory(
+            Mock.Of<IDecisionLogger>(),
+            new PathReadGuard(new NullGitIgnoreResolver()),
+            new PathWriteGuard(new PathReadGuard(new NullGitIgnoreResolver())),
+            Mock.Of<IContextYamlSerializer>());
+
+        var bundle = factory.Create(Mock.Of<ISandbox>(), "/repo", repoName: "api", contextName: "api");
+
+        bundle.Tools.OfType<AIFunction>().Select(f => f.Name)
+            .Should().Contain(WriteContextYamlToolHost.ToolName);
+    }
+
+    [Fact]
     public async Task BootstrapPromptFactory_PathsUsePerContextMetaDir()
     {
         // p0161d: BootstrapRoundHandler must hand BootstrapPromptFactory the
@@ -76,7 +95,7 @@ public sealed class BootstrapPerContextTests
         var captured = new CapturedPrompt();
         var handler = new BootstrapRoundHandler(
             new PromptCapturingFactory(new CapturingChatClient(captured)),
-            new BootstrapToolHostFactory(Mock.Of<IDecisionLogger>(), new PathReadGuard(new NullGitIgnoreResolver()), new PathWriteGuard(new PathReadGuard(new NullGitIgnoreResolver()))),
+            new BootstrapToolHostFactory(Mock.Of<IDecisionLogger>(), new PathReadGuard(new NullGitIgnoreResolver()), new PathWriteGuard(new PathReadGuard(new NullGitIgnoreResolver())), Mock.Of<IContextYamlSerializer>()),
             BootstrapReaderStubs.NullReaderFactory(),
             EventTestStubs.RunContext,
             NullLogger<BootstrapRoundHandler>.Instance);
@@ -103,7 +122,7 @@ public sealed class BootstrapPerContextTests
         var captured = new CapturedPrompt();
         var handler = new BootstrapRoundHandler(
             new PromptCapturingFactory(new CapturingChatClient(captured)),
-            new BootstrapToolHostFactory(Mock.Of<IDecisionLogger>(), new PathReadGuard(new NullGitIgnoreResolver()), new PathWriteGuard(new PathReadGuard(new NullGitIgnoreResolver()))),
+            new BootstrapToolHostFactory(Mock.Of<IDecisionLogger>(), new PathReadGuard(new NullGitIgnoreResolver()), new PathWriteGuard(new PathReadGuard(new NullGitIgnoreResolver())), Mock.Of<IContextYamlSerializer>()),
             BootstrapReaderStubs.NullReaderFactory(),
             EventTestStubs.RunContext,
             NullLogger<BootstrapRoundHandler>.Instance);
@@ -148,7 +167,7 @@ public sealed class BootstrapPerContextTests
         var existing = "meta:\n  workdir: server\nstack:\n  lang: node\n";
         var handler = new BootstrapRoundHandler(
             new PromptCapturingFactory(new CapturingChatClient(captured)),
-            new BootstrapToolHostFactory(Mock.Of<IDecisionLogger>(), new PathReadGuard(new NullGitIgnoreResolver()), new PathWriteGuard(new PathReadGuard(new NullGitIgnoreResolver()))),
+            new BootstrapToolHostFactory(Mock.Of<IDecisionLogger>(), new PathReadGuard(new NullGitIgnoreResolver()), new PathWriteGuard(new PathReadGuard(new NullGitIgnoreResolver())), Mock.Of<IContextYamlSerializer>()),
             BootstrapReaderStubs.ReaderFactoryReturning(existing),
             EventTestStubs.RunContext,
             NullLogger<BootstrapRoundHandler>.Instance);
@@ -172,7 +191,7 @@ public sealed class BootstrapPerContextTests
         var captured = new CapturedPrompt();
         var handler = new BootstrapRoundHandler(
             new PromptCapturingFactory(new CapturingChatClient(captured)),
-            new BootstrapToolHostFactory(Mock.Of<IDecisionLogger>(), new PathReadGuard(new NullGitIgnoreResolver()), new PathWriteGuard(new PathReadGuard(new NullGitIgnoreResolver()))),
+            new BootstrapToolHostFactory(Mock.Of<IDecisionLogger>(), new PathReadGuard(new NullGitIgnoreResolver()), new PathWriteGuard(new PathReadGuard(new NullGitIgnoreResolver())), Mock.Of<IContextYamlSerializer>()),
             BootstrapReaderStubs.NullReaderFactory(),
             EventTestStubs.RunContext,
             NullLogger<BootstrapRoundHandler>.Instance);

--- a/tests/AgentSmith.Tests/Handlers/BootstrapRoundHandlerMultiRepoTests.cs
+++ b/tests/AgentSmith.Tests/Handlers/BootstrapRoundHandlerMultiRepoTests.cs
@@ -141,7 +141,7 @@ public sealed class BootstrapRoundHandlerMultiRepoTests
 
     private static BootstrapRoundHandler NewHandler(CapturedPrompt captured) => new(
         new PromptCapturingFactory(new CapturingChatClient(captured)),
-        new BootstrapToolHostFactory(Mock.Of<IDecisionLogger>(), new PathReadGuard(new NullGitIgnoreResolver()), new PathWriteGuard(new PathReadGuard(new NullGitIgnoreResolver()))),
+        new BootstrapToolHostFactory(Mock.Of<IDecisionLogger>(), new PathReadGuard(new NullGitIgnoreResolver()), new PathWriteGuard(new PathReadGuard(new NullGitIgnoreResolver())), Mock.Of<IContextYamlSerializer>()),
         BootstrapReaderStubs.NullReaderFactory(),
         EventTestStubs.RunContext,
         NullLogger<BootstrapRoundHandler>.Instance);


### PR DESCRIPTION
## Problem
Every `init-project` run wrote `.agentsmith/contexts/<ctx>/coding-principles.md` but **no `context.yaml`** — and still reported success. Observed on RHS.Translate.Server (MR !8769, contexts `api` + `clientapigenerator`).

## Root cause
`p0193` (6c166a8f) introduced the typed `write_context_yaml` tool and **hard-rejects** `write_file` for `.agentsmith/contexts/*/context.yaml`. The tool was wired into the master/agentic paths but **never into the bootstrap round** (`BootstrapToolHostFactory` only built `FilesystemToolHost` + `LogDecisionToolHost`). So in bootstrap the old path was forbidden and the new one absent → `context.yaml` was literally unwritable. `coding-principles.md` (plain `write_file`) still worked, so the run looked successful. No post-condition verified `context.yaml`, so it failed silently.

Aggravating: `BootstrapPromptFactory` still told the LLM to use `WriteFile` for context.yaml (the rejected path). The deployed skill (`agent-smith-skills` v1.3.0) was already correct — this is a framework-only bug.

## Fix
- Wire `WriteContextYamlToolHost` into `BootstrapToolHostFactory` / `AgenticToolSurface.Bootstrap` (mirrors the master path).
- `BootstrapPromptFactory`: instruct `write_context_yaml` for context.yaml, `write_file` for coding-principles.md.
- `BootstrapRoundHandler`: verify `context.yaml` exists on the sandbox after the round; `Fail` loudly if missing (it bypasses `GetChanges` via its own Step).
- Regression guard asserting `write_context_yaml` is present in the bootstrap surface.

## Tests
- Full unit suite: **2751/2751 green** (incl. new `BootstrapToolHostFactory_ExposesWriteContextYamlTool`).
- Real proof: the next `init-project` run must produce a `context.yaml` per context — verify after rebuilding the deploy image (`--no-cache`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)