### PR TITLE
fix(feature): pipeline_name add-feature accepted end-to-end (drop feature-implementation)

### DIFF
--- a/tests/AgentSmith.PipelineHarness/Composition/PipelineNameConceptMap.cs
+++ b/tests/AgentSmith.PipelineHarness/Composition/PipelineNameConceptMap.cs
@@ -1,17 +1,21 @@
 namespace AgentSmith.PipelineHarness.Composition;
 
 /// <summary>
-/// p0199: maps CLI-level preset names onto the canonical concept-vocabulary
-/// values that <c>PipelineNameInitializer</c> writes. Without this mapping
-/// the concept writer rejects e.g. "add-feature" — the vocab uses
-/// "feature-implementation". Same rule the production initializer applies;
-/// we keep it in test code so the runner stays decoupled from the writer.
+/// Maps CLI-level preset names onto the canonical concept-vocabulary values
+/// that <c>PipelineNameInitializer</c> writes. Most presets publish their own
+/// name (add-feature, fix-bug, …); only fix-no-test aliases onto fix-bug so it
+/// reuses the fix-bug skill roster.
+///
+/// NOTE: production's PipelineNameInitializer does NOT apply this map — it
+/// publishes the resolved name verbatim. Harmless for identity presets, but it
+/// means fix-no-test is still broken end-to-end in production (SetEnum rejects
+/// "fix-no-test"); tracked separately. add-feature was the same class of bug
+/// until the concept vocab + coding skills were renamed to "add-feature".
 /// </summary>
 internal static class PipelineNameConceptMap
 {
     public static string ToConceptValue(string presetName) => presetName switch
     {
-        "add-feature" => "feature-implementation",
         "fix-no-test" => "fix-bug",
         _ => presetName,
     };

--- a/tests/AgentSmith.PipelineHarness/Composition/PipelineRunner.cs
+++ b/tests/AgentSmith.PipelineHarness/Composition/PipelineRunner.cs
@@ -149,7 +149,7 @@ public sealed class PipelineRunner(IServiceProvider services)
         // PRESET name ("add-feature"), NOT the concept-vocabulary value. The
         // keystone (CommitAndPRHandler → PipelinePresets.ExpectsCodeChanges/
         // ExpectsGreenTests) keys off the preset name; seeding the concept value
-        // here ("feature-implementation") silently bypassed the add-feature
+        // here (the pre-rename concept value) silently bypassed the add-feature
         // keystone in the fast tier — the fidelity gap this phase closes. The
         // pipeline_name CONCEPT is a separate channel, written by
         // PipelineNameInitializerHandler from ResolvedPipelineConfig.PipelineName.

--- a/tests/AgentSmith.PipelineHarness/Fixtures/SkillsCatalog/skills/concept-vocabulary.yaml
+++ b/tests/AgentSmith.PipelineHarness/Fixtures/SkillsCatalog/skills/concept-vocabulary.yaml
@@ -6,7 +6,7 @@
 concepts:
   - name: pipeline_name
     type: enum
-    enum_values: [api-security-scan, security-scan, fix-bug, feature-implementation, mad-discussion, legal-analysis, init-project, autonomous, skill-manager, pr-review]
+    enum_values: [api-security-scan, security-scan, fix-bug, add-feature, mad-discussion, legal-analysis, init-project, autonomous, skill-manager, pr-review]
     description: "Identity of the currently routing pipeline; published by PipelineNameInitializerHandler."
     writers: [PipelineNameInitializerHandler]
   - name: project_language

--- a/tests/AgentSmith.PipelineHarness/Presets/AddFeatureTests.cs
+++ b/tests/AgentSmith.PipelineHarness/Presets/AddFeatureTests.cs
@@ -42,7 +42,7 @@ public sealed class AddFeatureTests
         // p0239: add-feature is in CodeChangingPresets, so the keystone refuses a
         // run that ships nothing — exactly like fix-bug. The fast tier used to
         // report this GREEN because PipelineRunner seeded ContextKeys.PipelineName
-        // with the concept value ("feature-implementation") instead of the preset
+        // with the old concept value (pre-rename) instead of the preset
         // name; ExpectsCodeChanges keys off the preset name, so the keystone was
         // silently bypassed for add-feature. With the seed corrected, a zero-change
         // add-feature run correctly FAILS. GenerateTests/GenerateDocs still tolerate

--- a/tests/AgentSmith.Tests/Handlers/VerifyRoundHandlerMultiVerifierTests.cs
+++ b/tests/AgentSmith.Tests/Handlers/VerifyRoundHandlerMultiVerifierTests.cs
@@ -139,6 +139,6 @@ public sealed class VerifyRoundHandlerMultiVerifierTests
         Role = "investigator",
         InvestigatorMode = "verify_diff",
         OutputSchema = "observation",
-        ActivatesWhen = "pipeline_name = \"fix-bug\" OR pipeline_name = \"feature-implementation\"",
+        ActivatesWhen = "pipeline_name = \"fix-bug\" OR pipeline_name = \"add-feature\"",
     };
 }

--- a/tests/AgentSmith.Tests/Handlers/VerifyRoundHandlerTests.cs
+++ b/tests/AgentSmith.Tests/Handlers/VerifyRoundHandlerTests.cs
@@ -268,7 +268,7 @@ public sealed class VerifyRoundHandlerTests
         Role = "investigator",
         InvestigatorMode = "verify_diff",
         OutputSchema = "observation",
-        ActivatesWhen = "pipeline_name = \"fix-bug\" OR pipeline_name = \"feature-implementation\"",
+        ActivatesWhen = "pipeline_name = \"fix-bug\" OR pipeline_name = \"add-feature\"",
     };
 
     private static RoleSkillDefinition JudgeOnly(string name) => new()

--- a/tests/AgentSmith.Tests/Integration/PipelineE2EHarness.cs
+++ b/tests/AgentSmith.Tests/Integration/PipelineE2EHarness.cs
@@ -90,13 +90,10 @@ internal sealed class PipelineE2EHarness : IAsyncDisposable
     {
         var pipeline = new PipelineContext();
         var agent = new AgentConfig { Type = "claude", Model = "sonnet" };
-        // The concept vocab's pipeline_name enum uses canonical slugs; map
-        // CLI-level aliases (add-feature, fix-no-test) onto the enum value
-        // PipelineNameInitializer would write. Without this, the handler
-        // rejects the preset name as not-in-enum.
+        // Most presets publish their own name into the pipeline_name enum;
+        // fix-no-test aliases onto fix-bug to reuse its skill roster.
         var conceptValue = presetName switch
         {
-            "add-feature" => "feature-implementation",
             "fix-no-test" => "fix-bug",
             _ => presetName,
         };

--- a/tests/AgentSmith.Tests/TestHelpers/RunStateConceptsTestFactory.cs
+++ b/tests/AgentSmith.Tests/TestHelpers/RunStateConceptsTestFactory.cs
@@ -51,7 +51,7 @@ internal static class RunStateConceptsTestFactory
     {
         ["pipeline_name"] = new(
             "pipeline_name", "test", ConceptType.Enum,
-            new[] { "api-security-scan", "security-scan", "fix-bug", "feature-implementation",
+            new[] { "api-security-scan", "security-scan", "fix-bug", "add-feature",
                     "mad-discussion", "legal-analysis", "init-project",
                     "autonomous", "skill-manager", "pr-review" },
             null, []),


### PR DESCRIPTION
## What
The `feature`/`add-feature` pipeline was **broken end-to-end**: it died at step 2 (`PipelineNameInitializer`) before any LLM call, because it publishes `pipeline_name=add-feature` but the concept-vocabulary enum + all coding skills used `feature-implementation`. `fix-bug` works only because its preset key == concept name == skill name are all consistently `fix-bug`.

Found by a real-LLM `/smoke` `feature` run. **No unit/harness test caught it** — a test-only `PipelineNameConceptMap` silently remapped `add-feature → feature-implementation`, so the harness passed while production was dead. Its doc-comment even claimed *'Same rule the production initializer applies'* — it doesn't.

## Fix (operator chose `add-feature` as canonical)
Skills side (agent-smith-skills PR #117): concept-vocab enum + 27 coding skills' `activates_when` → `add-feature`. This backend PR is the test/fixture counterpart. **No production .cs change** — once the renamed skills are pinned, `SetEnum('add-feature')` is accepted and the coding skills activate on the published name.

## Verification
- Real CLI `feature` run (local skills): `PipelineNameInitializerCommand completed: pipeline_name=add-feature`, proceeds through FetchTicket → GeneratePlan (was: crash at step 2).
- Full suite **3065 green**.

## ⚠️ Related bug NOT fixed here
`fix-no-test` has the identical defect — it maps to `fix-bug` only in the harness `PipelineNameConceptMap`, which production does not apply, so `fix-no-test` via CLI dies at `SetEnum('fix-no-test')` the same way. Flagged in the code comment; needs a decision (move the alias into production `PipelineNameInitializer`, or drop the preset).

Pairs with agent-smith-skills #117 — merge + pin the renamed skills for the fix to take effect in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)