### PR TITLE
fix: re-run checks out the existing ticket branch, building on prior …

### DIFF
--- a/src/backend/AgentSmith.Application/Services/Handlers/SandboxRepoCloner.cs
+++ b/src/backend/AgentSmith.Application/Services/Handlers/SandboxRepoCloner.cs
@@ -42,7 +42,7 @@ public sealed class SandboxRepoCloner(
             if (clone.ExitCode != 0)
                 return FailWith(
                     $"git clone into sandbox '{key}' failed (exit={clone.ExitCode}): {clone.ErrorMessage}", config);
-            await MaybeSwitchBranchAsync(sandbox, branch, resolved.CurrentBranch, ct);
+            await MaybeSwitchBranchAsync(sandbox, branch, ct);
         }
         return repo;
     }
@@ -53,11 +53,19 @@ public sealed class SandboxRepoCloner(
         return null;
     }
 
+    // Check out the ticket branch's EXISTING content on a re-run (build on the
+    // prior run's committed work), falling back to creating it from the clone's
+    // default HEAD on a first run. The full `git clone` fetches every branch, so
+    // `git checkout <ticket-branch>` finds origin/<branch> and lands its content.
+    // No early-out on "requested == resolved": CheckoutAsync only ECHOES the
+    // requested branch back as CurrentBranch, so that guard was always true and
+    // silently skipped the switch — the sandbox stayed on the default and the
+    // prior run's work was ignored (then force-pushed over). `git checkout` on the
+    // branch we are already on is a harmless no-op, so the switch is unconditional.
     private async Task MaybeSwitchBranchAsync(
-        ISandbox sandbox, BranchName? requested, BranchName resolvedDefault, CancellationToken ct)
+        ISandbox sandbox, BranchName? requested, CancellationToken ct)
     {
-        if (requested is null
-            || requested.Value.Equals(resolvedDefault.Value, StringComparison.Ordinal))
+        if (requested is null)
             return;
         var branch = requested.Value;
 

--- a/tests/AgentSmith.Tests/Commands/MultiRepoHandlerTests.cs
+++ b/tests/AgentSmith.Tests/Commands/MultiRepoHandlerTests.cs
@@ -42,6 +42,47 @@ public sealed class MultiRepoHandlerTests
             It.IsAny<IProgress<StepEvent>?>(), It.IsAny<CancellationToken>()), Times.Once);
     }
 
+    // Regression: a re-run must check out the ticket branch's EXISTING content (build
+    // on the prior run), not stay on the clone's default. AzureRepos.CheckoutAsync
+    // ECHOES the requested branch back as CurrentBranch, so the old
+    // `requested == resolvedDefault` guard was always true and silently skipped the
+    // switch — the sandbox stayed on the default and the prior work was force-pushed
+    // over. This mocks that echo (unlike the CheckoutHarness "main") and asserts the
+    // switch happens anyway.
+    [Fact]
+    public async Task Checkout_ReRun_ChecksOutExistingTicketBranch_EvenWhenProviderEchoesIt()
+    {
+        var ticket = new BranchName("agent-smith/19106");
+        var config = new RepoConnection
+        {
+            Name = "server", Type = RepoType.GitHub,
+            Url = "https://x/server.git", DefaultBranch = "main"
+        };
+
+        var provider = new Mock<ISourceProvider>();
+        provider.SetupGet(p => p.ProviderType).Returns("github");
+        provider.Setup(p => p.CheckoutAsync(It.IsAny<BranchName?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Repository(ticket, config.Url!)); // echoes the requested branch, like AzDO
+        var factory = new Mock<ISourceProviderFactory>();
+        factory.Setup(f => f.Create(It.IsAny<RepoConnection>())).Returns(provider.Object);
+
+        var sandbox = new Mock<ISandbox>();
+        sandbox.Setup(s => s.RunStepAsync(
+                It.IsAny<Step>(), It.IsAny<IProgress<StepEvent>?>(), It.IsAny<CancellationToken>()))
+            .Returns<Step, IProgress<StepEvent>?, CancellationToken>((step, _, _) =>
+                Task.FromResult(new StepResult(StepResult.CurrentSchemaVersion, step.StepId, 0, false, 0.1, null)));
+
+        var cloner = new SandboxRepoCloner(factory.Object, NullLogger<SandboxRepoCloner>.Instance);
+        var sandboxes = new[] { new KeyValuePair<string, ISandbox>("server", sandbox.Object) };
+
+        await cloner.CheckoutIntoSandboxesAsync(config, ticket, sandboxes, CancellationToken.None);
+
+        sandbox.Verify(s => s.RunStepAsync(
+            It.Is<Step>(st => st.Command == "git"
+                && st.Args!.Contains("checkout") && st.Args!.Contains("agent-smith/19106")),
+            It.IsAny<IProgress<StepEvent>?>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
     [Fact]
     public async Task Checkout_LocalProvider_PublishesPrimaryRepository_AtConstWorkPath()
     {


### PR DESCRIPTION
…work (p0341e)

CheckoutAsync only ECHOES the requested branch back as CurrentBranch, so the `requested == resolvedDefault` guard in MaybeSwitchBranchAsync was always true and silently skipped the branch switch — every re-run stayed on the clone's default branch, ignored the ticket branch's committed partial work, then force-pushed over it. Drop the guard: the full clone fetches every branch, so `git checkout <ticket>` lands the existing content (build on it), falling back to `checkout -b` from default on a first run. Regression test mocks the real echo behaviour (the CheckoutHarness mock returned 'main', which is why no test caught this).