### PR TITLE
fix(hooks): phase gate must test the tree the commit runs in

### DIFF
--- a/.claude/hooks/phase-gate.sh
+++ b/.claude/hooks/phase-gate.sh
@@ -25,8 +25,14 @@
 set -uo pipefail
 
 input=$(cat)
-cmd=$(printf '%s' "$input" \
-  | python3 -c 'import sys,json; print(json.load(sys.stdin).get("tool_input",{}).get("command",""))' 2>/dev/null) || exit 0
+read -r cmd_b64 cwd_b64 <<<"$(printf '%s' "$input" | python3 -c '
+import sys, json, base64
+d = json.load(sys.stdin)
+enc = lambda s: base64.b64encode((s or "").encode()).decode()
+print(enc(d.get("tool_input", {}).get("command", "")), enc(d.get("cwd", "")))
+' 2>/dev/null)" || exit 0
+cmd=$(printf '%s' "$cmd_b64" | base64 -d 2>/dev/null)
+hook_cwd=$(printf '%s' "$cwd_b64" | base64 -d 2>/dev/null)
 
 # Only gate an actual `git commit` invocation (command word at start or after a
 # shell separator) whose message names a phase, e.g. (p0272) / (p73a). This
@@ -35,13 +41,30 @@ cmd=$(printf '%s' "$input" \
 printf '%s' "$cmd" | grep -Eq '(^|[;&|]|&&)[[:space:]]*git[[:space:]]+commit\b' || exit 0
 printf '%s' "$cmd" | grep -Eq '\(p[0-9]+[a-z]?\)' || exit 0
 
-cd "${CLAUDE_PROJECT_DIR:-.}" || { echo "phase-gate: cannot cd to project dir" >&2; exit 2; }
+# Gate the tree the commit ACTUALLY runs in, not the session's project dir. Work
+# in a git worktree (a phase implemented on its own branch) lives outside
+# CLAUDE_PROJECT_DIR, so the old unconditional `cd "$CLAUDE_PROJECT_DIR"` built and
+# tested the main checkout and waved the worktree's changes through without ever
+# compiling them — the gate reported numbers from code the commit does not contain.
+# Resolution order: an explicit leading `cd <dir>` in the command, then the hook
+# payload's cwd, then the project dir; each resolved to its git top level.
+target_dir=""
+for candidate in \
+  "$(printf '%s' "$cmd" | sed -n 's/^[[:space:]]*cd[[:space:]]\{1,\}\([^&;|]*\).*/\1/p' | head -1 | sed 's/[[:space:]]*$//' | tr -d "\"'")" \
+  "$hook_cwd" \
+  "${CLAUDE_PROJECT_DIR:-.}"
+do
+  [ -n "$candidate" ] && [ -d "$candidate" ] || continue
+  target_dir=$(cd "$candidate" 2>/dev/null && git rev-parse --show-toplevel 2>/dev/null) && [ -n "$target_dir" ] && break
+done
+[ -n "$target_dir" ] || { echo "phase-gate: cannot resolve the git tree to gate" >&2; exit 2; }
+cd "$target_dir" || { echo "phase-gate: cannot cd to $target_dir" >&2; exit 2; }
 
 tmp=$(mktemp -d 2>/dev/null || echo /tmp)
 log()  { echo "[phase-gate] $*" >&2; }
 fail() { echo "" >&2; echo "PHASE GATE BLOCKED COMMIT — $1 failed. Fix it before committing the phase." >&2; exit 2; }
 
-log "phase commit detected — running blocking gate (build, tests, dry-runs, harness presets)"
+log "phase commit detected — gating $target_dir (build, tests, dry-runs, harness presets)"
 
 log "1/4 build..."
 if ! dotnet build AgentSmith.sln -clp:ErrorsOnly >"$tmp/build.log" 2>&1; then


### PR DESCRIPTION
The phase gate unconditionally `cd`'d to `CLAUDE_PROJECT_DIR`. A phase implemented in a git worktree — the normal shape when work runs on its own branch — was therefore built and tested in the **main checkout**:

- it blocked a commit twice on failures from code the commit did not contain (once on `RedisJobBusTests` needing Docker, once on a `JobsBroadcasterDrainTests` flake), and
- it would have waved the worktree's actual changes through **without ever compiling them**. The test counts it printed (3545) came from a tree that did not have the phase's new tests (3552).

A gate that reports numbers from the wrong tree is worse than no gate: it produces evidence for a claim it never checked.

Resolution order is now an explicit leading `cd <dir>` in the command, then the hook payload's `cwd`, then the project dir — each resolved to its git top level. The log line names the tree being gated, so a wrong-tree case is visible rather than silent.

Verified against four payload shapes: explicit `cd` into a worktree, hook `cwd` in a worktree, plain main checkout, and a non-phase commit (passes through untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)