### PR TITLE
fix: repoint homepage 'Get started' links to a live docs page (p0338)

### DIFF
--- a/website/src/index.njk
+++ b/website/src/index.njk
@@ -24,7 +24,7 @@
   </ul>
   <div class="nav-cta">
     <a href="https://github.com/{{ site.githubRepo }}" class="btn btn-text">GitHub</a>
-    <a href="{{ site.docsUrl }}/getting-started/" class="btn btn-primary">Get started</a>
+    <a href="{{ site.docsUrl }}/get-it-running/install/" class="btn btn-primary">Get started</a>
   </div>
 </nav>
 
@@ -134,9 +134,9 @@
 <section class="cta-section">
   <div class="section-wrap section-narrow">
     <h2 class="cta-title">Have a look</h2>
-    <p class="cta-sub">First bug fix in about five minutes if your Docker is set up. The getting-started guide walks through it.</p>
+    <p class="cta-sub">First bug fix in about five minutes if your Docker is set up. The install guide walks through it.</p>
     <div class="cta-actions">
-      <a href="{{ site.docsUrl }}/getting-started/" class="btn btn-on-dark">Get started</a>
+      <a href="{{ site.docsUrl }}/get-it-running/install/" class="btn btn-on-dark">Get started</a>
       <a href="https://github.com/{{ site.githubRepo }}" class="btn btn-secondary-on-dark">View on GitHub</a>
     </div>
   </div>


### PR DESCRIPTION
The two "Get started" buttons on the marketing homepage — the nav CTA and the "Have a look" footer CTA — pointed at `docs.agent-smith.org/getting-started/`, a path removed in the p0335 docs restructure (docs now use `get-it-running/`). Both **404'd**. The hero button already used `/get-it-running/install/`; this repoints the other two to match, so all three are consistent and land on a live page. The stale "getting-started guide" prose is aligned to "install guide".

**Corrects the p0338 tracking assumption:** the marketing site is not a separate repo — it lives in `website/` (Eleventy) in this checkout, next to the docs (`docs/`, MkDocs). Both are fixable here (p0338 was closed as external tracking-only; that was wrong).

🤖 Generated with [Claude Code](https://claude.com/claude-code)