### PR TITLE
fix: pipeline hardening (execute-prompt tokens, rate estimate, AzDO PR limit, plan-decision noise)

### DIFF
--- a/src/backend/AgentSmith.Application/Services/Handlers/GeneratePlanHandler.cs
+++ b/src/backend/AgentSmith.Application/Services/Handlers/GeneratePlanHandler.cs
@@ -119,12 +119,15 @@ public sealed class GeneratePlanHandler(
 
     // p0276b: GeneratePlan runs SERVER-side, but for sandbox coding presets the repo
     // lives in the sandbox (repo.LocalPath = "/work"), which the server cannot write
-    // to (UnauthorizedAccessException). The decision-FILE write is best-effort: the
-    // decision still surfaces via AppendDecisions + the plan handed to the master, so
-    // a denied repo path must not fail the run.
+    // to. The decision still surfaces via AppendDecisions + the plan handed to the
+    // master, so the FILE write is best-effort — only attempt it when the repo is a
+    // real server-side checkout (the path exists on THIS filesystem). This skips the
+    // guaranteed-to-fail "/work" write silently instead of logging a stack trace per
+    // decision (10x per run in the spawned-orchestrator model).
     private async Task TryWriteDecisionFileAsync(
         string? repoPath, DecisionCategory category, string decision, string sourceLabel, CancellationToken ct)
     {
+        if (string.IsNullOrEmpty(repoPath) || !Directory.Exists(repoPath)) return;
         try
         {
             await decisionLogger.LogAsync(repoPath, category, decision, ct, sourceLabel);
@@ -132,8 +135,8 @@ public sealed class GeneratePlanHandler(
         catch (Exception ex)
         {
             logger.LogWarning(ex,
-                "GeneratePlan: could not write the decision file to '{Path}' (sandbox repo not on the "
-                + "server filesystem?); the decision is surfaced via the event stream instead.", repoPath);
+                "GeneratePlan: could not write the decision file to '{Path}'; the decision is "
+                + "surfaced via the event stream instead.", repoPath);
         }
     }
 }

--- a/src/backend/AgentSmith.Application/Services/Prompts/AgentPromptBuilder.cs
+++ b/src/backend/AgentSmith.Application/Services/Prompts/AgentPromptBuilder.cs
@@ -97,10 +97,18 @@ public sealed class AgentPromptBuilder(IPromptCatalog prompts)
             ["ProjectContextSection"] = BuildProjectContextSection(projectContext),
             ["CodingPrinciples"] = codingPrinciples,
             ["CodeMapSection"] = BuildCodeMapSection(codeMap),
-            // p0328: agent-execute-system resolves to the coding master via the
-            // NameMap — supply the token so a skills version that references
-            // {ExpectationSection} never renders it unbound on this path.
+            // agent-execute-system resolves to the coding master via the NameMap.
+            // The master body owns a self-contained plan+execute+fix loop and so
+            // references the AgenticMaster-only tokens below; the secondary callers
+            // of this method (GenerateTests / GenerateDocs / AgenticExecute) do not
+            // supply them, so bind every KNOWN master token here (empty is fine —
+            // strict Render only rejects an UNBOUND token) rather than crash with
+            // "unbound master token(s): RepoNames, PlanSection, ...".
             ["ExpectationSection"] = string.Empty,
+            ["RepoNames"] = string.Empty,
+            ["PlanSection"] = string.Empty,
+            ["RunRecordDir"] = string.Empty,
+            ["MaxFixIterations"] = string.Empty,
         });
     }
 

--- a/src/backend/AgentSmith.Infrastructure/Services/Providers/Source/AzureReposSourceProvider.cs
+++ b/src/backend/AgentSmith.Infrastructure/Services/Providers/Source/AzureReposSourceProvider.cs
@@ -54,6 +54,20 @@ public sealed class AzureReposSourceProvider(
         return new Repository(target, _cloneUrl);
     }
 
+    // Azure DevOps rejects a PR whose description exceeds 4000 characters
+    // ("A description for a pull request must not be longer than 4000
+    // characters."). A multi-repo run record easily blows past it; truncate with
+    // a visible marker so the PR still opens — the full record lives in result.md.
+    internal const int MaxDescriptionChars = 4000;
+
+    internal static string TruncateDescription(string? description)
+    {
+        if (string.IsNullOrEmpty(description) || description.Length <= MaxDescriptionChars)
+            return description ?? string.Empty;
+        const string marker = "\n\n… (truncated — see result.md for the full record)";
+        return string.Concat(description.AsSpan(0, MaxDescriptionChars - marker.Length), marker);
+    }
+
     public async Task<string> CreatePullRequestAsync(
         Repository repository, string title, string description,
         CancellationToken cancellationToken,
@@ -64,7 +78,7 @@ public sealed class AzureReposSourceProvider(
         var tgt = $"refs/heads/{await GetDefaultBranchAsync(cancellationToken)}";
         var pr = new GitPullRequest
         {
-            Title = title, Description = description,
+            Title = title, Description = TruncateDescription(description),
             SourceRefName = src, TargetRefName = tgt,
             IsDraft = isDraft
         };

--- a/src/backend/AgentSmith.Infrastructure/Services/RateLimiting/RateLimitingChatClient.cs
+++ b/src/backend/AgentSmith.Infrastructure/Services/RateLimiting/RateLimitingChatClient.cs
@@ -62,20 +62,39 @@ internal sealed class RateLimitingChatClient : DelegatingChatClient
         }
     }
 
-    private static int EstimateInputTokens(IEnumerable<ChatMessage> messages)
+    // Internal for direct unit testing of the estimate.
+    internal static int EstimateInputTokens(IEnumerable<ChatMessage> messages)
     {
         var chars = 0;
         foreach (var m in messages)
         {
             if (m.Contents is null) continue;
             foreach (var c in m.Contents)
-            {
-                if (c is TextContent tc && tc.Text is { } t)
-                {
-                    chars += t.Length;
-                }
-            }
+                chars += EstimateContentChars(c);
         }
         return Math.Max(1, chars / CharsPerToken);
+    }
+
+    // An agentic loop re-sends the WHOLE conversation each turn, and the bulk of
+    // it is tool traffic — the model's function calls and, above all, the tool
+    // RESULTS (grep output, file reads). Counting only TextContent undercounted
+    // the input ~7x on a large coding run (25k estimated vs ~190k actual), so the
+    // limiter throttled on a fiction while the real per-minute load blew past the
+    // provider quota. Count every content kind by its rendered length.
+    private static int EstimateContentChars(AIContent content) => content switch
+    {
+        TextContent t => t.Text?.Length ?? 0,
+        FunctionCallContent call => (call.Name?.Length ?? 0) + ArgumentsLength(call.Arguments),
+        FunctionResultContent result => result.Result?.ToString()?.Length ?? 0,
+        _ => 0,
+    };
+
+    private static int ArgumentsLength(IDictionary<string, object?>? arguments)
+    {
+        if (arguments is null) return 0;
+        var chars = 0;
+        foreach (var (key, value) in arguments)
+            chars += key.Length + (value?.ToString()?.Length ?? 0);
+        return chars;
     }
 }

--- a/tests/AgentSmith.Tests/Infrastructure/AzureReposPrDescriptionTests.cs
+++ b/tests/AgentSmith.Tests/Infrastructure/AzureReposPrDescriptionTests.cs
@@ -1,0 +1,33 @@
+using AgentSmith.Infrastructure.Services.Providers.Source;
+using FluentAssertions;
+
+namespace AgentSmith.Tests.Infrastructure;
+
+/// <summary>
+/// Regression: Azure DevOps rejects a PR whose description exceeds 4000
+/// characters. A multi-repo run record easily exceeds it; the description is
+/// truncated with a marker so the PR still opens.
+/// </summary>
+public sealed class AzureReposPrDescriptionTests
+{
+    [Fact]
+    public void TruncateDescription_OverLimit_TruncatesToLimitWithMarker()
+    {
+        var result = AzureReposSourceProvider.TruncateDescription(new string('a', 5000));
+
+        result.Length.Should().BeLessThanOrEqualTo(AzureReposSourceProvider.MaxDescriptionChars);
+        result.Should().EndWith("full record)");
+    }
+
+    [Fact]
+    public void TruncateDescription_UnderLimit_ReturnsUnchanged()
+    {
+        AzureReposSourceProvider.TruncateDescription("short body").Should().Be("short body");
+    }
+
+    [Fact]
+    public void TruncateDescription_Null_ReturnsEmpty()
+    {
+        AzureReposSourceProvider.TruncateDescription(null).Should().BeEmpty();
+    }
+}

--- a/tests/AgentSmith.Tests/Infrastructure/RateLimitInputEstimateTests.cs
+++ b/tests/AgentSmith.Tests/Infrastructure/RateLimitInputEstimateTests.cs
@@ -1,0 +1,45 @@
+using AgentSmith.Infrastructure.Services.RateLimiting;
+using FluentAssertions;
+using Microsoft.Extensions.AI;
+
+namespace AgentSmith.Tests.Infrastructure;
+
+/// <summary>
+/// Regression: an agentic loop re-sends the whole conversation each turn, and the
+/// bulk is tool traffic (function calls + tool RESULTS). The old estimator counted
+/// only TextContent, undercounting ~7x (25k estimated vs ~190k actual on a real
+/// coding run), so the limiter throttled on a fiction while real load blew past
+/// the provider quota. The estimate must include tool-call and tool-result content.
+/// </summary>
+public sealed class RateLimitInputEstimateTests
+{
+    [Fact]
+    public void EstimateInputTokens_IncludesToolResults_NotJustText()
+    {
+        var textOnly = new[] { new ChatMessage(ChatRole.User, "hello") };
+        var withToolResult = new[]
+        {
+            new ChatMessage(ChatRole.User, "hello"),
+            new ChatMessage(ChatRole.Tool,
+                new List<AIContent> { new FunctionResultContent("call-1", new string('x', 4000)) }),
+        };
+
+        var textEstimate = RateLimitingChatClient.EstimateInputTokens(textOnly);
+        var toolEstimate = RateLimitingChatClient.EstimateInputTokens(withToolResult);
+
+        // 4000 chars / 4 chars-per-token ≈ 1000 tokens the old estimator ignored.
+        toolEstimate.Should().BeGreaterThan(textEstimate + 900,
+            "a large tool result must count toward the input-token estimate");
+    }
+
+    [Fact]
+    public void EstimateInputTokens_IncludesFunctionCallArguments()
+    {
+        var call = new FunctionCallContent("call-1", "run_command",
+            new Dictionary<string, object?> { ["command"] = new string('y', 2000) });
+        var messages = new[] { new ChatMessage(ChatRole.Assistant, new List<AIContent> { call }) };
+
+        RateLimitingChatClient.EstimateInputTokens(messages)
+            .Should().BeGreaterThan(400, "the 2000-char command argument must be counted");
+    }
+}

--- a/tests/AgentSmith.Tests/Prompts/AgentPromptBuilderTokenTests.cs
+++ b/tests/AgentSmith.Tests/Prompts/AgentPromptBuilderTokenTests.cs
@@ -1,0 +1,40 @@
+using AgentSmith.Application.Prompts;
+using AgentSmith.Application.Services.Prompts;
+using AgentSmith.Contracts.Services;
+using FluentAssertions;
+
+namespace AgentSmith.Tests.Prompts;
+
+/// <summary>
+/// Regression: agent-execute-system resolves to the coding master, whose body
+/// references the AgenticMaster-only tokens (RepoNames / PlanSection /
+/// RunRecordDir / MaxFixIterations). GenerateTests / GenerateDocs / AgenticExecute
+/// all render it via BuildExecutionSystemPrompt, which must bind EVERY known
+/// master token or strict Render throws "unbound master token(s)".
+/// </summary>
+public sealed class AgentPromptBuilderTokenTests
+{
+    private sealed class CapturingCatalog : IPromptCatalog
+    {
+        public IReadOnlyDictionary<string, string>? Captured { get; private set; }
+        public string Get(string name) => name;
+        public string Render(string name, IReadOnlyDictionary<string, string> tokens)
+        {
+            Captured = tokens;
+            return string.Empty;
+        }
+    }
+
+    [Fact]
+    public void BuildExecutionSystemPrompt_BindsEveryKnownMasterToken()
+    {
+        var catalog = new CapturingCatalog();
+
+        new AgentPromptBuilder(catalog).BuildExecutionSystemPrompt("principles", "code-map", "context");
+
+        catalog.Captured.Should().NotBeNull();
+        foreach (var token in MasterPromptTokens.All)
+            catalog.Captured!.Should().ContainKey(token,
+                "the coding master may reference {{{0}}} and strict Render rejects an unbound token", token);
+    }
+}


### PR DESCRIPTION
Four independent defects surfaced by a real DAP `add-feature` run (MediatR→Mediator / MassTransit→Wolverine migration). None are related to p0336/p0336b — all are pre-existing in 0.110.0.

## 1. Execute-prompt token crash (the recorded pipeline failure)
`GenerateTests` / `GenerateDocs` / `AgenticExecute` crashed with:
```
Prompt 'agent-execute-system' has unbound master token(s): RepoNames, PlanSection, RunRecordDir, MaxFixIterations
```
`agent-execute-system` resolves (NameMap) to the **coding master**, whose body owns a self-contained plan+execute+fix loop and references those tokens — only `AgenticMasterHandler` supplied them. `AgentPromptBuilder.BuildExecutionSystemPrompt` now binds **every known master token** (empty is fine; strict `Render` only rejects an *unbound* token). Follows the existing `ExpectationSection` precedent.

## 2. Rate-limiter input estimate undercounted ~7×
`EstimateInputTokens` counted only `TextContent`, ignoring function-call arguments and, above all, tool **results** (grep output, file reads) — the bulk of an agentic conversation. It reported ~25k while the real per-call input was ~190k, so the limiter throttled on a fiction while real load blew past the Azure quota. Now counts tool-call + tool-result content.

## 3. Azure DevOps PR description > 4000 chars
AzDO rejects a PR description over 4000 chars; a multi-repo run record exceeded it and the record PR failed to open. The description is truncated with a marker (full record stays in `result.md`).

## 4. GeneratePlan decision-file stack-trace spam
GeneratePlan logged a full stack trace **per decision** (10×/run) trying to write a decision file to the sandbox path `/work` the server can't reach. The write is now attempted only for a real server-side checkout (`Directory.Exists`); the decision still surfaces via the event stream.

## Tests
**3099 backend tests green** — 6 new: every-master-token binding, estimator counts tool results + call args, AzDO description truncation.

## Note (not in this PR — config/ops)
The Azure gpt-5.1 deployment is **250k TPM** (GlobalStandard). Even with fix #2, a ~190k-token/call context allows only ~1.3 such calls/min at that quota — a big migration needs more Azure quota and/or less per-call context (context-scoping #403 + compaction). The `rate_limit` override was set in the operator's k8s configmap (not committed here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)