### PR TITLE
fix: release publish — keep RID/publish globals out of the skills-packaging tool (NETSDK1047)

### DIFF
--- a/src/backend/AgentSmith.Infrastructure.Core/AgentSmith.Infrastructure.Core.csproj
+++ b/src/backend/AgentSmith.Infrastructure.Core/AgentSmith.Infrastructure.Core.csproj
@@ -5,11 +5,15 @@
     <ProjectReference Include="..\AgentSmith.Domain\AgentSmith.Domain.csproj" />
     <!-- p0325: build-only reference — guarantees the packaging validator is
          restored + built before ValidateSkillsCatalog runs. Its output is
-         never shipped with this assembly. -->
+         never shipped with this assembly. The RID/publish globals of a
+         self-contained single-file publish must NOT flow into the tool: it is
+         restored RID-less, and an inherited SelfContained+PublishSingleFile
+         would infer the HOST RID (NETSDK1047 on the release publish). -->
     <ProjectReference Include="..\AgentSmith.SkillsPackaging\AgentSmith.SkillsPackaging.csproj"
                       ReferenceOutputAssembly="false"
                       Private="false"
-                      OutputItemType="SkillsPackagingTool" />
+                      OutputItemType="SkillsPackagingTool"
+                      UndefineProperties="RuntimeIdentifier;RuntimeIdentifiers;SelfContained;PublishSingleFile;PublishReadyToRun;PublishTrimmed;IncludeNativeLibrariesForSelfExtract" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Why

Every release-binary job (v0.109.0) failed with NETSDK1047: `dotnet publish -r <rid> --self-contained -p:PublishSingleFile=true` flows the global `SelfContained`/`PublishSingleFile` into the p0325 build-only `AgentSmith.SkillsPackaging` reference. That project restores RID-less, the inherited globals make it infer the HOST rid (arm64 runner) → assets mismatch.

## What

`UndefineProperties="RuntimeIdentifier;RuntimeIdentifiers;SelfContained;PublishSingleFile;PublishReadyToRun;PublishTrimmed;IncludeNativeLibrariesForSelfExtract"` on the ProjectReference — the validator builds RID-agnostic, exactly as restored.

## Verification

- Reproduced locally with the exact CI invocation (fails before, passes after; single-file binary produced)
- `dotnet build` 0 errors, `AgentSmith.Tests` all green (validator target still runs)

After merge: re-run the failed v0.109.0 release workflow (or let release-please cut the next tag) so the binaries get uploaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)