### PR TITLE
fix(website): drop the fake `agent-smith fix` CLI demo from the landing page

### DIFF
--- a/website/src/index.njk
+++ b/website/src/index.njk
@@ -45,30 +45,6 @@
       That's the standard flow. There's an approval gate before any code change lands, and every run records token usage and dollar cost so you actually know what you spent.
     </p>
 
-    <div class="terminal-panel-prose">
-      <div class="terminal-bar">
-        <span class="dot dot-r"></span><span class="dot dot-y"></span><span class="dot dot-g"></span>
-        <span class="terminal-title">agent-smith fix "#54 in todo-list"</span>
-      </div>
-      <div class="terminal-body">
-        <div><span class="tk-mute">$ </span><span class="tk-text">agent-smith fix "#54 in todo-list"</span></div>
-        <div class="tk-blank"></div>
-        <div><span class="tk-mute">[1]</span> <span class="tk-text">FetchTicket          </span><span class="tk-mute">→ Null ref in UserService</span></div>
-        <div><span class="tk-mute">[2]</span> <span class="tk-text">CheckoutSource       </span><span class="tk-mute">→ branch agentsmith/ticket-54 (3 repos)</span></div>
-        <div><span class="tk-mute">[3]</span> <span class="tk-text">LoadContext          </span><span class="tk-mute">→ project context for server, client, worker</span></div>
-        <div><span class="tk-mute">[4]</span> <span class="tk-text">AnalyzeCode          </span><span class="tk-mute">→ Scout mapped 483 files</span></div>
-        <div><span class="tk-mute">[5]</span> <span class="tk-text">Triage               </span><span class="tk-mute">→ backend-dev + tester picked</span></div>
-        <div><span class="tk-mute">[6]</span> <span class="tk-text">GeneratePlan         </span><span class="tk-mute">→ 4 steps, consensus after round 1</span></div>
-        <div><span class="tk-mute">[7]</span> <span class="tk-text">Approval             </span><span class="tk-ok">→ approved</span></div>
-        <div><span class="tk-mute">[8]</span> <span class="tk-text">AgenticExecute       </span><span class="tk-mute">→ UserService.cs, authClient.ts modified</span></div>
-        <div><span class="tk-mute">[9]</span> <span class="tk-text">Test                 </span><span class="tk-ok">→ 47 tests passed</span></div>
-        <div><span class="tk-mute">[10]</span><span class="tk-text"> CommitAndPR         </span><span class="tk-url">→ pull/42, pull/43</span></div>
-        <div><span class="tk-mute">[11]</span><span class="tk-text"> PrCrossLink         </span><span class="tk-mute">→ siblings linked in both PRs</span></div>
-        <div class="tk-blank"></div>
-        <div><span class="tk-ok">2 pull requests open · ticket #54 → resolved · $0.018</span></div>
-      </div>
-    </div>
-
     <h3 class="prose-heading">The loop under the hood</h3>
     <p class="prose">
       Seen from the inside, every coding run is one control loop. The ticket gets sized into a dollar-and-token budget at admission, the plan gets ratified before a line of code changes, and the loop keeps going only while it makes real forward progress. The exit is a verification cross-checked against the real committed diff — a run can't report green without a matching change.

--- a/website/src/static/styles.css
+++ b/website/src/static/styles.css
@@ -177,40 +177,6 @@ nav.nav-bar {
 .prose-link { color: var(--color-primary); border-bottom: 1px solid var(--color-primary); }
 .prose-link:hover { border-bottom-color: transparent; }
 
-/* ─── terminal panel inside prose (card-terminal-panel per DESIGN.md) ── */
-.terminal-panel-prose {
-  background: var(--color-terminal-bg);
-  color: var(--color-terminal-text);
-  border-radius: var(--rounded-md);
-  font-family: var(--typography-mono-code-family);
-  font-size: var(--typography-mono-code-size);
-  line-height: var(--typography-mono-code-line-height);
-  overflow: hidden;
-  margin-top: var(--spacing-2xl);
-}
-.terminal-bar {
-  background: rgba(255, 255, 255, 0.04);
-  padding: var(--spacing-sm) var(--spacing-md);
-  display: flex; align-items: center; gap: var(--spacing-xs);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
-}
-.dot { width: 10px; height: 10px; border-radius: var(--rounded-pill); }
-/* macOS-style traffic-light decoration — semantic chrome, not brand tokens. */
-.dot-r { background: #ef4444; }
-.dot-y { background: #eab308; }
-.dot-g { background: var(--color-terminal-accent); }
-.terminal-title {
-  color: var(--color-terminal-mute);
-  font-size: 12px;
-  margin-left: var(--spacing-sm);
-}
-.terminal-body { padding: var(--spacing-lg) var(--spacing-xl); }
-.terminal-body .tk-mute  { color: var(--color-terminal-mute); margin-right: var(--spacing-xs); }
-.terminal-body .tk-text  { color: var(--color-terminal-text); }
-.terminal-body .tk-ok    { color: var(--color-terminal-accent); }
-.terminal-body .tk-url   { color: var(--color-terminal-link); }
-.terminal-body .tk-blank { display: block; height: var(--typography-mono-code-line-height); }
-
 /* ─── CTA ────────────────────────────────────────────────────── */
 .cta-section {
   background: var(--color-ink);


### PR DESCRIPTION
## What

Removes the terminal mockup on the landing page that showed an invented CLI:

```
$ agent-smith fix "#54 in todo-list"
[1] FetchTicket → …
[2] CheckoutSource → …
…
[11] PrCrossLink → siblings linked in both PRs
2 pull requests open · ticket #54 → resolved · $0.018
```

## Why

That demo no longer reflects how a run actually works — it presents a fictional CLI surface and pipeline step names (`FetchTicket`, `Triage`, `PrCrossLink`, …) that don't exist. It's misleading to keep propagating it. The prose above the block and the control-loop diagram below already explain the real flow, so nothing is lost.

## Changes

- `website/src/index.njk` — remove the `terminal-panel-prose` block.
- `website/src/static/styles.css` — remove the now-dead terminal CSS (`.terminal-panel-prose`, `.terminal-bar`, `.dot*`, `.terminal-title`, `.terminal-body .tk-*`); no other markup uses these classes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)