### PR TITLE
fix(ci): build dashboard image amd64-only

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -70,9 +70,11 @@ jobs:
           - image: agent-smith-cli
             dockerfile: src/backend/AgentSmith.Cli/Dockerfile
             publish: always
+            platforms: linux/amd64,linux/arm64
           - image: agent-smith-server
             dockerfile: src/backend/AgentSmith.Server/Dockerfile
             publish: always
+            platforms: linux/amd64,linux/arm64
           # Sandbox carrier image consumed by the server's spawner as an init-
           # container. Was originally gated to v* tags only (p0115) under the
           # assumption that release-please's tag pushes would re-trigger this
@@ -84,15 +86,24 @@ jobs:
           - image: agent-smith-sandbox-agent
             dockerfile: src/backend/AgentSmith.Sandbox.Agent/Dockerfile
             publish: always
+            platforms: linux/amd64,linux/arm64
           # p0235: the dashboard (Next.js) image. It used to live in a separate
           # dashboard.yml whose publish-image was gated `if: refs/tags/v*` — and
           # since release-please tags never fire workflows (see the note above),
           # the dashboard image was NEVER pushed. Folding it into this matrix
           # with publish: always puts it on the same per-main-push rhythm as the
           # others — and in the same run, where operators look for it.
+          #
+          # amd64-only: the Next.js `next build` does not complete under
+          # QEMU-emulated arm64 (never reaches "Compiled successfully"), so
+          # `.next/standalone` is never produced and the runtime-stage COPY
+          # fails with "not found". The deploy target (AKS) is amd64, so arm64
+          # buys nothing here — unlike the .NET legs, which build multi-arch
+          # cleanly. Build this leg for linux/amd64 only.
           - image: agentsmith-dashboard
             dockerfile: src/dashboard/Dockerfile
             publish: always
+            platforms: linux/amd64
     permissions:
       contents: read
       packages: write
@@ -155,7 +166,7 @@ jobs:
         with:
           context: .
           file: ${{ matrix.dockerfile }}
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.platforms }}
           push: ${{ github.event_name != 'pull_request' && (matrix.publish == 'always' || (matrix.publish == 'tags' && startsWith(github.ref, 'refs/tags/v'))) }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Problem
The **Docker Build & Publish** job fails on every release-please PR (e.g. `chore(main): release 0.107.0`), which is what makes the release pipeline go red.

Root cause: the `agentsmith-dashboard` leg was folded into the shared `docker` matrix (p0235), which builds every image with `platforms: linux/amd64,linux/arm64`. The Next.js `next build` **does not complete under QEMU-emulated arm64** — the log shows only `Creating an optimized production build …`, never `✓ Compiled successfully`. As a result `.next/standalone` is never produced for arm64, and the runtime stage fails:

```
COPY --from=build /repo/src/dashboard/.next/standalone ./
ERROR: failed to calculate checksum ... "/repo/src/dashboard/.next/standalone": not found
```

amd64 builds fine; it is purely the arm64 emulation that breaks the Next build.

## Fix
Make `platforms` a per-matrix-entry field:
- `.NET` images (cli / server / sandbox-agent) keep `linux/amd64,linux/arm64` — they build multi-arch cleanly.
- `agentsmith-dashboard` builds `linux/amd64` only.

The deploy target (AKS) is amd64, so arm64 buys nothing for the dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)