### PR TITLE
docs: specs for p0391b, p0388d, p0392, p0374a

### DIFF
--- a/.agentsmith/phases/planned/p0374a-done-stays-done.yaml
+++ b/.agentsmith/phases/planned/p0374a-done-stays-done.yaml
@@ -1,0 +1,66 @@
+# yaml-language-server: $schema=../../phase-spec.schema.json
+phase: p0374a
+goal: "A ledger entry marked done stays done unless the model reopens it explicitly, and every transition is traceable — restoring the merge p0374 removed on a rationale p0368 had already satisfied"
+
+applies_to: "pipeline"
+
+requires: [p0368, p0374, p0393a]
+
+decisions:
+  - key: |
+      p0368 built LedgerMergePolicy: an incoming ledger MERGES with the stored one, and a
+      done entry returns to open only through an explicit reopen token. p0374 removed it, and
+      its stated rationale — that the model must be able to correct its own record — was the
+      exact case the reopen token already covered. The traceability snapshot p0374 promised
+      in exchange never shipped, so the system lost the guard and did not gain the
+      replacement.
+  - key: |
+      The operator has seen the consequence directly: a run that showed everything green and
+      finished, then showed something else entirely a moment later. Their ruling was plain —
+      done should not be replaced; on our side we keep order and state once something is done.
+  - key: |
+      This is NOT a re-argument about how much authority the ledger has. p0393 settled that:
+      the ledger has no vote on a green verdict and keeps one on red, where it separates
+      "gave up early" from "genuinely stuck". This phase is about the ledger not LYING —
+      about a record of what happened staying a record. A checklist that silently rewrites
+      its own history is unusable for the one job p0393 left it: telling a watcher what the
+      machine did, and when.
+  - key: |
+      Sequenced after p0393a because both edit the master's ledger handling, and p0393a is
+      the larger, less mechanical change. Landing this first would make that merge harder for
+      no gain.
+
+steps:
+  - id: restore-merge
+    action: "An incoming ledger merges with the stored one; a done entry survives unless the model sends the explicit reopen token"
+    modify:
+      - "The ledger update path in the master handler: merge rather than replace"
+  - id: reopen-token
+    action: "The reopen token is the only way back from done, and the skill says so"
+    modify:
+      - "coding-agent-master: how to reopen a step that turned out not to be finished"
+  - id: traceability
+    action: "Every transition is recorded with its cause — the snapshot p0374 promised and never delivered"
+    new:
+      - "A per-transition record: entry, from-state, to-state, cause, pass number"
+    modify:
+      - "The run trail: transitions are readable alongside the ledger"
+  - id: no-silent-rewrite
+    action: "An incoming ledger that would drop or downgrade a done entry without the token is refused and the attempt is recorded"
+    modify:
+      - "The merge policy: the refusal is visible, not a silent keep"
+
+tests:
+  - "Merge_IncomingWithoutDoneEntry_KeepsTheStoredDone"
+  - "Merge_IncomingDowngradesDoneWithoutToken_IsRefusedAndRecorded"
+  - "Merge_IncomingCarriesReopenToken_ReopensTheEntry"
+  - "Merge_NewEntries_AreAppended"
+  - "Traceability_EveryTransition_CarriesItsCauseAndPass"
+  - "Trail_LedgerTransitions_AreReadable"
+
+done:
+  - "A done entry cannot become open again without the explicit token — asserted for drop, downgrade and omission"
+  - "Every transition is recorded with cause and pass, and readable on the trail"
+  - "A refused rewrite is visible rather than silently ignored"
+  - "The skill states the one way to reopen a step"
+  - "Full suite green"

--- a/.agentsmith/phases/planned/p0388d-live-detail-follows-the-run.yaml
+++ b/.agentsmith/phases/planned/p0388d-live-detail-follows-the-run.yaml
@@ -1,0 +1,67 @@
+# yaml-language-server: $schema=../../phase-spec.schema.json
+phase: p0388d
+goal: "The step-detail view follows a running step instead of freezing on its first page: newest-anchored reads, a forward delta poll while the run is live, and an explicit way back into history"
+
+applies_to: "server + dashboard"
+
+requires: [p0388a, p0388b]
+
+decisions:
+  - key: |
+      p0388a and p0388b moved the run rail onto database projections, so the SPINE survives a
+      long run. The detail pane did not move with it. Two defects remain, and together they
+      produce the symptom the operator reported: the left counter climbs while the right pane
+      shows nothing new.
+  - key: |
+      Defect one is the anchor. TrailReader's step page is ordered ascending from the OLDEST
+      row (`Seq > sinceSeq`, `OrderBy(Seq)`, `Take(page)`), so opening a step that has since
+      produced thousands of rows returns its FIRST page — the beginning of a step whose
+      interesting end is what the operator opened it for. A live view must anchor at the
+      newest end and walk backwards.
+  - key: |
+      Defect two is that nothing re-reads. The detail hooks fetch once on mount; only the
+      2-second trail poll refreshes, and it feeds the rail rather than the open step. So a
+      step that is still producing rows looks finished. A forward delta poll (~1s) while the
+      RUN is live, stopping when it ends, is the smallest thing that makes the pane honest.
+  - key: |
+      Newest-anchored is not a substitute for history: an operator diagnosing a run needs the
+      beginning too. So "load older" is explicit and paged, not an infinite scroll that
+      re-fetches what the rail already dropped once for cost reasons.
+  - key: |
+      No cap. p0388a/b exist because caps were the wrong answer — the operator's ruling was
+      that a four-hour pipeline cannot be bounded by a number nobody can defend. Paging is
+      bounded by what is on screen, which is a property of the view rather than a guess about
+      the run.
+
+steps:
+  - id: newest-anchor
+    action: "The step page reads from the newest end: descending from a cursor, with the page returned in display order"
+    modify:
+      - "TrailReader: the step page query anchors at the newest row"
+  - id: forward-delta
+    action: "The open step polls forward for rows after its newest cursor about once a second while the run is live, and stops when the run ends"
+    modify:
+      - "The step-detail hook: a forward delta poll bounded by the run's own liveness"
+  - id: load-older
+    action: "An explicit control pages backwards into the step's history"
+    new:
+      - "A backwards pager on the step-detail view, driven by the same cursor"
+  - id: no-silent-truncation
+    action: "A step with more rows than the view holds says so, rather than showing a page that looks complete"
+    modify:
+      - "The step-detail view: state that older rows exist"
+
+tests:
+  - "TrailReader_StepWithManyRows_ReturnsTheNewestPage"
+  - "TrailReader_BackwardsCursor_WalksIntoHistoryWithoutGaps"
+  - "StepDetail_RunLive_PollsForwardAndAppendsNewRows"
+  - "StepDetail_RunFinished_StopsPolling"
+  - "StepDetail_MoreRowsThanShown_SaysOlderRowsExist"
+
+done:
+  - "Opening a step that has produced thousands of rows shows its newest, not its first"
+  - "An open step on a live run keeps appending without the operator pressing anything"
+  - "Polling stops when the run does — a finished run costs nothing"
+  - "History is reachable, explicitly and without gaps"
+  - "Nothing is truncated silently"
+  - "Full suite green"

--- a/.agentsmith/phases/planned/p0391b-no-startup-path-throws.yaml
+++ b/.agentsmith/phases/planned/p0391b-no-startup-path-throws.yaml
@@ -1,0 +1,72 @@
+# yaml-language-server: $schema=../../phase-spec.schema.json
+phase: p0391b
+goal: "The remaining startup paths that still throw become probes that record a finding, and the CLI validates the same configuration the server does — so a bad config is reported by whichever surface the operator is holding"
+
+applies_to: "server + cli"
+
+requires: [p0391a, p0393]
+
+decisions:
+  - key: |
+      p0391a established the ruling — aborting startup is never justifiable, because a dead
+      process reports nothing and an operator who cannot be told what is broken is as
+      incapable as the service. It converted the paths it found. This phase closes the rest,
+      and the reason it is a separate phase is that p0391a's own spec sentence did not stop
+      a throw: the ClarificationParkStatusRule threw at boot on the day it shipped. A ruling
+      is not a mechanism.
+  - key: |
+      Evidence that the class is not closed: p0393 found ANOTHER one, in a path p0391a had
+      already written a probe for. AddJobSpawnerAsync registered no IJobSpawner when neither
+      Docker nor Kubernetes was reachable, so a hosted service could not be constructed and
+      StartAsync threw — and SpawnerProbe, written for exactly that situation, could never
+      publish its finding because the process died first. An absent dependency killed the
+      server, not a broken one. Every remaining throw is assumed to hide the same shape until
+      each is checked.
+  - key: |
+      ConfigCatalogResolver.ThrowIfErrors is the biggest one and needs a decision rather than
+      a mechanical conversion: it aggregates every configuration error into one throw. As a
+      finding it must stay ONE finding per error with its field, not one config-wide blob —
+      an operator fixing six things needs six lines, and p0391a's findings endpoint already
+      carries unit, field, severity and reason per entry.
+  - key: |
+      The CLI validates the same configuration through the same rules. Today an operator can
+      load a config the server will refuse and learn about it only from a container that
+      comes up degraded. Same rules, same findings, printed — not a second validator, which
+      would be a second source of truth about what a valid configuration is.
+
+steps:
+  - id: inventory
+    action: "List every remaining throw on a startup path and classify each: convert to a probe finding, or state why it must stay fatal"
+    new:
+      - "The inventory as decisions in this phase's decision file — a throw kept fatal must name what an operator could do about it"
+  - id: config-catalog-resolver
+    action: "ConfigCatalogResolver reports one finding per configuration error with its field, instead of one aggregated throw"
+    modify:
+      - "ConfigCatalogResolver: ThrowIfErrors becomes a finding-producing evaluation"
+  - id: remaining-paths
+    action: "Convert the rest of the inventory"
+    modify:
+      - "Each startup path identified in step 1"
+  - id: cli-validate
+    action: "The CLI validates a configuration through the server's own rules and prints the findings"
+    new:
+      - "A CLI validate command reporting the same StartupFindings the server would record"
+  - id: boot-under-failure
+    action: "Composition tests boot the real server with each converted dependency broken — the teeth p0391a needed and this phase inherits"
+    modify:
+      - "The startup-resilience composition tests, extended per converted path"
+
+tests:
+  - "Startup_EveryConvertedPath_RecordsAFindingAndTheServerAnswers"
+  - "ConfigCatalogResolver_SixErrors_ProducesSixFindingsWithTheirFields"
+  - "ConfigCatalogResolver_NoErrors_ProducesNone"
+  - "Cli_Validate_ReportsTheSameFindingsAsTheServer"
+  - "Cli_Validate_ValidConfig_ExitsZero"
+  - "StartupPaths_NoRemainingThrow_IsUnaccountedFor"
+
+done:
+  - "Every remaining startup throw is either converted or listed with the reason it stays fatal — no path is unaccounted for"
+  - "A configuration with several errors produces one finding per error, each naming its field"
+  - "The CLI reports what the server would report, from the same rules"
+  - "A composition test boots the server with each converted dependency broken and the diagnostic surface answers"
+  - "Full suite green"

--- a/.agentsmith/phases/planned/p0392-config-studio-shows-what-is-missing.yaml
+++ b/.agentsmith/phases/planned/p0392-config-studio-shows-what-is-missing.yaml
@@ -1,0 +1,75 @@
+# yaml-language-server: $schema=../../phase-spec.schema.json
+phase: p0392
+goal: "Config Studio edits every field the backend reads and says which required ones are missing — so a configuration cannot be incomplete in a way only a failed run reveals"
+
+applies_to: "server + dashboard"
+
+requires: [p0349, p0345c, p0391a]
+
+decisions:
+  - key: |
+      Operator report, 2026-07-31: a trigger was missing needs_clarification_status, the
+      server refused to start, and the way out was rolling back to an older image, exporting
+      the config through the CLI, hand-editing it, importing and rolling forward. The startup
+      half is p0391a's. This is the other half: the field could not be set in the UI at all,
+      so no amount of care would have prevented it.
+  - key: |
+      The gap is measured, not assumed. The tracker section reads roughly sixteen backend
+      fields and offers eleven; missing at least needs_clarification_status,
+      close_transition_name, extra_fields, zero_match_comment, endpoints and
+      not_implementable_status. The trigger section is missing needs_clarification_status,
+      project_resolution and default_pipeline. Step one re-measures before anything is built,
+      because that list is days old and p0393 has since changed what a pipeline name may be.
+  - key: |
+      The capabilities descriptor is the lever. GET /api/config/capabilities already tells the
+      UI which types and fields exist; p0393 proved it stays honest (it now offers `code` and
+      not the retired aliases). Deriving the form from it means a field added to the backend
+      cannot stay invisible — which is the actual defect, not any one missing input.
+  - key: |
+      Missing REQUIRED is shown before saving, not after starting. p0391a made the server
+      report what is missing once it is running; a configuration that cannot start is worth
+      catching in the editor that produced it. Same rules, one source: the Studio asks the
+      same validation the server uses rather than restating the requirements in TypeScript.
+  - key: |
+      Retired preset names are accepted but never offered — the p0393 distinction between
+      IsAcceptedName and Names. An operator's existing `fix-bug` trigger must keep loading
+      and must not be presented as a choice for a new one.
+
+steps:
+  - id: measure
+    action: "Enumerate every field the backend reads per section against what the Studio offers, and record the gap"
+    new:
+      - "The measured gap as decisions in this phase's decision file — the list drives the work and the done-check"
+  - id: capabilities-drives-the-form
+    action: "The Studio renders its inputs from the capabilities descriptor, so a backend field that is not offered is a capabilities gap rather than a UI omission"
+    modify:
+      - "The capabilities endpoint: every field the backend reads, with its requiredness"
+      - "The Studio's config forms: derived from the descriptor"
+  - id: missing-required
+    action: "A section missing a required field says so, on the section and on the field, before it can be saved"
+    modify:
+      - "The Studio's validation surface: required-but-empty, using the server's rules"
+  - id: aliases
+    action: "A stored retired pipeline name loads and is labelled as retired; the picker offers only current names"
+    modify:
+      - "The pipeline picker and its value handling"
+  - id: guard
+    action: "A test walks the backend's read surface against the capabilities descriptor so the next added field cannot go missing"
+    new:
+      - "A descriptor-completeness test over the config models"
+
+tests:
+  - "Capabilities_EveryBackendReadField_IsDeclared"
+  - "Capabilities_DeclaredFields_CarryTheirRequiredness"
+  - "Studio_TriggerMissingNeedsClarificationStatus_IsFlaggedBeforeSave"
+  - "Studio_RequiredFieldEmpty_BlocksSaveAndNamesTheField"
+  - "Studio_StoredRetiredPipelineName_LoadsAndIsLabelledRetired"
+  - "Studio_PipelinePicker_OffersOnlyCurrentNames"
+
+done:
+  - "Every field the backend reads is editable in the Studio — measured against the read surface, not against a list written by hand"
+  - "A required field left empty is named in the editor, before saving, by the server's own rules"
+  - "The specific case that caused the outage — a trigger without needs_clarification_status — is caught in the UI"
+  - "An existing configuration naming a retired preset still loads, and no new one can be created with it"
+  - "A newly added backend field fails a test until the descriptor declares it"
+  - "Full suite green"


### PR DESCRIPTION
Four phases that existed only as prose in `context.yaml`. No agent can work from a description, and each carries a decision that needs the context it came from — so they are written before anyone picks them up. Specs only, no code.

- **p0391b** — the remaining startup throws become findings, and the CLI validates through the server's own rules. p0393 found *another* instance of that class while it was open, in a path p0391a had already written a probe for, so the phase assumes the class is not closed until each path is checked.
- **p0388d** — the step-detail pane. `TrailReader` anchors at the *oldest* row and nothing re-reads, so a live step looks finished while the counter climbs. No caps — that was the ruling behind p0388a/b.
- **p0392** — the Studio edits every field the backend reads. The 2026-07-31 outage happened because the field that broke startup could not be set in the UI at all.
- **p0374a** — restores the merge p0374 removed on a rationale p0368's reopen token had already satisfied, plus the traceability p0374 promised and never shipped. Sequenced after p0393a: both edit the master's ledger handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)