### PR TITLE
fix: sort discovered repos alphabetically in the studio repo picker

### DIFF
--- a/src/dashboard/src/components/config/RepoInventory.tsx
+++ b/src/dashboard/src/components/config/RepoInventory.tsx
@@ -105,7 +105,7 @@ function ConnectionInventory({
               <span className="fv">ran, but found no repos in this connection</span>
             </div>
           )}
-          {snapshot.repos.map((r) => {
+          {[...snapshot.repos].sort((a, b) => a.name.localeCompare(b.name)).map((r) => {
             const referencedBy = projects
               .filter((p) => p.repos.some((ref) => refMatches(ref, connection.id, r.name)))
               .map((p) => p.id);

--- a/src/dashboard/src/components/config/RepoPicker.tsx
+++ b/src/dashboard/src/components/config/RepoPicker.tsx
@@ -121,7 +121,7 @@ export function RepoPicker({
             </span>
           ) : discovered ? (
             <div className="picks">
-              {discovered.repos.map((r) => {
+              {[...discovered.repos].sort((a, b) => a.name.localeCompare(b.name)).map((r) => {
                 const ref = `${connection}/${r.name}`;
                 const on = values.includes(ref);
                 return (


### PR DESCRIPTION
The connection's discovered repos rendered in discovery order (unsorted). Sorts them name-ascending in the project repo picker (RepoPicker) and the repo inventory (RepoInventory) so the list is scannable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)