### PR TITLE
fix: checkout continuity, sub-agent config, cancel-persist, cost tracking, re-engage hardening (p0341e)

### DIFF
--- a/src/backend/AgentSmith.Application/Services/Handlers/AgenticMasterHandler.cs
+++ b/src/backend/AgentSmith.Application/Services/Handlers/AgenticMasterHandler.cs
@@ -261,7 +261,17 @@ public sealed class AgenticMasterHandler(
             return CommandResult.Fail(reason);
         }
 
-        costTracker.Track(loopResult.Response);
+        // p0341e: the coding master's spend is now recorded PER ITERATION by the governor hook
+        // (BuildMasterLoopHooks → RecordIterationUsage feeds the shared tracker), so tracking the
+        // final aggregate here would DOUBLE-count it — and would still be lost on a throwing pass.
+        // Track the final response ONLY on the paths that have no governor hooks (scan / spec-
+        // dialog masters), where the loop is a single aggregate and never re-driven.
+        void TrackMasterResponse(ChatResponse response)
+        {
+            if (masterHooks is null) costTracker.Track(response);
+        }
+
+        TrackMasterResponse(loopResult.Response);
 
         // p0315d: the master asked mid-run — pause the run instead of nudging it
         // on. Publish the partial work + the question; MasterOpenQuestions posts
@@ -293,7 +303,7 @@ public sealed class AgenticMasterHandler(
             {
                 var deeper = await loopRunner.RunAsync(
                     request with { UserPrompt = scanPromptFactory.BuildCoverageNudge(userPrompt) }, cancellationToken);
-                costTracker.Track(deeper.Response);
+                TrackMasterResponse(deeper.Response);
                 loopResult = deeper; // the deeper pass re-emits the complete observation array
             }
             catch (Exception ex) when (!cancellationToken.IsCancellationRequested)
@@ -329,7 +339,7 @@ public sealed class AgenticMasterHandler(
             {
                 var applyResult = await loopRunner.RunAsync(
                     request with { UserPrompt = BuildApplyNudge(userPrompt, progress.GetLedger()) }, cancellationToken);
-                costTracker.Track(applyResult.Response);
+                TrackMasterResponse(applyResult.Response);
                 loopResult = applyResult; // verdict + duration come from the apply pass
                 changes = fs.GetChanges();
             }
@@ -379,7 +389,7 @@ public sealed class AgenticMasterHandler(
             {
                 var verdictResult = await loopRunner.RunAsync(
                     request with { UserPrompt = BuildVerdictNudge(userPrompt, progress.GetLedger()) }, cancellationToken);
-                costTracker.Track(verdictResult.Response);
+                TrackMasterResponse(verdictResult.Response);
                 verification = MasterVerificationParser.TryParse(verdictResult.Response.Text);
             }
             catch (Exception ex) when (!cancellationToken.IsCancellationRequested)
@@ -396,7 +406,8 @@ public sealed class AgenticMasterHandler(
         // progress pass, or a parked operator question (which short-circuits the whole run).
         (loopResult, changes, verification) = await ReengageWhileProductiveAsync(
             context, request, userPrompt, pipelineName, progress, fs, log,
-            costTracker, ticketClarifications, loopResult, changes, verification, cancellationToken);
+            costTracker, TrackMasterResponse, ticketClarifications, loopResult, changes, verification,
+            cancellationToken);
         if (ticketClarifications?.Captured is { } reengageQuestion)
         {
             context.Pipeline.Set(ContextKeys.CodeChanges, changes);
@@ -611,13 +622,17 @@ public sealed class AgenticMasterHandler(
             AgenticMasterContext context, AgenticLoopRequest request, string userPrompt,
             string? pipelineName, ProgressLedgerToolHost progress, FilesystemToolHost fs,
             LogDecisionToolHost log, PipelineCostTracker costTracker,
+            Action<ChatResponse> trackMasterResponse,
             TicketClarificationToolHost? ticketClarifications,
             AgenticLoopResult loopResult, IReadOnlyList<CodeChange> changes,
             MasterVerification? verification, CancellationToken cancellationToken)
     {
+        var ratifiedCriteria = RatifiedCriteria(context.Pipeline);
         for (var pass = 0; pass < ReengageHardSafetyCap; pass++)
         {
-            if (!ShouldReengage(pipelineName, progress.GetLedger(), verification, costTracker.IsBudgetExhausted))
+            if (!ShouldReengage(
+                    pipelineName, progress.GetLedger(), verification,
+                    costTracker.IsBudgetExhausted, ratifiedCriteria, changes))
                 break;
             if (ticketClarifications?.Captured is not null)
                 break; // an operator question short-circuits — the caller parks the run
@@ -638,7 +653,9 @@ public sealed class AgenticMasterHandler(
                         UserPrompt = BuildReengageNudge(userPrompt, progress.GetLedger(), log.GetDecisions(), verification),
                     },
                     cancellationToken);
-                costTracker.Track(reengaged.Response);
+                // p0341e: no-op for the coding master (per-iteration governor hook already
+                // recorded this pass's spend); the shared helper keeps the gating in one place.
+                trackMasterResponse(reengaged.Response);
                 loopResult = reengaged;
                 changes = fs.GetChanges();
                 var reparsed = MasterVerificationParser.TryParse(reengaged.Response.Text);
@@ -676,17 +693,67 @@ public sealed class AgenticMasterHandler(
         return (loopResult, changes, verification);
     }
 
-    // p0341c: the re-engagement predicate — pure + testable, mirroring ShouldDriveApply /
-    // ShouldNudgeForVerdict. Re-engage when the run expects code, actionable ledger steps
-    // remain, the master did not honestly report FAILED (respect honest RED), and the
-    // per-pipeline budget is not exhausted.
+    // p0341c/p0341e: the re-engagement predicate — pure + testable, mirroring ShouldDriveApply /
+    // ShouldNudgeForVerdict. Re-engages the open loop while the run is OBJECTIVELY incomplete —
+    // not merely while the MODEL still reports pending steps. A model that drains the ledger by
+    // marking steps done WITHOUT doing them (or a plan that under-seeds the repo) previously
+    // defeated re-engagement: HasActionablePending went false and the loop quit early, leaving
+    // the keystone to catch the lie only at the very end. Now three signals, first two OBJECTIVE:
+    //   (1) the model's own checklist still has actionable steps (the original signal), OR
+    //   (2) a DONE-marked step's declared target is absent from the actual diff (marking-without-
+    //       doing — the diff is unfakeable), OR
+    //   (3) the ratified acceptance contract is not yet objectively satisfied (build/tests green
+    //       AND every criterion met/justified) — a drained ledger over an unmet contract is not
+    //       a real completion.
+    // Still respects honest RED and the exhausted budget, and stays BOUNDED by the caller's
+    // forward-progress gate + the hard safety cap — no fixed re-drive count.
     internal static bool ShouldReengage(
-        string? pipelineName, ProgressLedger ledger, MasterVerification? verification, bool budgetExhausted) =>
-        !string.IsNullOrEmpty(pipelineName)
-        && PipelinePresets.ExpectsCodeChanges(pipelineName)
-        && ledger.HasActionablePending
-        && verification?.Status != VerificationStatus.Failed
-        && !budgetExhausted;
+        string? pipelineName, ProgressLedger ledger, MasterVerification? verification,
+        bool budgetExhausted, IReadOnlyList<string> ratifiedCriteria, IReadOnlyList<CodeChange> changes)
+    {
+        if (string.IsNullOrEmpty(pipelineName) || !PipelinePresets.ExpectsCodeChanges(pipelineName))
+            return false;
+        if (budgetExhausted) return false;
+        if (verification?.Status == VerificationStatus.Failed) return false; // respect honest RED
+
+        if (ledger.HasActionablePending) return true;
+        if (ProgressLedgerCoverage.UnbackedDoneSteps(ledger, changes).Count > 0) return true;
+        if (ratifiedCriteria.Count > 0
+            && !AcceptanceObjectivelySatisfied(verification, ratifiedCriteria.Count))
+            return true;
+        return false;
+    }
+
+    // p0341e: the objective acceptance gate mirrored from RunOutcomeKeystone.EvaluateAcceptance
+    // (the single definition of done). The contract is satisfied ONLY when the build/tests are
+    // green (or genuinely test-less) AND every ratified criterion has a reported disposition that
+    // is Met or justified not-applicable. A missing verdict, a non-green status, or any unmet /
+    // missing disposition => not satisfied. Pure + testable.
+    internal static bool AcceptanceObjectivelySatisfied(MasterVerification? verification, int criteriaCount)
+    {
+        if (criteriaCount == 0) return true;
+        if (verification is null) return false;
+        if (verification.Status is not (VerificationStatus.Green or VerificationStatus.NoTests))
+            return false;
+        var dispositions = verification.AcceptanceDispositions;
+        if (dispositions is null || dispositions.Count < criteriaCount) return false;
+        for (var i = 0; i < criteriaCount; i++)
+        {
+            var d = dispositions[i];
+            if (d.Status == AcceptanceStatus.Met) continue;
+            if (d.Status == AcceptanceStatus.NotApplicable && !string.IsNullOrWhiteSpace(d.Evidence)) continue;
+            return false;
+        }
+        return true;
+    }
+
+    // p0341e: the ratified acceptance criteria for this run (empty when nothing was negotiated —
+    // fix-bug self-planning, ticketless runs). Same source the keystone reads.
+    private static IReadOnlyList<string> RatifiedCriteria(PipelineContext pipeline) =>
+        pipeline.TryGet<Contracts.Expectations.RatifiedExpectation>(
+            ContextKeys.RunExpectation, out var exp) && exp is not null
+            ? exp.Draft.Expected
+            : Array.Empty<string>();
 
     // p0341c: MEANINGFUL forward progress — a newly-DONE ledger step, or a verdict that now
     // passes (a repo that now builds / tests that now pass). A bare edit that moved neither
@@ -781,7 +848,22 @@ public sealed class AgenticMasterHandler(
                 ? null
                 : () => startUsd + estimator.EstimateCostUsd() > cap.Usd
                     || startTokens + estimator.TotalTokens > cap.Tokens,
-            RecordIterationUsage: estimator.Track,
+            // p0341e: record EACH tool-loop iteration's usage into BOTH the pass-local fence
+            // estimator AND the shared per-pipeline tracker — as it happens. This is the fix
+            // for the run summary that showed $0.14 while the master truly spent $16.38: the
+            // handler previously fed the shared tracker ONLY the FunctionInvokingChatClient's
+            // final aggregate via Track(loopResult.Response) AFTER the loop, so a pass that
+            // ended by THROWING (the within-pass money fence, or an LLM-layer timeout) dropped
+            // its ENTIRE spend from the summary and from IsBudgetExhausted. Feeding per
+            // iteration makes the shared tracker exact and exception-proof; the redundant
+            // handler-level Track calls for the coding master are dropped to avoid double-count.
+            // The fence math is unaffected — it reads the FROZEN startUsd/startTokens plus the
+            // independent estimator, never the shared tracker live.
+            RecordIterationUsage: response =>
+            {
+                estimator.Track(response);
+                costTracker.Track(response);
+            },
             RenderReminder: () => BuildInPassReminder(ledger()),
             ReminderEveryNIterations: context.AgentConfig.LedgerReminderEveryNIterations,
             DriftEditlessIterations: context.AgentConfig.ReminderDriftEditlessIterations,

--- a/src/backend/AgentSmith.Application/Services/Handlers/AgenticMasterHandler.cs
+++ b/src/backend/AgentSmith.Application/Services/Handlers/AgenticMasterHandler.cs
@@ -544,7 +544,8 @@ public sealed class AgenticMasterHandler(
         var sandboxes = context.Pipeline.Get<IReadOnlyDictionary<string, ISandbox>>(ContextKeys.Sandboxes);
         var subCtx = new SubAgentContext(
             context.Pipeline, sandboxes, PipelineCostTracker.GetOrCreate(context.Pipeline), runId,
-            ChildTools: BaseSurface().ToList(), AnswerStore: childAnswerStore, Budget: subAgentBudget);
+            ChildTools: BaseSurface().ToList(), AnswerStore: childAnswerStore, Budget: subAgentBudget,
+            AgentConfig: context.AgentConfig);
         var spawn = new SpawnAgentToolHost(subAgentRunner, subAgentBudget, subAgentNameValidator, decisionLogger, subCtx);
         var readObs = new ReadSubAgentObservationsToolHost(childAnswerStore);
         return master.Concat(spawn.GetTools(null, null)).Concat(readObs.GetTools(null, null)).ToList();

--- a/src/backend/AgentSmith.Application/Services/Loop/SubAgentContext.cs
+++ b/src/backend/AgentSmith.Application/Services/Loop/SubAgentContext.cs
@@ -1,4 +1,5 @@
 using AgentSmith.Contracts.Commands;
+using AgentSmith.Contracts.Models.Configuration;
 using AgentSmith.Contracts.Sandbox;
 using AgentSmith.Contracts.Services;
 using AgentSmith.Domain.Models;
@@ -23,4 +24,10 @@ public sealed record SubAgentContext(
     IReadOnlyList<AITool> ChildTools,
     IChildAnswerStore AnswerStore,
     SubAgentBudget Budget,
+    // The master's resolved AgentConfig, passed EXPLICITLY. The coding-master path never
+    // publishes it to ContextKeys.AgentConfig (only the api/security/pr round handlers do),
+    // so a pipeline lookup silently fell back to an empty AgentConfig — provider type '' —
+    // and ChatClientFactory.Create threw "No IChatClientBuilder registered for type=''",
+    // killing every spawned child before its first LLM call.
+    AgentConfig AgentConfig,
     string? ParentSubAgentId = null);

--- a/src/backend/AgentSmith.Application/Services/Loop/SubAgentResult.cs
+++ b/src/backend/AgentSmith.Application/Services/Loop/SubAgentResult.cs
@@ -27,7 +27,12 @@ public sealed record SubAgentResult(
     int FilesWrittenCount,
     int ToolCalls,
     decimal CostUsd,
-    DateTimeOffset OccurredAt) : IDomainEvent
+    DateTimeOffset OccurredAt,
+    // p0341e: WHY a child failed (the exception's message), so the master's logged decision
+    // shows the cause instead of a bare "Failed cost $0.0000" that forced an operator into the
+    // pod logs. Null on success. NOT distilled observation text — the SubAgentResult_HasNoResultText
+    // discipline still holds (this is an error reason, pulled from the exception, not a result body).
+    string? FailureReason = null) : IDomainEvent
 {
     private readonly string _eventId = Guid.NewGuid().ToString();
 

--- a/src/backend/AgentSmith.Application/Services/Loop/SubAgentRunner.cs
+++ b/src/backend/AgentSmith.Application/Services/Loop/SubAgentRunner.cs
@@ -127,7 +127,10 @@ public sealed class SubAgentRunner(
         var tools = context.ChildTools.ToList();
         var systemPrompt = BuildSystemPrompt(spec);
         var userPrompt = BuildUserPrompt(spec);
-        var agentConfig = ResolveAgentConfig(context.Pipeline);
+        // The master's real AgentConfig, passed explicitly on the context — NOT looked up
+        // from the pipeline (the coding-master path never publishes it there, which made
+        // the lookup fall back to an empty config and fail every child at Create).
+        var agentConfig = context.AgentConfig;
         return new AgenticLoopRequest(
             AgentConfig: agentConfig,
             TaskType: TaskType.Primary,
@@ -145,13 +148,6 @@ public sealed class SubAgentRunner(
             // most need it. Sub-agents get no governor hooks (no budget-fence/reminder) —
             // their cost rolls up to the shared tracker via SubAgentRunner.
             MaxIterations: agentConfig.MaxSubAgentLoopIterations);
-    }
-
-    private static AgentConfig ResolveAgentConfig(PipelineContext pipeline)
-    {
-        if (pipeline.TryGet<AgentConfig>(ContextKeys.AgentConfig, out var agent) && agent is not null)
-            return agent;
-        return new AgentConfig();
     }
 
     private static string BuildSystemPrompt(SubAgentSpec spec)

--- a/src/backend/AgentSmith.Application/Services/Loop/SubAgentRunner.cs
+++ b/src/backend/AgentSmith.Application/Services/Loop/SubAgentRunner.cs
@@ -58,7 +58,7 @@ public sealed class SubAgentRunner(
         catch (Exception ex)
         {
             logger.LogError(ex, "Sub-agent slot {Index} threw outside the loop runner — recording as failed", index);
-            slots[index] = BuildFailureResult(spec, index, Guid.NewGuid().ToString("N"), 0m);
+            slots[index] = BuildFailureResult(spec, index, Guid.NewGuid().ToString("N"), 0m, DescribeFailure(ex));
         }
         finally
         {
@@ -84,7 +84,11 @@ public sealed class SubAgentRunner(
 
             // Each child's cost rolls up against the shared per-run tracker.
             context.CostTracker.Track(loopResult.Response);
-            var costUsd = EstimateCostUsd(loopResult.Response);
+            // p0341e: the child's OWN per-run cost — from its response usage at the shared
+            // tracker's pricing (race-free under concurrent children; not a before/after
+            // Track-delta they would corrupt). Replaces the old stub that always returned 0m,
+            // which surfaced "cost $0.0000" on the decision even for a succeeded child.
+            var costUsd = context.CostTracker.EstimateResponseCostUsd(loopResult.Response);
             var observationsCount = CountObservations(loopResult.Response);
             var toolCalls = CountToolCalls(loopResult.Response);
 
@@ -114,7 +118,7 @@ public sealed class SubAgentRunner(
             await PublishCompletedAsync(
                 subAgentId, context, SubAgentStatus.Failed,
                 0, 0, 0, 0, 0m, ct);
-            return BuildFailureResult(spec, index, subAgentId, 0m);
+            return BuildFailureResult(spec, index, subAgentId, 0m, DescribeFailure(ex));
         }
     }
 
@@ -198,7 +202,8 @@ public sealed class SubAgentRunner(
         return eventPublisher.PublishAsync(evt, ct);
     }
 
-    private static SubAgentResult BuildFailureResult(SubAgentSpec spec, int index, string subAgentId, decimal cost) =>
+    private static SubAgentResult BuildFailureResult(
+        SubAgentSpec spec, int index, string subAgentId, decimal cost, string? failureReason = null) =>
         new(
             TaskIndex: index,
             Status: SubAgentStatus.Failed,
@@ -209,20 +214,24 @@ public sealed class SubAgentRunner(
             FilesWrittenCount: 0,
             ToolCalls: 0,
             CostUsd: cost,
-            OccurredAt: DateTimeOffset.UtcNow);
+            OccurredAt: DateTimeOffset.UtcNow,
+            FailureReason: failureReason);
+
+    // p0341e: a one-line, operator-readable failure cause from the exception chain (the
+    // innermost message is usually the real reason — e.g. the provider error, not the wrapper).
+    private static string DescribeFailure(Exception ex)
+    {
+        var inner = ex;
+        while (inner.InnerException is not null) inner = inner.InnerException;
+        var message = string.IsNullOrWhiteSpace(inner.Message) ? ex.Message : inner.Message;
+        return $"{inner.GetType().Name}: {message}";
+    }
 
     private static string HashInheritedContext(InheritedContext ctx)
     {
         var payload = $"{ctx.PipelineGoal}\n{ctx.PriorContextSlice}\n{ctx.OptionalSystemPromptBlock}";
         var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(payload));
         return "sha256:" + Convert.ToHexString(bytes)[..12].ToLowerInvariant();
-    }
-
-    private static decimal EstimateCostUsd(ChatResponse response)
-    {
-        var usage = response.Usage;
-        if (usage is null) return 0m;
-        return 0m;
     }
 
     private static int CountObservations(ChatResponse response) =>

--- a/src/backend/AgentSmith.Application/Services/PipelineCostTracker.cs
+++ b/src/backend/AgentSmith.Application/Services/PipelineCostTracker.cs
@@ -146,6 +146,35 @@ public sealed class PipelineCostTracker
     }
 
     /// <summary>
+    /// p0341e: the cost of a SINGLE response's usage at this tracker's pricing, WITHOUT
+    /// mutating the running totals or reading the shared counters. Lets a caller report a
+    /// per-response cost (e.g. a sub-agent's own per-run cost) consistently with the
+    /// pipeline summary, and RACE-FREE under concurrent callers — it reads only the passed
+    /// response, never the shared state a before/after Track-delta would straddle. Token
+    /// extraction mirrors <see cref="Track"/>; pricing mirrors <see cref="EstimateCostUsdLocked"/>.
+    /// </summary>
+    public decimal EstimateResponseCostUsd(ChatResponse response)
+    {
+        if (response.Usage is null) return 0m;
+        var input = (int)(response.Usage.InputTokenCount ?? 0);
+        var output = (int)(response.Usage.OutputTokenCount ?? 0);
+        var anthropicRead = ReadAdditionalCount(response.Usage, "CacheReadInputTokens")
+            + ReadAdditionalCount(response.Usage, "cache_read_input_tokens");
+        var openAiCached = ReadAdditionalCount(response.Usage, "cached_tokens");
+        var cacheRead = anthropicRead + openAiCached;
+        var cacheCreate = ReadAdditionalCount(response.Usage, "CacheCreationInputTokens")
+            + ReadAdditionalCount(response.Usage, "cache_creation_input_tokens");
+        var billable = Math.Max(0, input - openAiCached);
+        var model = string.IsNullOrEmpty(response.ModelId) ? _lastModel : response.ModelId;
+        var pricing = _pricing.Resolve(model);
+        if (pricing is null) return 0m;
+        return (billable / 1_000_000m * pricing.InputPerMillion)
+             + (output / 1_000_000m * pricing.OutputPerMillion)
+             + (cacheCreate / 1_000_000m * pricing.InputPerMillion * 1.25m)
+             + (cacheRead / 1_000_000m * pricing.CacheReadPerMillion);
+    }
+
+    /// <summary>
     /// Snapshots the tracker into a <see cref="RunCostSummary"/> for result.md
     /// frontmatter. Per-skill records are grouped by
     /// <see cref="SkillExecutionPhase"/>; calls that ran outside any explicit

--- a/src/backend/AgentSmith.Application/Services/PipelineExecutor.cs
+++ b/src/backend/AgentSmith.Application/Services/PipelineExecutor.cs
@@ -20,6 +20,7 @@ public sealed class PipelineExecutor(
     IPipelineStepRunner stepRunner,
     IPipelineErrorHandler errorHandler,
     IPipelineLifecycleCoordinator lifecycleCoordinator,
+    IRunCancellationRegistry cancellationRegistry,
     ILogger<PipelineExecutor> logger) : IPipelineExecutor
 {
     private const int MaxCommandExecutions = 100;
@@ -106,9 +107,36 @@ public sealed class PipelineExecutor(
                                           "Possible infinite loop in command insertion.");
             }
 
-            var stepResult = batch.Count == 1
-                ? await stepRunner.RunSingleAsync(current, commands, projectConfig, context, ++executionCount, ct)
-                : await stepRunner.RunBatchAsync(batch, commands, projectConfig, context, executionCount + 1, ct);
+            StepExecutionResult stepResult;
+            try
+            {
+                stepResult = batch.Count == 1
+                    ? await stepRunner.RunSingleAsync(current, commands, projectConfig, context, ++executionCount, ct)
+                    : await stepRunner.RunBatchAsync(batch, commands, projectConfig, context, executionCount + 1, ct);
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                // p0341e: a cancellation RETHROWS from the step runner (PipelineStepRunner:
+                // `catch (OCE) when (IsCancellationRequested) throw`), so it flew past the
+                // finalizer branch below and the run was discarded — no commit, no result.md,
+                // no PR. The #19106 migration lost 23 real source edits + ~$16 that way.
+                // BUT distinguish the cause: a WALL-TIME safety cancel means the run was doing
+                // real work and a timer fired → persist the partial (the sandbox is still
+                // alive here, before teardown). An OPERATOR cancel is a deliberate abort →
+                // let it abort, no half-baked PR. The registry records which.
+                var isWallTime = context.TryGet<string>(ContextKeys.RunId, out var rid)
+                    && rid is not null
+                    && cancellationRegistry.TryGetReason(rid, out var reason)
+                    && reason == "watchdog-wall-time";
+                if (isWallTime)
+                {
+                    context.Set(ContextKeys.FailureReason,
+                        "Run hit the wall-time safety budget — partial work preserved.");
+                    await RunFinalizerTailAsync(
+                        batch[^1], commands, projectConfig, context, executionCount, CancellationToken.None);
+                }
+                throw;
+            }
             if (batch.Count > 1) executionCount += batch.Count;
 
             if (!stepResult.Result.IsSuccess)

--- a/src/backend/AgentSmith.Application/Services/Tools/SpawnAgentToolHost.cs
+++ b/src/backend/AgentSmith.Application/Services/Tools/SpawnAgentToolHost.cs
@@ -167,9 +167,16 @@ public sealed class SpawnAgentToolHost : IToolHost
         CancellationToken ct)
     {
         if (ranSpecs.Count == 0) return;
+        // p0341e: append the failure REASON for a failed child so the decision names the cause
+        // (was a bare "Failed cost $0.0000" that hid WHY in the pod logs). Succeeded children
+        // carry no reason, so the suffix is empty for them.
         var summary = string.Join(
             "; ",
-            ranSpecs.Zip(results, (s, r) => $"{s.Name} ({s.Activity}) — {r.Status} cost ${r.CostUsd:F4}"));
+            ranSpecs.Zip(results, (s, r) =>
+                $"{s.Name} ({s.Activity}) — {r.Status} cost ${r.CostUsd:F4}"
+                + (r.Status == SubAgentStatus.Failed && !string.IsNullOrWhiteSpace(r.FailureReason)
+                    ? $" — {r.FailureReason}"
+                    : string.Empty)));
         await _decisionLogger.LogAsync(
             "/work", DecisionCategory.Implementation,
             $"Spawned {ranSpecs.Count} sub-agents: {summary}", ct);

--- a/tests/AgentSmith.Tests/Application/Services/Loop/SubAgentRunnerTests.cs
+++ b/tests/AgentSmith.Tests/Application/Services/Loop/SubAgentRunnerTests.cs
@@ -156,6 +156,24 @@ public sealed class SubAgentRunnerTests
         answer.Should().Be("ok");
     }
 
+    // Regression: the child's AgentConfig was looked up from the pipeline
+    // (ContextKeys.AgentConfig), which the coding-master path never populates — so it fell
+    // back to an empty AgentConfig (Type="") and ChatClientFactory.Create threw
+    // "No IChatClientBuilder registered for type=''", killing every spawned child before
+    // its first LLM call. The child must carry the master's real config, passed explicitly.
+    [Fact]
+    public async Task SubAgentRunner_ChildRequestCarriesMastersAgentConfig_NotEmptyDefault()
+    {
+        var stub = new StubLoopRunner();
+        var sut = BuildRunner(stub);
+
+        await sut.RunAsync(new[] { Spec("TopologyAuditor") }, BuildContext(), CancellationToken.None);
+
+        stub.SeenRequests.Should().HaveCount(1);
+        stub.SeenRequests[0].AgentConfig.Type.Should().Be("azure_openai");
+        stub.SeenRequests[0].AgentConfig.Model.Should().Be("test-model");
+    }
+
     private static SubAgentRunner BuildRunner(
         IAgenticLoopRunner loopRunner,
         int maxConcurrent = 4,
@@ -178,7 +196,8 @@ public sealed class SubAgentRunnerTests
             MasterRunId: "run-test",
             ChildTools: System.Array.Empty<Microsoft.Extensions.AI.AITool>(),
             AnswerStore: new InMemoryChildAnswerStore(),
-            new SubAgentBudget(maxPerRun: 100));
+            Budget: new SubAgentBudget(maxPerRun: 100),
+            AgentConfig: new AgentConfig { Type = "azure_openai", Model = "test-model" });
     }
 
     private sealed class NullSandbox : ISandbox

--- a/tests/AgentSmith.Tests/Application/Services/Tools/SpawnAgentToolHostTests.cs
+++ b/tests/AgentSmith.Tests/Application/Services/Tools/SpawnAgentToolHostTests.cs
@@ -88,7 +88,8 @@ public sealed class SpawnAgentToolHostTests
             MasterRunId: "run-1",
             ChildTools: System.Array.Empty<Microsoft.Extensions.AI.AITool>(),
             AnswerStore: new InMemoryChildAnswerStore(),
-            new SubAgentBudget(budget));
+            Budget: new SubAgentBudget(budget),
+            AgentConfig: new AgentConfig { Type = "azure_openai", Model = "test-model" });
         var logger = new RecordingDecisionLogger();
         return (
             new SpawnAgentToolHost(

--- a/tests/AgentSmith.Tests/Handlers/AgenticMasterReengageTests.cs
+++ b/tests/AgentSmith.Tests/Handlers/AgenticMasterReengageTests.cs
@@ -23,12 +23,23 @@ public sealed class AgenticMasterReengageTests
         new(status, true, status != VerificationStatus.Failed, true,
             status is VerificationStatus.Green, "summary");
 
+    // A Green verdict that ALSO reports every ratified criterion Met — an objectively
+    // satisfied acceptance contract.
+    private static MasterVerification GreenWithMet(int criteriaCount) =>
+        new(VerificationStatus.Green, true, true, true, true, "summary",
+            AcceptanceDispositions: Enumerable.Range(0, criteriaCount)
+                .Select(i => new AcceptanceDisposition($"criterion {i}", AcceptanceStatus.Met, "edit X"))
+                .ToList());
+
+    private static readonly IReadOnlyList<string> NoCriteria = System.Array.Empty<string>();
+    private static readonly IReadOnlyList<CodeChange> NoChanges = System.Array.Empty<CodeChange>();
+
     [Fact]
     public void ShouldReengage_PartialLedgerActionableStepsAndBudgetRemain_True()
     {
         AgenticMasterHandler.ShouldReengage(
             "fix-bug", Ledger(ProgressStatus.Done, ProgressStatus.Pending),
-            Verdict(VerificationStatus.Green), budgetExhausted: false)
+            Verdict(VerificationStatus.Green), budgetExhausted: false, NoCriteria, NoChanges)
             .Should().BeTrue();
     }
 
@@ -37,7 +48,7 @@ public sealed class AgenticMasterReengageTests
     {
         AgenticMasterHandler.ShouldReengage(
             "fix-bug", Ledger(ProgressStatus.Pending),
-            Verdict(VerificationStatus.Green), budgetExhausted: true)
+            Verdict(VerificationStatus.Green), budgetExhausted: true, NoCriteria, NoChanges)
             .Should().BeFalse();
     }
 
@@ -47,16 +58,16 @@ public sealed class AgenticMasterReengageTests
         // An honest RED is respected — the loop does not grind a failed run.
         AgenticMasterHandler.ShouldReengage(
             "fix-bug", Ledger(ProgressStatus.Pending),
-            Verdict(VerificationStatus.Failed), budgetExhausted: false)
+            Verdict(VerificationStatus.Failed), budgetExhausted: false, NoCriteria, NoChanges)
             .Should().BeFalse();
     }
 
     [Fact]
-    public void ShouldReengage_LedgerDrained_False()
+    public void ShouldReengage_LedgerDrained_NoContract_False()
     {
         AgenticMasterHandler.ShouldReengage(
             "fix-bug", Ledger(ProgressStatus.Done, ProgressStatus.Done),
-            Verdict(VerificationStatus.Green), budgetExhausted: false)
+            Verdict(VerificationStatus.Green), budgetExhausted: false, NoCriteria, NoChanges)
             .Should().BeFalse();
     }
 
@@ -65,7 +76,68 @@ public sealed class AgenticMasterReengageTests
     {
         AgenticMasterHandler.ShouldReengage(
             "security-scan", Ledger(ProgressStatus.Pending),
-            Verdict(VerificationStatus.Green), budgetExhausted: false)
+            Verdict(VerificationStatus.Green), budgetExhausted: false, NoCriteria, NoChanges)
+            .Should().BeFalse();
+    }
+
+    [Fact]
+    public void ShouldReengage_ModelMarkedAllDoneButAcceptanceObjectivelyUnmet_StillReengages()
+    {
+        // The model drained the ledger (all steps done) and reported Green — but the ratified
+        // acceptance contract has an UNMET criterion. Objective incompleteness wins over the
+        // model's self-reported "all done": re-engage rather than let the loop quit early.
+        var criteria = new[] { "Server updated", "BackgroundWorker updated" };
+        var verdict = new MasterVerification(
+            VerificationStatus.Green, true, true, true, true, "summary",
+            AcceptanceDispositions: new[]
+            {
+                new AcceptanceDisposition("Server updated", AcceptanceStatus.Met, "edited Server.cs"),
+                new AcceptanceDisposition("BackgroundWorker updated", AcceptanceStatus.Unmet, ""),
+            });
+
+        AgenticMasterHandler.ShouldReengage(
+            "fix-bug", Ledger(ProgressStatus.Done, ProgressStatus.Done),
+            verdict, budgetExhausted: false, criteria, NoChanges)
+            .Should().BeTrue();
+    }
+
+    [Fact]
+    public void ShouldReengage_ModelMarkedDoneButTargetAbsentFromDiff_StillReengages()
+    {
+        // The ledger is drained and the step is marked done, but its declared target never
+        // appears in the diff — marking-without-doing. The unfakeable diff drives re-engagement.
+        var ledger = new ProgressLedger(new[]
+        {
+            new ProgressLedgerEntry("1", "add worker", ProgressStatus.Done, Target: "src/Worker.cs"),
+        });
+        var changes = new[]
+        {
+            new CodeChange(new FilePath("src/Unrelated.cs"), "x", "modified"),
+        };
+
+        AgenticMasterHandler.ShouldReengage(
+            "fix-bug", ledger, Verdict(VerificationStatus.Green),
+            budgetExhausted: false, NoCriteria, changes)
+            .Should().BeTrue();
+    }
+
+    [Fact]
+    public void ShouldReengage_GenuinelyDone_ContractMetAndDiffBacks_Stops()
+    {
+        // Drained ledger, every ratified criterion reported Met, the done step's target IS in
+        // the diff — genuinely complete. The loop stops.
+        var ledger = new ProgressLedger(new[]
+        {
+            new ProgressLedgerEntry("1", "update server", ProgressStatus.Done, Target: "src/Server.cs"),
+        });
+        var changes = new[]
+        {
+            new CodeChange(new FilePath("src/Server.cs"), "x", "modified"),
+        };
+
+        AgenticMasterHandler.ShouldReengage(
+            "fix-bug", ledger, GreenWithMet(1),
+            budgetExhausted: false, new[] { "Server updated" }, changes)
             .Should().BeFalse();
     }
 

--- a/tests/AgentSmith.Tests/Services/MasterLoopCostAccrualTests.cs
+++ b/tests/AgentSmith.Tests/Services/MasterLoopCostAccrualTests.cs
@@ -1,0 +1,104 @@
+using AgentSmith.Application.Services;
+using AgentSmith.Contracts.Providers;
+using AgentSmith.Infrastructure.Services.Providers.Agent;
+using FluentAssertions;
+using Microsoft.Extensions.AI;
+
+namespace AgentSmith.Tests.Services;
+
+// p0341e: the run summary once showed $0.14 while the master truly spent $16.38 across 353
+// LLM calls. Root cause: the shared PipelineCostTracker was fed ONLY the
+// FunctionInvokingChatClient's final aggregate AFTER the loop (Track(loopResult.Response)),
+// so a pass that ended by THROWING (the within-pass money fence / an LLM-layer timeout) dropped
+// its ENTIRE spend. The fix feeds the tracker PER ITERATION via the governor's
+// RecordIterationUsage hook. These tests pin that the tracker accrues EVERY iteration of a
+// multi-iteration tool loop — not just the last call — and that the spend already landed when a
+// later iteration throws.
+public sealed class MasterLoopCostAccrualTests
+{
+    // A fake provider client that emits a tool call for the first (calls-1) iterations (forcing
+    // the FunctionInvokingChatClient to loop) then a final text turn — each with its own usage.
+    private sealed class MultiIterationInner : IChatClient
+    {
+        private readonly int _toolIterations;
+        private int _call;
+
+        public MultiIterationInner(int toolIterations) => _toolIterations = toolIterations;
+
+        public int Calls => _call;
+
+        public Task<ChatResponse> GetResponseAsync(
+            IEnumerable<ChatMessage> messages, ChatOptions? options = null,
+            CancellationToken cancellationToken = default)
+        {
+            var index = _call++;
+            var usage = new UsageDetails { InputTokenCount = 1000, OutputTokenCount = 500 };
+            ChatMessage message = index < _toolIterations
+                ? new ChatMessage(ChatRole.Assistant,
+                    new AIContent[] { new FunctionCallContent($"c{index}", "noop", new Dictionary<string, object?>()) })
+                : new ChatMessage(ChatRole.Assistant, "done");
+            return Task.FromResult(new ChatResponse(message) { Usage = usage, ModelId = "test-model" });
+        }
+
+        public IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+            IEnumerable<ChatMessage> messages, ChatOptions? options = null,
+            CancellationToken cancellationToken = default) => throw new NotSupportedException();
+
+        public object? GetService(Type serviceType, object? serviceKey = null) => null;
+        public void Dispose() { }
+    }
+
+    private static IChatClient BuildLoop(IChatClient inner, MasterLoopHooks hooks) =>
+        new ChatClientBuilder(new MasterLoopGovernorChatClient(inner, hooks))
+            .UseFunctionInvocation(configure: c => c.MaximumIterationsPerRequest = 25)
+            .Build();
+
+    [Fact]
+    public async Task SharedTracker_FedPerIteration_AccruesEveryToolLoopIteration_NotJustTheFinalCall()
+    {
+        var tracker = new PipelineCostTracker();
+        // Mirror BuildMasterLoopHooks: RecordIterationUsage feeds the shared tracker per iteration.
+        var hooks = new MasterLoopHooks(
+            RecordIterationUsage: tracker.Track,
+            ReminderEveryNIterations: 0, DriftEditlessIterations: 0);
+        var inner = new MultiIterationInner(toolIterations: 3); // 3 tool turns + 1 final = 4 provider calls
+        var loop = BuildLoop(inner, hooks);
+        var tools = new List<AITool> { AIFunctionFactory.Create(() => "ok", name: "noop") };
+
+        await loop.GetResponseAsync(
+            new[] { new ChatMessage(ChatRole.User, "go") },
+            new ChatOptions { Tools = tools });
+
+        inner.Calls.Should().Be(4, "the loop made 3 tool iterations plus a final answer");
+        // The tracker must reflect ALL FOUR provider calls, not just the last one.
+        tracker.CallCount.Should().Be(4);
+        tracker.TotalInputTokens.Should().Be(4000);
+        tracker.TotalOutputTokens.Should().Be(2000);
+    }
+
+    [Fact]
+    public async Task SharedTracker_SpendAlreadyRecorded_WhenAPassThrowsMidLoop()
+    {
+        var tracker = new PipelineCostTracker();
+        var iterations = 0;
+        var hooks = new MasterLoopHooks(
+            // Trip the fence after 3 recorded iterations — the analogue of the within-pass money
+            // fence firing mid-pass; the governor throws MasterBudgetExhaustedException.
+            IsBudgetExhausted: () => iterations >= 3,
+            RecordIterationUsage: r => { iterations++; tracker.Track(r); },
+            ReminderEveryNIterations: 0, DriftEditlessIterations: 0);
+        var inner = new MultiIterationInner(toolIterations: 10);
+        var loop = BuildLoop(inner, hooks);
+        var tools = new List<AITool> { AIFunctionFactory.Create(() => "ok", name: "noop") };
+
+        var act = async () => await loop.GetResponseAsync(
+            new[] { new ChatMessage(ChatRole.User, "go") },
+            new ChatOptions { Tools = tools });
+
+        await act.Should().ThrowAsync<MasterBudgetExhaustedException>();
+        // Even though the pass threw, the 3 iterations that ran were ALREADY recorded in the
+        // shared tracker — the summary is no longer $0 for a run that spent real money.
+        tracker.CallCount.Should().Be(3);
+        tracker.TotalInputTokens.Should().Be(3000);
+    }
+}

--- a/tests/AgentSmith.Tests/Services/PipelineExecutorTestBuilder.cs
+++ b/tests/AgentSmith.Tests/Services/PipelineExecutorTestBuilder.cs
@@ -28,6 +28,7 @@ internal sealed class PipelineExecutorTestBuilder
     public Mock<ICommandContextFactory> FactoryMock { get; } = new();
     public Mock<ITicketProviderFactory> TicketFactoryMock { get; } = new();
     public Mock<IPipelineLifecycleCoordinator> LifecycleCoordinatorMock { get; } = new();
+    public Mock<IRunCancellationRegistry> CancellationRegistryMock { get; } = new();
     public Mock<IAsyncPipelineLifecycle> LifecycleMock { get; } = new();
     public Mock<ISandboxFactory> SandboxFactoryMock { get; } = new();
     public Mock<IProgressReporter> ProgressReporterMock { get; } = new();
@@ -84,6 +85,7 @@ internal sealed class PipelineExecutorTestBuilder
             stepRunner,
             errorHandler,
             LifecycleCoordinatorMock.Object,
+            CancellationRegistryMock.Object,
             NullLogger<PipelineExecutor>.Instance);
     }
 }


### PR DESCRIPTION
## p0341e — a batch of coding-master robustness fixes

Five fixes on top of the p0341c/d durable-ledger + continuous-context work.

### 1. Re-run checks out the existing ticket branch
A re-triggered run now builds on the prior run's branch instead of starting from a clean checkout, so partial work isn't thrown away.

### 2. Sub-agents get the master's real AgentConfig
The child config was looked up from the pipeline (which the coding-master path never populates), falling back to an empty `AgentConfig` and failing every child at `ChatClientFactory.Create` with `type=''`. The master's real config is now passed explicitly on `SubAgentContext`.

### 3. Wall-time-cancelled runs persist partial work
A watchdog/wall-time cancel now preserves the partial changes + ledger and finalizes an honest record; an operator cancel still aborts.

### 4. Cost tracking no longer under-counts the master loop
A run summary showed **$0.14** while the master truly spent **$16.38 across 353 LLM calls**. Root cause: the shared `PipelineCostTracker` was fed only the `FunctionInvokingChatClient`'s final aggregate via `Track(loopResult.Response)` **after** the loop — so any pass that ended by **throwing** (the within-pass money fence, or an LLM-layer timeout) dropped its **entire** spend.

Investigation (decompiled M.E.AI 10.3.0) confirmed FIC **does** aggregate `Usage` across all tool iterations, including cache tokens via `UsageDetails.Add` — so a *normally-completed* pass was already correct; the loss was purely on the exception paths. Fix: the governor's `RecordIterationUsage` hook now feeds **both** the pass-local fence estimator **and** the shared tracker, per iteration, as it happens — exact and exception-proof. The redundant handler-level `Track(finalResponse)` is gated to the hook-less scan / spec-dialog paths so the coding master is not double-counted. The within-pass fence math is unchanged (frozen start snapshot + independent estimator), and the budget cap (`IsBudgetExhausted`) now reads the true number.

### 5. Re-engagement no longer defeated by a model that drains the ledger
`ShouldReengage` gated purely on `ledger.HasActionablePending` — which the model controls. A model that marks steps done without doing them (or a plan that under-seeds the repo) drained the ledger, so re-engagement never fired and the loop quit early. It now drives off **objective** incompleteness: keep re-engaging while (1) actionable ledger steps remain, **or** (2) a done-marked step's declared target is absent from the actual diff (marking-without-doing), **or** (3) the ratified acceptance contract is not yet objectively satisfied (build/tests green **and** every criterion met/justified — mirrored from `RunOutcomeKeystone`). Still respects honest RED + exhausted budget, and stays bounded by the existing forward-progress gate + hard safety cap (no fixed re-drive count).

### 6. Two sub-agent side-findings
- `SubAgentRunner.EstimateCostUsd` was a stub returning `0m` — a child's per-agent cost read `$0.0000` even on success. Now computed from the child response usage at the shared tracker's pricing (`PipelineCostTracker.EstimateResponseCostUsd`), race-free under concurrent children.
- The child failure **reason** (previously only a `LogWarning`) is surfaced on `SubAgentResult.FailureReason` and in the master's logged spawn decision, so an operator sees **why** without digging pod logs.

## Verification
- `dotnet build AgentSmith.sln -c Release` — **0 errors** (pre-existing warnings only).
- Unit tier `AgentSmith.Tests` — **3187 passed, 0 failed, 0 skipped**. New tests: multi-iteration cost accrual (full cost, not just the final call; spend already recorded when a pass throws mid-loop) and objective re-engagement (marked-all-done-but-unmet / target-absent-from-diff ⇒ re-engage; genuinely done ⇒ stop).
- Docker/PipelineHarness tier not run (macOS-flaky, infra-bound).

🤖 Generated with [Claude Code](https://claude.com/claude-code)