### PR TITLE
feat: dashboard favicon (brand 'a' mark)

### DIFF
--- a/src/dashboard/src/app/icon.svg
+++ b/src/dashboard/src/app/icon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="8" fill="#22c55e"/>
+  <text x="16" y="16" fill="#ffffff" text-anchor="middle" dominant-baseline="central"
+        font-family="system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="21" font-weight="800">a</text>
+</svg>


### PR DESCRIPTION
Next.js App Router auto-serves `app/icon.svg` as the favicon — a rounded green (#22c55e, the --accent brand color) square with the white bold "a", matching the sidebar logo. Replaces the default blank browser-tab icon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)