### PR TITLE
fix: working-status ticket comment posts once per logical run, not per capacity relaunch

### DIFF
--- a/src/backend/AgentSmith.Application/Services/ExecutePipelineUseCase.cs
+++ b/src/backend/AgentSmith.Application/Services/ExecutePipelineUseCase.cs
@@ -91,6 +91,12 @@ public sealed class ExecutePipelineUseCase(
         pipeline.Set<IReadOnlyList<RepoConnection>>(ContextKeys.Repos, repos);
         pipeline.Set(ContextKeys.ResolvedPipeline, resolved);
         pipeline.Set(ContextKeys.Headless, request.Headless);
+        // A provided RunId means this launch REUSES an existing run row (p0320c
+        // capacity-queue relaunch): every attempt of the same logical run must not
+        // repeat one-shot ticket side effects like the "working on it" comment —
+        // a capacity-starved ticket otherwise collects one comment per retry.
+        if (request.RunId is not null)
+            pipeline.Set(ContextKeys.RelaunchedRun, true);
         pipeline.Set(ContextKeys.PipelineTypeName, PipelinePresets.GetPipelineType(request.PipelineName));
         pipeline.Set(ContextKeys.PipelineName, request.PipelineName);
         pipeline.Set(ContextKeys.ConfigDir, Path.GetDirectoryName(Path.GetFullPath(configPath)) ?? ".");

--- a/src/backend/AgentSmith.Application/Services/PipelineExecutor.cs
+++ b/src/backend/AgentSmith.Application/Services/PipelineExecutor.cs
@@ -32,7 +32,11 @@ public sealed class PipelineExecutor(
         for (var i = 0; i < commandNames.Count; i++)
             logger.LogInformation("  [{Index}/{Total}] {Command}", i + 1, commandNames.Count, commandNames[i]);
 
-        await errorHandler.PostWorkingStatusAsync(projectConfig, context, cancellationToken);
+        // The "working on it" ticket comment is a one-shot per logical run: a
+        // capacity-queue relaunch (reused run row) must not post it again — a
+        // starved ticket otherwise collects one comment per retry cycle.
+        if (!context.TryGet<bool>(ContextKeys.RelaunchedRun, out var relaunched) || !relaunched)
+            await errorHandler.PostWorkingStatusAsync(projectConfig, context, cancellationToken);
         await using var lifecycle = await lifecycleCoordinator.BeginAsync(projectConfig, context, cancellationToken);
         await using var sandbox = serviceProvider.GetRequiredService<IPipelineSandboxCoordinator>();
         try { return await RunLoopAsync(commandNames, projectConfig, context, lifecycle, sandbox, cancellationToken); }

--- a/src/backend/AgentSmith.Contracts/Commands/ContextKeys.cs
+++ b/src/backend/AgentSmith.Contracts/Commands/ContextKeys.cs
@@ -94,6 +94,9 @@ public static partial class ContextKeys
     public const string CodeMap = "CodeMap";
     public const string ProjectContext = "ProjectContext";
     public const string Headless = "Headless";
+    // True when this launch reuses an existing run row (capacity-queue relaunch,
+    // p0320c): one-shot ticket side effects (working-comment) must not repeat.
+    public const string RelaunchedRun = "RelaunchedRun";
     public const string ConfigDir = "ConfigDir";
 
     public const string SourceType = "SourceType";

--- a/tests/AgentSmith.Tests/Services/PipelineExecutorTests.cs
+++ b/tests/AgentSmith.Tests/Services/PipelineExecutorTests.cs
@@ -56,6 +56,27 @@ public class PipelineExecutorTests
     }
 
     [Fact]
+    public async Task ExecuteAsync_RelaunchedRun_DoesNotRepeatWorkingStatusComment()
+    {
+        // A capacity-queue relaunch reuses the run row (p0320c) — every retry of the
+        // same logical run posting "working on it" flooded starved tickets with one
+        // comment per cycle (observed: 528 comments on one ticket).
+        var h = new PipelineExecutorTestBuilder();
+        var ticketProviderMock = new Mock<ITicketProvider>();
+        h.TicketFactoryMock.Setup(f => f.Create(It.IsAny<TrackerConnection>()))
+            .Returns(ticketProviderMock.Object);
+
+        var pipeline = new PipelineContext();
+        pipeline.Set(ContextKeys.TicketId, new TicketId("42"));
+        pipeline.Set(ContextKeys.RelaunchedRun, true);
+
+        await h.Sut.ExecuteAsync(Array.Empty<string>(), new ResolvedProject(), pipeline, CancellationToken.None);
+
+        ticketProviderMock.Verify(t => t.UpdateStatusAsync(
+            It.IsAny<TicketId>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
     public async Task ExecuteAsync_TicketStatusFailure_DoesNotBlockPipeline()
     {
         var h = new PipelineExecutorTestBuilder();


### PR DESCRIPTION
## Why

When resources are insufficient at claim time, the capacity queue relaunches the reserved run every few minutes — and every relaunch re-entered `PipelineExecutor`, which posts the "Agent Smith is working on this issue..." ticket comment unconditionally. A capacity-starved ticket collected **528 comments**.

## What

- A provided `PipelineRequest.RunId` means the launch REUSES an existing run row (p0320c capacity relaunch; p0327 resumes on the batch branch carry it too) — `ExecutePipelineUseCase` stamps `ContextKeys.RelaunchedRun`.
- `PipelineExecutor` posts the working comment only when the flag is absent: one comment per logical run, on the first attempt.

## Verification

- Build 0 errors; `AgentSmith.Tests` 2993/2993 (new: `ExecuteAsync_RelaunchedRun_DoesNotRepeatWorkingStatusComment`); PipelineHarness fast tier 72/72.

Note: merges cleanly with #396's p0327 resume path (resumes also carry a RunId and correctly skip the repeat comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)