### PR TITLE
fix(context-yaml): preserve arch/quality values + require stack.image

### DIFF
--- a/src/backend/AgentSmith.Application/Services/Tools/InferredTypeJsonConverter.cs
+++ b/src/backend/AgentSmith.Application/Services/Tools/InferredTypeJsonConverter.cs
@@ -1,0 +1,55 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace AgentSmith.Application.Services.Tools;
+
+/// <summary>
+/// Deserializes JSON <c>object</c>-typed values into plain CLR types
+/// (string / double / bool / null / List&lt;object?&gt; / Dictionary&lt;string, object?&gt;)
+/// instead of leaving them as <see cref="JsonElement"/>.
+///
+/// context.yaml's pass-through sections (arch / quality / behavior) are typed as
+/// <c>IDictionary&lt;string, object?&gt;</c>. Without this converter their values
+/// land as <see cref="JsonElement"/>, and the YAML serializer — which reflects an
+/// object's public properties — emits <c>value_kind: String</c> instead of the
+/// actual scalar/list. This converter closes that round-trip so the written
+/// context.yaml preserves the real arch/quality content.
+/// </summary>
+public sealed class InferredTypeJsonConverter : JsonConverter<object>
+{
+    public override object? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
+        reader.TokenType switch
+        {
+            JsonTokenType.String => reader.GetString(),
+            JsonTokenType.True => true,
+            JsonTokenType.False => false,
+            JsonTokenType.Null => null,
+            JsonTokenType.Number => reader.TryGetInt64(out var l) ? l : reader.GetDouble(),
+            JsonTokenType.StartArray => ReadArray(ref reader, options),
+            JsonTokenType.StartObject => ReadObject(ref reader, options),
+            _ => throw new JsonException($"Unsupported token {reader.TokenType}"),
+        };
+
+    private List<object?> ReadArray(ref Utf8JsonReader reader, JsonSerializerOptions options)
+    {
+        var list = new List<object?>();
+        while (reader.Read() && reader.TokenType != JsonTokenType.EndArray)
+            list.Add(Read(ref reader, typeof(object), options));
+        return list;
+    }
+
+    private Dictionary<string, object?> ReadObject(ref Utf8JsonReader reader, JsonSerializerOptions options)
+    {
+        var map = new Dictionary<string, object?>(StringComparer.Ordinal);
+        while (reader.Read() && reader.TokenType != JsonTokenType.EndObject)
+        {
+            var key = reader.GetString()!;
+            reader.Read();
+            map[key] = Read(ref reader, typeof(object), options);
+        }
+        return map;
+    }
+
+    public override void Write(Utf8JsonWriter writer, object value, JsonSerializerOptions options) =>
+        JsonSerializer.Serialize(writer, value, value.GetType(), options);
+}

--- a/src/backend/AgentSmith.Application/Services/Tools/WriteContextYamlToolHost.cs
+++ b/src/backend/AgentSmith.Application/Services/Tools/WriteContextYamlToolHost.cs
@@ -56,7 +56,8 @@ public sealed class WriteContextYamlToolHost : IToolHost
                      "stack?: { lang?, image?, resources?, runtime?, infra?, testing?, frameworks?, sdks? }, " +
                      "arch?: object, quality?: object, behavior?: object }. " +
                      "meta.workdir is REQUIRED — '.' for single-stack, otherwise the sub-tree path. " +
-                     "stack.image is the exact toolchain Docker image whose runtime can BOTH build " +
+                     "stack.image is REQUIRED whenever a stack is present — the exact toolchain Docker " +
+                     "image whose runtime can BOTH build " +
                      "AND run this stack's tests (e.g. mcr.microsoft.com/dotnet/sdk:8.0, node:20-bookworm); " +
                      "name it from a trusted hub and pick a git-bearing tag (full -bookworm/-bullseye, an " +
                      "mcr .../sdk tag, or buildpack-deps:...-scm — never -slim/-alpine). " +
@@ -87,9 +88,22 @@ public sealed class WriteContextYamlToolHost : IToolHost
             return $"Error: document is not a valid context.yaml shape — {ex.Message}";
         }
 
+        // Serialize first: it validates the fundamental meta.workdir requirement.
         string yaml;
         try { yaml = _serializer.Serialize(typed); }
         catch (InvalidOperationException ex) { return $"Error: {ex.Message}"; }
+
+        // stack.image is mandatory whenever a stack is described: the toolchain
+        // image the sandbox builds + tests this stack in must be named explicitly,
+        // not left to the weaker language→image fallback table. Fail loud so the
+        // agent re-emits with an exact image rather than silently shipping a
+        // context.yaml the resolver has to guess an image for.
+        if (typed.Stack is not null && string.IsNullOrWhiteSpace(typed.Stack.Image))
+            return "Error: stack.image is required — name the exact toolchain Docker image whose "
+                 + "runtime can BOTH build AND run this stack's tests (e.g. "
+                 + "mcr.microsoft.com/dotnet/sdk:8.0, node:20-bookworm). Pick a git-bearing tag "
+                 + "(full -bookworm/-bullseye, an mcr .../sdk tag, or buildpack-deps:...-scm — "
+                 + "never -slim/-alpine).";
 
         if (!TryResolveSandbox(repo, out var sandbox, out var err))
             return err!;
@@ -120,5 +134,9 @@ public sealed class WriteContextYamlToolHost : IToolHost
     {
         PropertyNameCaseInsensitive = true,
         PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        // Deserialize arch/quality/behavior (IDictionary<string, object?>) into plain
+        // CLR types, not JsonElement, so the YAML serializer emits real values instead
+        // of a `value_kind: String` type wrapper.
+        Converters = { new InferredTypeJsonConverter() },
     };
 }

--- a/tests/AgentSmith.PipelineHarness/Presets/InitProjectTests.cs
+++ b/tests/AgentSmith.PipelineHarness/Presets/InitProjectTests.cs
@@ -49,7 +49,7 @@ public sealed class InitProjectTests
             // p0193-fix: BootstrapRound fails loudly unless context.yaml exists on
             // the sandbox after the round — script the typed write path too.
             .EnqueueToolCall("write_context_yaml",
-                """{"repo":"","context_name":"default","document":{"meta":{"workdir":"."},"stack":{"lang":"csharp"}}}""")
+                """{"repo":"","context_name":"default","document":{"meta":{"workdir":"."},"stack":{"lang":"csharp","image":"mcr.microsoft.com/dotnet/sdk:8.0"}}}""")
             .EnqueueText("Bootstrap files written.");
     }
 }

--- a/tests/AgentSmith.Tests/Application/Services/Tools/WriteContextYamlToolHostTests.cs
+++ b/tests/AgentSmith.Tests/Application/Services/Tools/WriteContextYamlToolHostTests.cs
@@ -32,7 +32,7 @@ public sealed class WriteContextYamlToolHostTests
         var document = JsonDocument.Parse("""
             {
               "meta": { "workdir": "src/Client", "project": "AuthClient", "type": "Angular SPA" },
-              "stack": { "lang": "TypeScript", "sdks": ["@azure/msal-angular", "rxjs"] }
+              "stack": { "lang": "TypeScript", "image": "node:20-bookworm", "sdks": ["@azure/msal-angular", "rxjs"] }
             }
             """).RootElement;
 
@@ -87,6 +87,50 @@ public sealed class WriteContextYamlToolHostTests
         var result = await sut.WriteContextYaml(repo: "missing", context_name: "default", document);
 
         result.Should().Contain("unknown repo 'missing'");
+    }
+
+    [Fact]
+    public async Task WriteContextYaml_ArchAndQuality_SerializeRealValues_NotValueKindPlaceholders()
+    {
+        var sut = BuildHost();
+        var document = JsonDocument.Parse("""
+            {
+              "meta": { "workdir": ".", "project": "Listener" },
+              "stack": { "lang": "C#", "image": "mcr.microsoft.com/dotnet/sdk:8.0" },
+              "arch": { "style": "Worker Service", "patterns": ["Mediator", "Generic Host"] },
+              "quality": { "lang": "C#" }
+            }
+            """).RootElement;
+
+        Step? captured = null;
+        _sandboxMock.Setup(s => s.RunStepAsync(
+                It.IsAny<Step>(), It.IsAny<IProgress<StepEvent>?>(), It.IsAny<CancellationToken>()))
+            .Returns<Step, IProgress<StepEvent>?, CancellationToken>((step, _, _) =>
+            {
+                captured = step;
+                return Task.FromResult(new StepResult(StepResult.CurrentSchemaVersion, step.StepId, 0, false, 0.1, null));
+            });
+
+        var result = await sut.WriteContextYaml(repo: "client", context_name: "listener", document);
+
+        result.Should().StartWith("context.yaml written:");
+        captured!.Content.Should().NotContain("value_kind", "arch/quality values must serialize as real content");
+        captured.Content.Should().Contain("Worker Service");
+        captured.Content.Should().Contain("Mediator");
+    }
+
+    [Fact]
+    public async Task WriteContextYaml_StackWithoutImage_ReturnsError()
+    {
+        var sut = BuildHost();
+        var document = JsonDocument.Parse("""
+            { "meta": { "workdir": "." }, "stack": { "lang": "C#", "runtime": ".NET 8" } }
+            """).RootElement;
+
+        var result = await sut.WriteContextYaml(repo: "client", context_name: "default", document);
+
+        result.Should().StartWith("Error:");
+        result.Should().Contain("stack.image is required");
     }
 
     [Fact]


### PR DESCRIPTION
Two defects in the `write_context_yaml` path (init-project / bootstrap), found while reviewing real init PRs.

## 1. arch/quality/behavior serialized as `value_kind: String/Array` placeholders
The generated context.yaml lost its architecture/quality content — the sections came out as type-wrapper placeholders instead of real values (visible in real init PRs as empty `arch:`/`quality:`).

**Root cause:** `ContextYamlDocument.Arch/Quality/Behavior` are `IDictionary<string, object?>` pass-through. `JsonSerializer.Deserialize` left their values as `JsonElement`, and YamlDotNet serializes a `JsonElement` by reflecting its public properties → `value_kind: String`. **Fix:** a new `InferredTypeJsonConverter` deserializes `object`-typed values into plain CLR types (string/double/bool/List/Dictionary), closing the round-trip.

Intermittent because it only bites when the LLM routes arch/quality through the typed tool — but when it does, the whole section is garbage.

## 2. `stack.image` is now mandatory whenever a stack is present
It was optional, falling back to the weaker language→image convention table — which left some generated contexts with no explicit image (asymmetric diffs; the resolver had to guess). The tool now **fails loud** so the agent re-emits with the exact toolchain image. This matches what `context-generator-master` already instructs (*'You MUST name the toolchain Docker image'*), so no skill change is needed — the backend now enforces the existing contract. Docs-only contexts (no `stack`) are unaffected.

## Tests
value_kind round-trip (arch/quality preserved, no `value_kind` in output), stack-without-image rejection; happy-path + init harness updated to carry an image. Full suite **3067 green** (+2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)