### PR TITLE
fix(docker): copy phase-spec.schema.json into CLI + Server build contexts

### DIFF
--- a/src/backend/AgentSmith.Cli/Dockerfile
+++ b/src/backend/AgentSmith.Cli/Dockerfile
@@ -14,9 +14,11 @@ COPY src/backend/AgentSmith.Sandbox.Wire/AgentSmith.Sandbox.Wire.csproj src/back
 
 RUN dotnet restore src/backend/AgentSmith.Cli/AgentSmith.Cli.csproj
 
-# Schemas embedded into AgentSmith.Application via Link (p0128a).
-# csproj references ../../.agentsmith/schemas/*.json relative to the project dir.
+# Schemas embedded into AgentSmith.Application via Link (p0128a, p0315b).
+# csproj references ../../.agentsmith/schemas/*.json and
+# ../../.agentsmith/phase-spec.schema.json relative to the project dir.
 COPY .agentsmith/schemas/ .agentsmith/schemas/
+COPY .agentsmith/phase-spec.schema.json .agentsmith/
 
 # Copy source and publish
 COPY src/ src/

--- a/src/backend/AgentSmith.Server/Dockerfile
+++ b/src/backend/AgentSmith.Server/Dockerfile
@@ -14,9 +14,11 @@ COPY src/backend/AgentSmith.Sandbox.Wire/AgentSmith.Sandbox.Wire.csproj       sr
 
 RUN dotnet restore src/backend/AgentSmith.Server/AgentSmith.Server.csproj
 
-# Schemas embedded into AgentSmith.Application via Link (p0128a).
-# csproj references ../../.agentsmith/schemas/*.json relative to the project dir.
+# Schemas embedded into AgentSmith.Application via Link (p0128a, p0315b).
+# csproj references ../../.agentsmith/schemas/*.json and
+# ../../.agentsmith/phase-spec.schema.json relative to the project dir.
 COPY .agentsmith/schemas/ .agentsmith/schemas/
+COPY .agentsmith/phase-spec.schema.json .agentsmith/
 
 # Copy all source and publish
 COPY src/ src/


### PR DESCRIPTION
Docker Build & Publish broke on main after #374: p0315b embeds `.agentsmith/phase-spec.schema.json` into AgentSmith.Application, but the CLI/Server Dockerfiles only copy `.agentsmith/schemas/` — `dotnet publish` in the image fails with CS1566. One COPY line each, mirroring the p0128a pattern. Build stage verified locally.

The test jobs in both failed runs were green — only the cli/server image builds failed. After merge, re-run the failed publish for the current release so the images get pushed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)