### PR TITLE
fix(api-scan): publish a synthetic Repository in passive mode

### DIFF
--- a/src/backend/AgentSmith.Application/Services/Handlers/TryCheckoutSourceHandler.cs
+++ b/src/backend/AgentSmith.Application/Services/Handlers/TryCheckoutSourceHandler.cs
@@ -90,6 +90,13 @@ public sealed class TryCheckoutSourceHandler(
     private CommandResult WarnPassive(PipelineContext pipeline, string message)
     {
         logger.LogWarning("{Message}", message);
+        // Passive mode has no checked-out source, but a synthetic Repository must
+        // still be published: downstream builders (LoadContext, LoadCodingPrinciples,
+        // AgenticMaster, …) read ContextKeys.Repository unconditionally, and its
+        // LocalPath is the fixed sandbox work path regardless of a real clone. Without
+        // this, api-scan — which is passive by design (it targets a running API, not a
+        // repo) — dies at the first builder with a missing-key error.
+        pipeline.Set(ContextKeys.Repository, new Repository(new BranchName("(passive)"), string.Empty));
         EmitBanner(pipeline, sourcePath: null);
         return Ok();
     }


### PR DESCRIPTION
## What
api-scan has been **fully broken end-to-end since p0198 (2026-06-02)**. Found by `/smoke` running a real api-scan against a live API.

api-scan is passive by design — it targets a running API, not a checked-out repo — so `TryCheckoutSource` takes the `WarnPassive` branch and never sets `ContextKeys.Repository`. But ~15 downstream context builders (`LoadContext`, `LoadCodingPrinciples`, `AgenticMaster`, …) read that key unconditionally via `Get<Repository>`, so the pipeline died at the first one with `Key 'Repository' not found` (step 7 of 16).

## Why no test caught it
No unit or harness test exercises the passive api-scan path — the whole point the smoke suite exists for. The 3065 existing tests all passed while api-scan was dead.

## Fix
Root cause, one line: `WarnPassive` publishes a synthetic `(passive)` Repository. Its `LocalPath` is the fixed sandbox work path (`/work`) regardless of a clone, so every downstream builder is satisfied — instead of decoupling 15 sites individually.

## Verification
- Real api-scan against a live minimal API: **16/16 green** (was: crash at step 7), verdict 1/1 passed.
- Full suite: **3065 green**, no regression.

Separate from #377 (Docker publish fix) — both found in the same smoke session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)