### PR TITLE
docs: update spec-first methodology to 2.1.0 — root CLAUDE.md with v2 read order (memory index)

### DIFF
--- a/.agentsmith/contexts/default/context.yaml
+++ b/.agentsmith/contexts/default/context.yaml
@@ -7,7 +7,7 @@ meta:
   workdir: "."
 
 methodology:
-  version: "2.0.1"
+  version: "2.1.0"
 
 stack:
   runtime: .NET 8

--- a/.agentsmith/decisions/p-meta-update.yaml
+++ b/.agentsmith/decisions/p-meta-update.yaml
@@ -41,3 +41,17 @@ decisions:
       into `decisions/p0132c.yaml` and the bogus `PR.yaml` deleted.
       Fix to plugin migration script for the next operator's run:
       tighten the regex to require a digit after `p` (`p[0-9][0-9a-z]*`).
+  - category: Tooling
+    chose: "Updated Spec-First methodology from v2.0.1 to v2.1.0 (memory substrate)"
+    over: "Staying on v2.0.1"
+    reason: |
+      2.1.0 adds the experiential-memory layer: memory/ + MEMORY.md were already
+      present (p0380 seed), so the retroactive structural step was a no-op; the
+      real changes are methodology.version 2.0.1 -> 2.1.0 and the root CLAUDE.md
+      created from the new v2 read-order prompt template (contexts glob,
+      decisions/*.yaml, phases/active/*.yaml, memory/MEMORY.md) — closing the
+      wrong-place context lookups for IDE sessions in this repo. decision.schema.json
+      already byte-identical with the plugin (p0380 sync); the project's
+      phase-spec.schema.json is intentionally KEPT over the plugin template (it is
+      the evolved variant — 4-digit ids, relaxed goal length — that 200 existing
+      specs validate against). Migration mode: 2.x additive merge.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,60 @@
+# agent-smith — AI Agent Instructions
+
+## Context Files (read in this order)
+
+1. **Every** `.agentsmith/contexts/<name>/context.yaml` (glob `contexts/*/context.yaml`) — architecture, stack, integrations, phase status PER stack
+2. **Every** `.agentsmith/contexts/<name>/coding-principles.md` — code quality rules per stack (ALWAYS follow)
+3. `.agentsmith/phases/active/*.yaml` — spec for the phase being implemented (its `applies_to:` names the dominant context)
+4. `.agentsmith/decisions/*.yaml` — past decisions, one YAML per phase or run (read the active phase's file and its `requires:` chain)
+5. `.agentsmith/memory/MEMORY.md` — the experiential-memory index, one line per recorded fact; recall detail from `.agentsmith/memory/<name>.md` on demand when a line touches your task
+
+## Phase Directory Structure
+
+```
+.agentsmith/phases/
+  done/       # completed phases (historical reference)
+  active/     # phase currently being worked on
+  planned/    # upcoming phases with requirements
+```
+
+## Experiential Memory (remember / recall)
+
+`.agentsmith/memory/` holds typed Markdown facts: one file per memory with
+frontmatter `name` (slug = filename), `description` (one line), and
+`metadata.type` (`feedback` = how the operator wants the agent to work,
+ratification required; `project` = goals/constraints/state not derivable from
+code or git; `reference` = external pointers). `MEMORY.md` is the index —
+one line per memory, content never in the index.
+
+- **Recall before re-deriving**: when the index hints at a fact you are about
+  to work out from scratch, read the entry file instead.
+- **Remember sparingly**: store what code and git cannot already tell the
+  next agent — one fact per file; check the index for an existing entry and
+  update rather than duplicate; delete a memory that turns out wrong; link
+  related memories as `[[slug]]` (a cited slug requires its committed
+  definition). A new or changed `feedback` entry is a PROPOSAL until the
+  operator ratifies it.
+- **Memory vs decision**: a decision records a CHOICE (`decisions/`); a
+  memory records a transferable FACT or RULE. Never duplicate one into the
+  other.
+
+## Implementation Workflow (follow this order for every phase)
+
+1. **Write phase spec first** — create `.agentsmith/phases/planned/p{NNNN}-slug.yaml` with goal, `applies_to:`, steps, and definition of done BEFORE writing any code. No exceptions.
+2. **Move to active** — move the phase file from `planned/` to `active/` when starting work.
+3. **Plan first** — explore codebase, design approach, get user approval before coding.
+4. **Implement step by step** — contracts/models first, then implementation, then wiring, then tests.
+5. **Build after each step** — fix errors immediately, don't accumulate them.
+6. **Run ALL tests** — ensure zero failures before moving on.
+7. **Log decisions** — one YAML per phase at `.agentsmith/decisions/p{NNNN}.yaml`; each entry: what was chosen, what alternatives existed, and why.
+8. **Update state** — move phase from `planned`/`active` to `done` in the relevant context's `context.yaml`.
+9. **Move to done** — move the phase file from `active/` to `done/`.
+10. **Commit** — one commit per phase, descriptive message.
+
+## Key Rules
+
+- **English only** — all code, comments, docs, exceptions, logs, commit messages. Phase specs and repo docs are English even when the conversation is German.
+- **No customer names** — never write customer, project, or target identifiers into any artifact in this repo (see `[[feedback_no_customer_names]]`).
+- **No over-engineering** — only build what the phase requires, nothing more.
+- **Tests** — every new public method gets at least one test.
+- **Follow each context's coding-principles.md** — these are constraints, not suggestions.


### PR DESCRIPTION
The 2.x → 2.1.0 additive migration from the updated update-project skill, applied to this repo:

- **Root CLAUDE.md created** from the new v2 read-order prompt template (contexts glob → coding-principles → phases/active/*.yaml → decisions/*.yaml → memory/MEMORY.md, plus the remember/recall discipline). This repo had NO root CLAUDE.md — IDE sessions had no committed read order at all, which is the wrong-place-lookup class the 2.1.0 template closes. This is the one change outside .agentsmith/ — drop the file if unwanted.
- methodology.version 2.0.1 → 2.1.0
- memory/ + MEMORY.md: already present (p0380 seed) — retroactive creation was a no-op
- decision.schema.json: already byte-identical with the plugin (p0380 sync)
- phase-spec.schema.json: intentionally KEPT (project's evolved variant — 4-digit ids, relaxed limits — that existing specs validate against; plugin template is the generic upstream)
- Update logged in decisions/p-meta-update.yaml

Companion: plugin re-land PR specification-first-agentic-development#7 (the 2.1.0 content itself — #6 had been merged into its stacked base after the base was already squashed, so it never reached main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)