### PR TITLE
fix(dashboard): trace drawer detail pane is the wide reading area (was too thin)

### DIFF
--- a/src/dashboard/src/app/jobs/[id]/page.tsx
+++ b/src/dashboard/src/app/jobs/[id]/page.tsx
@@ -203,11 +203,7 @@ function RunDetail({ runId }: { runId: string }) {
           </button>
         </div>
         <div className="drawer-b" style={{ padding: 0, flex: 1 }}>
-          <div
-            data-testid="trace-master-detail"
-            className="grid h-full grid-cols-1 md:grid-cols-[300px_1fr]"
-            style={{ display: "grid" }}
-          >
+          <div data-testid="trace-master-detail" className="trace-grid">
             <NavRail nodes={nodes} overview={overviewItems} selection={selection} />
             <Detail
               selected={selection.selected}

--- a/src/dashboard/src/styles/mock-parity.css
+++ b/src/dashboard/src/styles/mock-parity.css
@@ -556,7 +556,16 @@
    parity-port helpers (documented additions — NOT from the mocks)
    ========================================================================= */
 /* the trace drawer hosts the existing NavRail+DetailPane master/detail */
-.mock-viewer .drawer.wide { width: min(1100px, 96vw); }
+.mock-viewer .drawer.wide { width: min(1320px, 96vw); }
+
+/* p0343e: the trace drawer hosts the master/detail — the step INDEX is a fixed
+   narrow rail, the selected node's content is the WIDE reading pane (the Tailwind
+   grid template was being overridden, collapsing to content-sized auto columns
+   → a too-thin detail). Explicit unlayered grid wins deterministically. */
+.mock-viewer .trace-grid { display: grid; height: 100%; grid-template-columns: 300px minmax(0, 1fr); min-height: 0; }
+.mock-viewer .trace-grid > :first-child { overflow-y: auto; }
+.mock-viewer .trace-grid > :last-child { min-width: 0; overflow: auto; }
+@media (max-width: 760px) { .mock-viewer .trace-grid { grid-template-columns: 1fr; } }
 /* idle variants for the honest liveness states the mock hard-coded green */
 .mock-shell .tracker-foot .td.idle { background: var(--idle); }
 .mock-runs .inflow .id.idle { background: var(--idle); color: var(--idle); animation: none; }


### PR DESCRIPTION
The Full-pipeline drawer hosts the existing NavRail + DetailPane. The Tailwind grid template was overridden → the grid collapsed to content-sized auto columns, so the step index ate the width and the actual detail (Result/Plan/tool output) rendered as a thin sliver (operator: "der rechte bereich ist etwas dünn").

Fix: pin the drawer's master/detail with an explicit unlayered grid — `300px` step index + `minmax(0,1fr)` detail — and widen the drawer to 1320px so the reading pane has room. 31 story/trace tests + `next build` green.

After merge: `docker compose -f deploy/docker-compose.yml --profile dashboard up -d --build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)