### PR TITLE
feat: the step detail follows a live run (p0388d)

### DIFF
--- a/.agentsmith/decisions/p0388d.yaml
+++ b/.agentsmith/decisions/p0388d.yaml
@@ -1,0 +1,81 @@
+# yaml-language-server: $schema=../decision.schema.json
+phase: p0388d
+
+decisions:
+  - category: Architecture
+    chose: "The step page is read from the newest end backwards, with a cursor that walks into history"
+    over: "Keeping the ascending read and jumping to the last page by counting the step's rows"
+    reason: |
+      The p0388b query read `Seq > sinceSeq` ascending, so opening a step returned its FIRST
+      page. That is the wrong end by construction: an operator opens a long step to find out
+      how it ENDED. Counting rows first to compute an offset would have been a second query
+      whose answer is stale before the page is read, and OFFSET paging over a growing table
+      skips or repeats rows exactly when the run is busiest. Reading descending from a cursor
+      and reversing the page uses the same (RunId, StepIndex, Seq) index p0388a added, costs
+      one query, and stays correct while rows are being appended underneath it — each
+      backwards page is contiguous with the one before it, so the walk has no gaps.
+
+  - category: Architecture
+    chose: "One route, three directions, and a response that ships only the flag its direction established"
+    over: "A single response shape carrying hasOlder and hasNewer on every read"
+    reason: |
+      A forward delta cannot answer "are there older rows" without a second query, and a
+      backwards page cannot answer "is more arriving". Filling both fields on every response
+      would have meant asserting a `false` no query established — and a forward tick would
+      then clear the `older rows exist` notice the opening read had correctly set. The
+      endpoint emits `{events, oldestSeq, newestSeq, hasOlder}` for a backwards read and
+      `{events, newestSeq, hasNewer}` for a forward one, and the client merges what it is
+      told rather than what it can infer from an absence.
+
+  - category: Implementation
+    chose: "sinceSeq=0 reads as the NEWEST page, not as a forward read from the beginning"
+    reason: |
+      A caller with no cursor holds nothing, and reading forward from nothing is precisely the
+      defect this phase removes. Treating a zero cursor as "no anchor" also means a browser
+      still running the p0388b bundle gets the newest page instead of the old wrong end, and
+      it leaves "everything from the start, forward" deliberately unreachable — the request
+      whose response size is O(runtime).
+
+  - category: Implementation
+    chose: "The poll's interval bounds the GAP between ticks; a tick drains what is waiting"
+    over: "Re-arming the timer at 0 ms while the server reports more pages"
+    reason: |
+      A step that produced more than one page between ticks would otherwise be followed a page
+      per second and fall further behind the busier it got — the pane would be honest about
+      the past and wrong about the present. The tick now reads on until the server says
+      nothing newer is left, so what bounds it is the step's own backlog rather than a timer.
+      The first cut used a 0 ms re-arm and its test needed several timer advances to reach one
+      steady state, which is the shape of a design that only converges eventually.
+
+  - category: TradeOff
+    chose: "No cap on what an open step accumulates in the client"
+    over: "Trimming the head of the list once it passes N rows"
+    reason: |
+      p0388a/b exist because caps were the wrong answer: the operator's ruling was that a
+      four-hour pipeline cannot be bounded by a number nobody can defend, and a FIFO trim is
+      the same eviction that ate the run rail's spine. What is bounded here is the REQUEST —
+      one page per read, in both directions — which is a property of the view. An open step
+      grows only while an operator is watching it, and closing the step drops the page.
+
+  - category: Implementation
+    chose: "Liveness is the RUN's status, and one shared definition of it"
+    over: "Deriving liveness from the selected step's own status"
+    reason: |
+      A step row is `running` until its StepFinished lands, so a step that ended while the
+      pane was open would stop following a run that had moved on, and a step whose finish
+      event is still buffered would be declared dead early. The run's status is the fact that
+      decides whether anything can still be written. `queued` and `waiting_for_input` count as
+      live: both resume as the same run, and freezing the pane exactly where the operator is
+      waiting for movement is the symptom, not the fix. RunCard already owned that set for the
+      cancel button, so isRunLive now serves both — "can this run still do something" is one
+      question, not two.
+
+  - category: Scope
+    chose: "The pane states what it is NOT showing, above the body"
+    over: "A load-more button at the bottom, as p0388b had it"
+    reason: |
+      With a newest-anchored page the missing rows are ABOVE, and a bare button says nothing
+      about whether anything is missing at all. The notice and the control sit together where
+      the truncation is, so a page that is a slice never reads as a complete step. This also
+      keeps the walk back explicit rather than an infinite scroll that would silently re-fetch
+      history the operator did not ask for.

--- a/src/backend/AgentSmith.Server/Extensions/RunStepQueryEndpoints.cs
+++ b/src/backend/AgentSmith.Server/Extensions/RunStepQueryEndpoints.cs
@@ -31,13 +31,45 @@ internal static class RunStepQueryEndpoints
         return Results.Ok(new { steps = rail });
     }
 
+    /// <summary>
+    /// p0388d: one step's events, in the direction the caller asks for.
+    /// <c>sinceSeq</c> (positive) is the live poll's forward delta;
+    /// <c>beforeSeq</c> walks backwards into history; neither means "the newest
+    /// page", which is what opening a step now returns.
+    ///
+    /// <para><c>sinceSeq=0</c> is deliberately NOT a forward read: a caller with
+    /// no cursor holds nothing, and reading forward from nothing is exactly the
+    /// defect this phase removes — it hands back the FIRST page of a step that
+    /// has since produced thousands of rows. It reads as "the newest page".</para>
+    ///
+    /// <para>The response carries only the flag the direction established:
+    /// a forward delta knows nothing about older rows, and saying
+    /// <c>hasOlder: false</c> there would overwrite what the caller already
+    /// learned from its opening read.</para>
+    /// </summary>
     internal static async Task<IResult> GetRunStepEventsAsync(
-        string runId, int stepIndex, long? sinceSeq, int? limit,
+        string runId, int stepIndex, long? sinceSeq, long? beforeSeq, int? limit,
         TrailReader trailReader, CancellationToken cancellationToken)
     {
-        var page = await trailReader.ReadStepPageAsync(
-            runId, stepIndex, sinceSeq ?? 0, limit, cancellationToken);
-        return Results.Ok(new { events = page.Events, nextSeq = page.NextSeq, hasMore = page.HasMore });
+        if (sinceSeq is > 0)
+        {
+            var delta = await trailReader.ReadStepForwardAsync(
+                runId, stepIndex, sinceSeq.Value, limit, cancellationToken);
+            return Results.Ok(new
+            {
+                events = delta.Events, newestSeq = delta.NewestSeq, hasNewer = delta.HasNewer,
+            });
+        }
+
+        var page = await trailReader.ReadStepBackwardsAsync(
+            runId, stepIndex, beforeSeq, limit, cancellationToken);
+        return Results.Ok(new
+        {
+            events = page.Events,
+            oldestSeq = page.OldestSeq,
+            newestSeq = page.NewestSeq,
+            hasOlder = page.HasOlder,
+        });
     }
 
     internal static async Task<IResult> GetRunDecisionsAsync(

--- a/src/backend/AgentSmith.Server/Services/Events/TrailReader.cs
+++ b/src/backend/AgentSmith.Server/Services/Events/TrailReader.cs
@@ -30,8 +30,10 @@ public sealed class TrailReader(IConnectionMultiplexer redis, IServiceScopeFacto
     public const int MaxPageCount = 2000;
 
     // p0388b: a step's detail page is bounded like the runs-list page — the view
-    // shows one step, and "load more" walks the cursor. The ceiling is what keeps
+    // shows one step, and the cursor walks from there. The ceiling is what keeps
     // a hand-edited limit from scanning a whole run's trail into one response.
+    // p0388d: this is a PAGE size, not a cap on the step: what it bounds is one
+    // response, and both directions of the walk reach every row.
     public const int DefaultStepPageCount = 100;
     public const int MaxStepPageCount = 200;
 
@@ -150,14 +152,58 @@ public sealed class TrailReader(IConnectionMultiplexer redis, IServiceScopeFacto
     }
 
     /// <summary>
-    /// p0388b: ONE step's structural events as a clamped, Seq-ordered page. The
-    /// (RunId, StepIndex, Seq) index added in p0388a serves both the filter and
-    /// the order, so a step's detail costs O(page) regardless of how large the
-    /// run's trail grew. The cursor is the last Seq shipped; <c>HasMore</c> says
-    /// whether another page follows. An unknown step index is an empty page, not
-    /// an error — a step can be selected before its events are flushed.
+    /// p0388b/p0388d: ONE step's structural events as a clamped page, read from
+    /// the NEWEST end backwards. The (RunId, StepIndex, Seq) index added in
+    /// p0388a serves both the filter and the order, so a step's detail costs
+    /// O(page) regardless of how large the run's trail grew.
+    ///
+    /// <para>p0388d: the ANCHOR is what this fixes. The p0388b query read
+    /// ascending from <c>Seq &gt; sinceSeq</c>, so opening a step that had since
+    /// produced thousands of rows returned its FIRST page — the beginning of a
+    /// step whose interesting end is what the operator opened it for.
+    /// <paramref name="beforeSeq"/> null means "the newest page"; a value walks
+    /// backwards into history, each page contiguous with the one before it so
+    /// the walk has no gaps. Events come back in display order (oldest first)
+    /// whichever direction the query ran.</para>
+    ///
+    /// <para>An unknown step index is an empty page, not an error — a step can
+    /// be selected before its events are flushed.</para>
     /// </summary>
-    public async Task<StepEventPage> ReadStepPageAsync(
+    public async Task<StepEventPage> ReadStepBackwardsAsync(
+        string runId, int stepIndex, long? beforeSeq, int? limit, CancellationToken cancellationToken)
+    {
+        var page = Math.Clamp(limit ?? DefaultStepPageCount, 1, MaxStepPageCount);
+        var ceiling = beforeSeq ?? long.MaxValue;
+        using var scope = scopeFactory.CreateScope();
+        var uow = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+        var rows = await uow.Set<Infrastructure.Persistence.Entities.RunEvent>()
+            .AsNoTracking()
+            .Where(e => e.RunId == runId && e.StepIndex == stepIndex && e.Seq < ceiling)
+            .OrderByDescending(e => e.Seq)
+            .Take(page + 1)
+            .ToListAsync(cancellationToken);
+
+        var hasOlder = rows.Count > page;
+        // Descending scan, ascending page: the extra row only proves older rows
+        // exist and is then dropped, so what the caller renders stays contiguous.
+        var slice = (hasOlder ? rows.Take(page) : rows).Reverse().ToList();
+        return new StepEventPage(
+            Materialize(slice),
+            OldestSeq: slice.Count > 0 ? slice[0].Seq : beforeSeq ?? 0,
+            NewestSeq: slice.Count > 0 ? slice[^1].Seq : beforeSeq ?? 0,
+            HasOlder: hasOlder,
+            HasNewer: false);
+    }
+
+    /// <summary>
+    /// p0388d: one step's FORWARD delta — the rows written after
+    /// <paramref name="sinceSeq"/>, in display order. This is what an open step
+    /// polls while the run is live, so the pane keeps appending instead of
+    /// freezing on the page it was opened with. <c>HasNewer</c> says the delta
+    /// was larger than one page, which lets the caller read on immediately
+    /// rather than trailing a busy step by a page per tick.
+    /// </summary>
+    public async Task<StepEventPage> ReadStepForwardAsync(
         string runId, int stepIndex, long sinceSeq, int? limit, CancellationToken cancellationToken)
     {
         var page = Math.Clamp(limit ?? DefaultStepPageCount, 1, MaxStepPageCount);
@@ -170,18 +216,29 @@ public sealed class TrailReader(IConnectionMultiplexer redis, IServiceScopeFacto
             .Take(page + 1)
             .ToListAsync(cancellationToken);
 
-        var hasMore = rows.Count > page;
-        var slice = hasMore ? rows.Take(page).ToList() : rows;
-        var events = new List<object>(slice.Count);
-        foreach (var row in slice)
+        var hasNewer = rows.Count > page;
+        var slice = hasNewer ? rows.Take(page).ToList() : rows;
+        return new StepEventPage(
+            Materialize(slice),
+            OldestSeq: slice.Count > 0 ? slice[0].Seq : sinceSeq,
+            NewestSeq: slice.Count > 0 ? slice[^1].Seq : sinceSeq,
+            HasOlder: false,
+            HasNewer: hasNewer);
+    }
+
+    // The cursors are taken from the ROWS, not from the events, so a payload
+    // that fails to deserialize still advances the walk instead of wedging the
+    // caller in a loop that re-reads the same bad row for ever.
+    private static IReadOnlyList<object> Materialize(
+        IReadOnlyList<Infrastructure.Persistence.Entities.RunEvent> rows)
+    {
+        var events = new List<object>(rows.Count);
+        foreach (var row in rows)
         {
             var ev = EventEnvelopeSerializer.DeserializeRaw(row.Type, row.PayloadJson);
             if (ev is not null) events.Add(ev);
         }
-        // Advance past every scanned row even if one failed to deserialize, so a
-        // single bad payload cannot wedge the caller in a loop.
-        var nextSeq = slice.Count > 0 ? slice[^1].Seq : sinceSeq;
-        return new StepEventPage(events, nextSeq, hasMore);
+        return events;
     }
 
     private static IReadOnlyList<object> ToEvents(StreamEntry[] entries) =>
@@ -190,8 +247,16 @@ public sealed class TrailReader(IConnectionMultiplexer redis, IServiceScopeFacto
     /// <summary>p0373: a Seq-delta page of the DB structural trail.</summary>
     public sealed record DbTrailPage(IReadOnlyList<object> Events, long MaxSeq);
 
-    /// <summary>p0388b: one clamped page of a single step's structural events.</summary>
-    public sealed record StepEventPage(IReadOnlyList<object> Events, long NextSeq, bool HasMore);
+    /// <summary>
+    /// p0388b/p0388d: one clamped page of a single step's structural events, in
+    /// display order. Both cursors are always filled; each direction fills the
+    /// flag it can answer — <see cref="HasOlder"/> on a backwards read,
+    /// <see cref="HasNewer"/> on a forward one — and the endpoint ships only the
+    /// flag the caller's direction asked about, rather than asserting a "no"
+    /// the query never established.
+    /// </summary>
+    public sealed record StepEventPage(
+        IReadOnlyList<object> Events, long OldestSeq, long NewestSeq, bool HasOlder, bool HasNewer);
 
     private static IReadOnlyList<RunEvent> ToTypedEvents(StreamEntry[] entries)
     {

--- a/src/dashboard/src/app/jobs/[id]/page.tsx
+++ b/src/dashboard/src/app/jobs/[id]/page.tsx
@@ -23,6 +23,7 @@ import { ResultDetail } from "@/components/execution/ResultDetail";
 import type { ExecutionNodeProps } from "@/components/execution/ExecutionNode";
 import type { NodeStatus } from "@/components/execution/TimingGutter";
 import { deriveRunRepoNames } from "@/lib/runRepoNames";
+import { isRunLive } from "@/lib/runLiveness";
 import { formatRunSummary } from "@/lib/formatRunSummary";
 import { stepIndexOf, toRailNodes } from "@/lib/runStepRail";
 import { cn } from "@/lib/utils";
@@ -347,10 +348,14 @@ function Detail(props: DetailProps) {
 }
 
 // p0388b: the selected step's body is ONE clamped page of that step's own
-// events, fetched on selection and extended through the Seq cursor. The rail row
+// events, fetched on selection and paged through the Seq cursor. The rail row
 // supplies the identity (label, status, duration, cost) — it comes from the
 // projection and is complete; the page supplies only the body, so nothing here
 // depends on the client's live event window.
+//
+// p0388d: the page now starts at the step's NEWEST events and follows the run
+// while it is live. What it is not showing is stated above the body, with the
+// walk back into history as an explicit control next to the statement.
 function StepDetail({
   runId,
   snapshot,
@@ -362,33 +367,39 @@ function StepDetail({
   railNode: ExecutionNodeProps | null;
   stepIndex: number | null;
 }) {
-  const page = useRunStepEvents(runId, stepIndex);
+  const page = useRunStepEvents(runId, stepIndex, isRunLive(snapshot?.status));
   // The step's page is a bounded event list — the same composer that used to
   // fold the whole run now composes exactly one step from exactly its events.
   const { nodes: composed } = useRunExecutionTree(page.events, snapshot, runId);
   const body = composed[0]?.body;
   const children = composed[0]?.children ?? [];
   const node = railNode ? { ...railNode, body } : null;
+  const lead = page.hasOlder ? (
+    <div
+      data-testid="step-events-older-notice"
+      className="mb-3 flex flex-wrap items-center gap-3 rounded-md border border-stone-200 bg-stone-50 px-3 py-2 text-sm text-stone-600"
+    >
+      <span>Showing this step&rsquo;s newest events — older ones exist.</span>
+      <button
+        type="button"
+        data-testid="step-events-load-older"
+        className="rounded-md border border-stone-300 bg-white px-3 py-1 text-sm text-stone-600 hover:bg-stone-50"
+        disabled={page.loading}
+        onClick={page.loadOlder}
+      >
+        {page.loading ? "Loading…" : "Load older events"}
+      </button>
+    </div>
+  ) : null;
   const footer = (
     <>
       {children.map((c) => (
         <ExecutionNode key={c.id} {...c} depth={0} />
       ))}
-      {page.hasMore && (
-        <button
-          type="button"
-          data-testid="step-events-load-more"
-          className="mt-3 rounded-md border border-stone-200 px-3 py-1 text-sm text-stone-600 hover:bg-stone-50"
-          disabled={page.loading}
-          onClick={page.loadMore}
-        >
-          {page.loading ? "Loading…" : "Load more events"}
-        </button>
-      )}
       {railNode?.label === ANALYZE_STEP_LABEL && <AnalyzeMarkdownSection runId={runId} />}
     </>
   );
-  return <DetailPane node={node} parentLabel={null} footer={footer} />;
+  return <DetailPane node={node} parentLabel={null} footer={footer} lead={lead} />;
 }
 
 // p0259: a cancelled run is not a failure — it gets its own neutral banner.

--- a/src/dashboard/src/app/jobs/__tests__/StepDetailFollowsTheRun.test.tsx
+++ b/src/dashboard/src/app/jobs/__tests__/StepDetailFollowsTheRun.test.tsx
@@ -1,0 +1,150 @@
+import { Suspense } from "react";
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import RunDetailPage from "@/app/jobs/[id]/page";
+import { EventStoreProvider } from "@/lib/eventStore/EventStoreProvider";
+import { silentEventStore } from "@/lib/eventStore/__tests__/fakes";
+import type { OverviewSnapshot, RunSnapshot } from "@/types/hub-events";
+
+// p0388d: the step-detail pane shows a step's NEWEST events, so on a step that
+// outgrew one page it is showing a slice — and it says so, with the walk back
+// into history as an explicit control rather than a page that looks complete.
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  usePathname: () => "/",
+}));
+
+const overviewRef: { current: OverviewSnapshot | null } = { current: null };
+vi.mock("@/hooks/useJobsHub", () => ({
+  useJobsHub: () => ({
+    client: {
+      getResultMarkdown: () => Promise.resolve(null),
+      getPlanMarkdown: () => Promise.resolve(null),
+      getAnalyzeMarkdown: () => Promise.resolve(null),
+    },
+    connectionState: 1,
+    overview: overviewRef.current,
+    systemActivity: null,
+  }),
+}));
+vi.mock("@/hooks/useRunEvents", () => ({ useRunEvents: () => [] }));
+vi.mock("@/hooks/useRunDetailSnapshot", () => ({
+  useRunDetailSnapshot: (_runId: string, list: RunSnapshot | null) => list,
+}));
+
+const STEPS = [
+  {
+    stepIndex: 0, stepName: "FetchTicket", displayName: "Fetch ticket", commandName: "FetchTicket",
+    status: "success", durationSeconds: 1.5, resultMessage: "T-1 fetched",
+    llmCalls: 0, costUsd: 0, sandboxCommands: 0, subAgents: 0,
+  },
+  {
+    stepIndex: 1, stepName: "SkillRound", displayName: "Implement", commandName: "SkillRound",
+    status: "success", durationSeconds: 6200, resultMessage: "3 repos changed",
+    llmCalls: 900, costUsd: 41, sandboxCommands: 5400, subAgents: 6,
+  },
+];
+
+const fetchMock = vi.fn();
+
+// The run is FINISHED — the state in which an operator opens a 103-minute step
+// to find out what happened at its end.
+function snap(): RunSnapshot {
+  return {
+    runId: "r1", pipeline: "fix-bug", trigger: "ticket", repos: ["server"], status: "success",
+    prUrl: null, summary: null, startedAt: "2026-07-29T09:00:00Z",
+    finishedAt: "2026-07-29T10:43:00Z", sandboxes: 1,
+    stepIndex: 1, stepName: "Implement", totalSteps: 2, lastEventType: null, costUsd: 41,
+    llmCalls: 900, ticketId: "T-1", ticketTitle: "Fix the login", agentName: "claude",
+    cancelRequested: false,
+  };
+}
+
+function resolvedParams(id: string): Promise<{ id: string }> {
+  const p = Promise.resolve({ id });
+  Object.assign(p, { status: "fulfilled", value: { id } });
+  return p;
+}
+
+function renderRunDetail() {
+  overviewRef.current = { active: [], recent: [snap()], systemActivity: null };
+  return render(
+    <EventStoreProvider store={silentEventStore()}>
+      <Suspense fallback={null}>
+        <RunDetailPage params={resolvedParams("r1")} />
+      </Suspense>
+    </EventStoreProvider>,
+  );
+}
+
+function urlsFetched(): string[] {
+  return fetchMock.mock.calls.map((c) => String(c[0]));
+}
+
+beforeEach(() => {
+  // Braced on purpose: a concise arrow RETURNS the mock, and vitest treats a
+  // value returned from a hook as its teardown callback.
+  fetchMock.mockReset();
+  fetchMock.mockImplementation(async (url: string) => {
+    if (url.includes("/events")) {
+      // A step far larger than one page: whichever end is read, older rows
+      // remain below it.
+      return {
+        ok: true,
+        json: async () => ({ events: [], oldestSeq: 4900, newestSeq: 5000, hasOlder: true }),
+      };
+    }
+    if (url.includes("/steps")) return { ok: true, json: async () => ({ steps: STEPS }) };
+    if (url.includes("/decisions")) return { ok: true, json: async () => ({ decisions: [] }) };
+    return { ok: true, json: async () => ({}) };
+  });
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+describe("Step detail follows the run", () => {
+  it("StepDetail_MoreRowsThanShown_SaysOlderRowsExist", async () => {
+    renderRunDetail();
+
+    const rail = await screen.findByTestId("nav-rail");
+    await waitFor(() => expect(rail).toHaveTextContent("Implement"));
+    fireEvent.click(within(rail).getByText("Implement"));
+
+    const notice = await screen.findByTestId("step-events-older-notice");
+    expect(notice).toHaveTextContent("older ones exist");
+
+    // History is reachable, and the walk is anchored on the page's own oldest
+    // row rather than starting over from the top of the step.
+    fireEvent.click(screen.getByTestId("step-events-load-older"));
+    await waitFor(() =>
+      expect(urlsFetched().some((u) => u.includes("beforeSeq=4900"))).toBe(true));
+  });
+
+  it("StepDetail_OpeningAStep_AsksForItsNewestPage", async () => {
+    renderRunDetail();
+
+    const rail = await screen.findByTestId("nav-rail");
+    await waitFor(() => expect(rail).toHaveTextContent("Implement"));
+    fireEvent.click(within(rail).getByText("Implement"));
+
+    await waitFor(() =>
+      expect(urlsFetched().some((u) => /\/steps\/1\/events$/.test(u))).toBe(true));
+    // No cursor at all: sinceSeq=0 was the old opening request, and reading
+    // forward from nothing is what returned a long step's FIRST page.
+    expect(urlsFetched().some((u) => u.includes("sinceSeq"))).toBe(false);
+  });
+
+  it("StepDetail_RunFinished_StopsPolling", async () => {
+    renderRunDetail();
+
+    const rail = await screen.findByTestId("nav-rail");
+    await waitFor(() => expect(rail).toHaveTextContent("Implement"));
+    fireEvent.click(within(rail).getByText("Implement"));
+    await screen.findByTestId("step-events-older-notice");
+
+    // A finished run costs nothing: no request repeats over the poll interval.
+    const settled = urlsFetched().length;
+    await new Promise((resolve) => setTimeout(resolve, 1300));
+    expect(urlsFetched().length).toBe(settled);
+  });
+});

--- a/src/dashboard/src/components/execution/DetailPane.tsx
+++ b/src/dashboard/src/components/execution/DetailPane.tsx
@@ -17,6 +17,10 @@ interface DetailPaneProps {
   /** p0247: extra content rendered at the bottom of the pane's scroll area —
    *  e.g. analyze.md under the Analyze-codebase step. Omitted for other steps. */
   footer?: ReactNode;
+  /** p0388d: content above the body — the place where the pane says what it is
+   *  NOT showing. A step whose body starts at the newest page announces the
+   *  older rows there, since that statement belongs where the truncation is. */
+  lead?: ReactNode;
 }
 
 const PILL_TEXT: Record<NodeStatus, string> = {
@@ -40,7 +44,7 @@ const PILL_CLS: Record<NodeStatus, string> = {
   input: "bg-violet-50 text-violet-700",
 };
 
-export function DetailPane({ node, parentLabel, footer }: DetailPaneProps) {
+export function DetailPane({ node, parentLabel, footer, lead }: DetailPaneProps) {
   if (!node) {
     return (
       <div data-testid="detail-pane" className="content-shell text-sm text-stone-400">
@@ -79,6 +83,7 @@ export function DetailPane({ node, parentLabel, footer }: DetailPaneProps) {
         <p className="mt-1 font-mono dsh-mono text-stone-500">{node.repoSummary.text}</p>
       )}
       <div className="mt-4 border-t border-stone-100 pt-4">
+        {lead}
         {node.body ?? (
           <div className="text-sm text-stone-400">No sub-events — fully described above.</div>
         )}

--- a/src/dashboard/src/components/jobs/RunCard.tsx
+++ b/src/dashboard/src/components/jobs/RunCard.tsx
@@ -5,11 +5,14 @@ import type { RunSnapshot } from "@/types/hub-events";
 import { CancelRunButton } from "./CancelRunButton";
 import { CancelRequestedBadge } from "./CancelRequestedBadge";
 import { Badge, type BadgeTone } from "@/components/ui/Badge";
+import { isRunLive } from "@/lib/runLiveness";
 
 // p0330: "queued" is NOT terminal for cancel purposes — the capacity-waiting
 // state is exactly the one the operator most wants to kill, and the backend
 // cancels it via TryCancelQueuedAsync. Only truly finished runs lose the button.
-const TERMINAL_STATUSES = new Set(["success", "failed", "error", "cancelled"]);
+// p0388d: the terminal set moved to lib/runLiveness, because the views that
+// FOLLOW a run ask the same question this button does — "can this run still do
+// something" — and two copies of it would be two answers waiting to disagree.
 
 interface Props {
   snapshot: RunSnapshot;
@@ -109,7 +112,7 @@ export function RunCard({ snapshot }: Props) {
             {formatStarted(snapshot.startedAt)}
           </span>
           <span>{formatElapsed(snapshot.startedAt, snapshot.finishedAt)}</span>
-          {!TERMINAL_STATUSES.has(snapshot.status.toLowerCase()) && (
+          {isRunLive(snapshot.status) && (
             <CancelRunButton runId={snapshot.runId} cancelRequested={snapshot.cancelRequested} />
           )}
         </span>

--- a/src/dashboard/src/hooks/__tests__/useRunStepEvents.test.tsx
+++ b/src/dashboard/src/hooks/__tests__/useRunStepEvents.test.tsx
@@ -1,0 +1,171 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { useRunStepEvents, STEP_POLL_INTERVAL_MS } from "@/hooks/useRunStepEvents";
+import { EventType, type RunEvent, type SandboxCommandEvent } from "@/types/hub-events";
+
+// p0388d: the open step has to FOLLOW the run. Two defects produced the symptom
+// the operator reported — the counter on the left climbing while the pane on the
+// right showed nothing new, even after a reload: the page was anchored at the
+// step's OLDEST row, and nothing ever re-read it.
+//
+// The fake below is the step-events endpoint's contract, not a stub of the hook:
+// it answers a newest-anchored page, a backwards page and a forward delta, each
+// with the cursors the real endpoint ships.
+
+const PAGE = 10;
+let rows: SandboxCommandEvent[] = [];
+
+function makeRows(count: number, from = 0): SandboxCommandEvent[] {
+  return Array.from({ length: count }, (_, i) => ({
+    runId: "r1",
+    type: EventType.SandboxCommand,
+    timestamp: "2026-07-29T09:00:00Z",
+    repo: "primary",
+    command: "run_command",
+    argsLength: 4,
+    summary: `cmd-${from + i}`,
+  }));
+}
+
+/** Rows are stored in Seq order; the index + 1 IS the Seq, so the fake can
+ *  answer cursor questions the same way the indexed query does. */
+function seqOf(row: SandboxCommandEvent): number {
+  return rows.indexOf(row) + 1;
+}
+
+function respond(rawUrl: string) {
+  const url = new URL(rawUrl, "http://dashboard.test");
+  const since = url.searchParams.get("sinceSeq");
+  const before = url.searchParams.get("beforeSeq");
+
+  if (since !== null) {
+    const after = rows.slice(Number(since));
+    const slice = after.slice(0, PAGE);
+    return json({
+      events: slice,
+      newestSeq: slice.length > 0 ? seqOf(slice[slice.length - 1]) : Number(since),
+      hasNewer: after.length > PAGE,
+    });
+  }
+
+  const below = before === null ? rows : rows.slice(0, Number(before) - 1);
+  const slice = below.slice(Math.max(0, below.length - PAGE));
+  return json({
+    events: slice,
+    oldestSeq: slice.length > 0 ? seqOf(slice[0]) : Number(before ?? 0),
+    newestSeq: slice.length > 0 ? seqOf(slice[slice.length - 1]) : Number(before ?? 0),
+    hasOlder: below.length > slice.length,
+  });
+}
+
+function json(body: unknown) {
+  return { ok: true, json: async () => body };
+}
+
+function summaries(events: RunEvent[]): (string | null)[] {
+  return events.map((e) => (e as SandboxCommandEvent).summary);
+}
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  // Braced on purpose: a concise arrow RETURNS the mock, and vitest treats a
+  // value returned from a hook as its teardown callback.
+  rows = [];
+  fetchMock.mockReset();
+  fetchMock.mockImplementation(async (url: string) => respond(url));
+  vi.stubGlobal("fetch", fetchMock);
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+async function settle(ms = 0) {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(ms);
+  });
+}
+
+describe("useRunStepEvents", () => {
+  it("StepDetail_OpeningALongStep_ShowsItsNewestRows", async () => {
+    rows = makeRows(25);
+
+    const { result } = renderHook(() => useRunStepEvents("r1", 0, false));
+    await settle();
+
+    // The step's END, not its beginning — the anchor defect this replaces
+    // returned cmd-0…cmd-9 for exactly this step.
+    expect(summaries(result.current.events)).toEqual(
+      Array.from({ length: PAGE }, (_, i) => `cmd-${15 + i}`));
+    expect(result.current.hasOlder).toBe(true);
+  });
+
+  it("StepDetail_LoadOlder_WalksIntoHistoryWithoutGaps", async () => {
+    rows = makeRows(25);
+
+    const { result } = renderHook(() => useRunStepEvents("r1", 0, false));
+    await settle();
+
+    await act(async () => result.current.loadOlder());
+    await settle();
+    await act(async () => result.current.loadOlder());
+    await settle();
+
+    expect(summaries(result.current.events)).toEqual(
+      Array.from({ length: 25 }, (_, i) => `cmd-${i}`));
+    expect(result.current.hasOlder).toBe(false);
+  });
+
+  it("StepDetail_RunLive_PollsForwardAndAppendsNewRows", async () => {
+    rows = makeRows(3);
+
+    const { result } = renderHook(() => useRunStepEvents("r1", 0, true));
+    await settle();
+    expect(result.current.events).toHaveLength(3);
+
+    // The step keeps producing while the pane sits open, and the operator
+    // presses nothing.
+    rows = [...rows, ...makeRows(2, 3)];
+    await settle(STEP_POLL_INTERVAL_MS);
+
+    expect(summaries(result.current.events)).toEqual(
+      ["cmd-0", "cmd-1", "cmd-2", "cmd-3", "cmd-4"]);
+  });
+
+  it("StepDetail_RunFinished_StopsPolling", async () => {
+    rows = makeRows(3);
+
+    const { rerender } = renderHook(
+      ({ live }) => useRunStepEvents("r1", 0, live),
+      { initialProps: { live: true } },
+    );
+    await settle();
+    await settle(STEP_POLL_INTERVAL_MS);
+    expect(fetchMock.mock.calls.length).toBeGreaterThan(1);
+
+    // The run reaches a terminal status while the pane is open.
+    rerender({ live: false });
+    const afterFinish = fetchMock.mock.calls.length;
+    rows = [...rows, ...makeRows(5, 3)];
+    await settle(10 * STEP_POLL_INTERVAL_MS);
+
+    // A finished run costs nothing.
+    expect(fetchMock.mock.calls.length).toBe(afterFinish);
+  });
+
+  it("StepDetail_BurstLargerThanAPage_CatchesUpWithoutWaitingATickPerPage", async () => {
+    rows = makeRows(1);
+
+    const { result } = renderHook(() => useRunStepEvents("r1", 0, true));
+    await settle();
+
+    // 25 rows arrive between two ticks — three pages' worth. ONE tick brings
+    // them all: the pane never trails a busy step by a page a second.
+    rows = [...rows, ...makeRows(25, 1)];
+    await settle(STEP_POLL_INTERVAL_MS);
+
+    expect(result.current.events).toHaveLength(26);
+  });
+});

--- a/src/dashboard/src/hooks/useRunStepEvents.ts
+++ b/src/dashboard/src/hooks/useRunStepEvents.ts
@@ -1,58 +1,151 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { fetchRunStepEvents } from "@/lib/runStepsApi";
+import { fetchRunStepEventDelta, fetchRunStepEventPage } from "@/lib/runStepsApi";
 import type { RunEvent } from "@/types/hub-events";
 
 // p0388b: ONE step's structural events, fetched when that step is selected and
-// extended page by page through the Seq cursor. Selecting a step never fetches
-// the run's whole trail, and deselecting it drops the page — so the detail
-// pane's cost is bounded by what the operator is actually looking at.
+// paged through a Seq cursor. Selecting a step never fetches the run's whole
+// trail, and deselecting it drops the page — so the detail pane's cost is
+// bounded by what the operator is actually looking at.
+//
+// p0388d: and it FOLLOWS the run. The p0388b hook read once on mount, from the
+// oldest row forward, which produced the symptom the operator reported: the
+// counter on the left climbs while the pane on the right shows nothing new,
+// even after a reload. Two things changed. Opening a step now lands on its
+// NEWEST page, because the end of a long step is what someone opens it for.
+// And while the run is live the hook polls forward from its newest cursor, so
+// the pane keeps appending on its own. Going back into the step's history is a
+// separate, explicit walk — never an infinite scroll that quietly re-fetches.
+
+/** The forward poll's rest interval — the gap between ticks, not a limit on
+ *  what a tick reads: a tick that finds more than one page waiting drains the
+ *  rest before resting, so the pane never trails a busy step by a page a
+ *  second. */
+export const STEP_POLL_INTERVAL_MS = 1000;
 
 export interface RunStepEvents {
   events: RunEvent[];
-  hasMore: boolean;
+  /** Older rows exist for this step than the pane is showing. The view states
+   *  this rather than rendering a page that looks like the whole step. */
+  hasOlder: boolean;
   loading: boolean;
-  loadMore: () => void;
+  loadOlder: () => void;
 }
 
 const EMPTY: RunEvent[] = [];
 
-export function useRunStepEvents(runId: string | null, stepIndex: number | null): RunStepEvents {
+export function useRunStepEvents(
+  runId: string | null,
+  stepIndex: number | null,
+  live: boolean,
+): RunStepEvents {
   const [events, setEvents] = useState<RunEvent[]>(EMPTY);
-  const [hasMore, setHasMore] = useState(false);
+  const [hasOlder, setHasOlder] = useState(false);
   const [loading, setLoading] = useState(false);
-  const cursor = useRef(0);
+  const newest = useRef(0);
+  const oldest = useRef(0);
 
-  const load = useCallback(
-    async (sinceSeq: number, signal?: AbortSignal) => {
+  // The newest page. Also what the poll falls back to while the step has not
+  // produced a single row yet: there is no cursor to read forward from, and
+  // asking for "everything from the start" is the anchor bug this phase removed.
+  const readNewestPage = useCallback(
+    async (signal?: AbortSignal) => {
       if (!runId || stepIndex === null) return;
-      setLoading(true);
-      try {
-        const page = await fetchRunStepEvents(runId, stepIndex, sinceSeq, signal);
-        cursor.current = page.nextSeq;
-        setHasMore(page.hasMore);
-        setEvents((prev) => (sinceSeq === 0 ? page.events : [...prev, ...page.events]));
-      } catch {
-        /* the pane keeps what it has; the operator can retry via load more */
-      } finally {
-        setLoading(false);
-      }
+      const page = await fetchRunStepEventPage(runId, stepIndex, null, signal);
+      if (signal?.aborted) return;
+      newest.current = page.newestSeq;
+      oldest.current = page.oldestSeq;
+      setEvents(page.events);
+      setHasOlder(page.hasOlder);
     },
     [runId, stepIndex],
   );
 
   useEffect(() => {
-    cursor.current = 0;
+    newest.current = 0;
+    oldest.current = 0;
     setEvents(EMPTY);
-    setHasMore(false);
+    setHasOlder(false);
     if (!runId || stepIndex === null) return;
     const ctrl = new AbortController();
-    void load(0, ctrl.signal);
+    void (async () => {
+      setLoading(true);
+      try {
+        await readNewestPage(ctrl.signal);
+      } catch {
+        /* the pane stays empty; the poll or a re-selection reads again */
+      } finally {
+        if (!ctrl.signal.aborted) setLoading(false);
+      }
+    })();
     return () => ctrl.abort();
-  }, [runId, stepIndex, load]);
+  }, [runId, stepIndex, readNewestPage]);
 
-  const loadMore = useCallback(() => void load(cursor.current), [load]);
+  // The forward poll, bounded by the RUN's own liveness — a finished run costs
+  // nothing, because this effect never starts (and tears itself down when the
+  // run reaches a terminal status while the pane is open).
+  useEffect(() => {
+    if (!live || !runId || stepIndex === null) return;
+    const ctrl = new AbortController();
+    let timer: ReturnType<typeof setTimeout> | undefined;
 
-  return { events, hasMore, loading, loadMore };
+    const tick = async () => {
+      if (ctrl.signal.aborted) return;
+      try {
+        if (newest.current === 0) {
+          await readNewestPage(ctrl.signal);
+        } else {
+          // Drain: a step that produced more than one page between ticks is
+          // read to its end NOW, rather than trailing the run by a page per
+          // second. The loop ends when the server says nothing newer is left,
+          // so what bounds it is the step's own backlog.
+          let more = true;
+          while (more && !ctrl.signal.aborted) {
+            const delta = await fetchRunStepEventDelta(
+              runId, stepIndex, newest.current, ctrl.signal);
+            if (ctrl.signal.aborted) return;
+            if (delta.events.length > 0) setEvents((prev) => [...prev, ...delta.events]);
+            // The CURSOR decides whether to read on, not the event count. The
+            // server moves it past every row it scanned, so a page whose
+            // payloads it could not deserialize still advances the drain
+            // instead of wedging it re-reading the same rows.
+            const advanced = delta.newestSeq > newest.current;
+            if (advanced) newest.current = delta.newestSeq;
+            more = delta.hasNewer && advanced;
+          }
+        }
+      } catch {
+        /* a failed tick changes nothing — the next one retries */
+      }
+      if (!ctrl.signal.aborted) timer = setTimeout(() => void tick(), STEP_POLL_INTERVAL_MS);
+    };
+
+    timer = setTimeout(() => void tick(), STEP_POLL_INTERVAL_MS);
+    return () => {
+      ctrl.abort();
+      if (timer) clearTimeout(timer);
+    };
+  }, [live, runId, stepIndex, readNewestPage]);
+
+  // History, walked explicitly: one page below the oldest row on screen, and
+  // contiguous with it, so the walk back has no gaps.
+  const loadOlder = useCallback(() => {
+    if (!runId || stepIndex === null || !hasOlder) return;
+    void (async () => {
+      setLoading(true);
+      try {
+        const page = await fetchRunStepEventPage(runId, stepIndex, oldest.current);
+        oldest.current = page.oldestSeq;
+        setEvents((prev) => [...page.events, ...prev]);
+        setHasOlder(page.hasOlder);
+      } catch {
+        /* the pane keeps what it has; the operator can ask again */
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [runId, stepIndex, hasOlder]);
+
+  return { events, hasOlder, loading, loadOlder };
 }

--- a/src/dashboard/src/lib/runLiveness.ts
+++ b/src/dashboard/src/lib/runLiveness.ts
@@ -1,0 +1,19 @@
+// p0388d: is this run still capable of producing events? Views that poll ask
+// this and stop when the answer turns false, so a finished run costs nothing.
+//
+// "queued" and "waiting_for_input" are LIVE: both resume as the same run, so a
+// view that stopped following them would freeze exactly where the operator is
+// waiting for movement. Only the four terminal statuses end the story — the
+// same set the run list uses to retire the cancel button (p0330).
+
+export const TERMINAL_RUN_STATUSES: ReadonlySet<string> = new Set([
+  "success",
+  "failed",
+  "error",
+  "cancelled",
+]);
+
+export function isRunLive(status: string | null | undefined): boolean {
+  if (!status) return false;
+  return !TERMINAL_RUN_STATUSES.has(status.toLowerCase());
+}

--- a/src/dashboard/src/lib/runStepsApi.ts
+++ b/src/dashboard/src/lib/runStepsApi.ts
@@ -22,10 +22,23 @@ export interface RunStepRow {
   subAgents: number;
 }
 
+/** p0388d: a step's page read from the newest end backwards. `oldestSeq` is the
+ *  cursor "load older" walks with; `hasOlder` is how the view knows it is not
+ *  showing the whole step. */
 export interface RunStepEventPage {
   events: RunEvent[];
-  nextSeq: number;
-  hasMore: boolean;
+  oldestSeq: number;
+  newestSeq: number;
+  hasOlder: boolean;
+}
+
+/** p0388d: what the live poll gets back — the rows written after the caller's
+ *  newest cursor. `hasNewer` means the delta outgrew one page, so the caller
+ *  reads on immediately instead of trailing the step by a page per tick. */
+export interface RunStepEventDelta {
+  events: RunEvent[];
+  newestSeq: number;
+  hasNewer: boolean;
 }
 
 export interface RunDecisionRow {
@@ -45,20 +58,57 @@ export async function fetchRunSteps(runId: string, signal?: AbortSignal): Promis
   return body.steps ?? [];
 }
 
-export async function fetchRunStepEvents(
+/**
+ * p0388d: the step's page anchored at its NEWEST row — what opening a step
+ * returns. `beforeSeq` walks the same read backwards into the step's history,
+ * each page contiguous with the last.
+ */
+export async function fetchRunStepEventPage(
+  runId: string,
+  stepIndex: number,
+  beforeSeq: number | null,
+  signal?: AbortSignal,
+): Promise<RunStepEventPage> {
+  const body = await getStepEvents(
+    runId, stepIndex, beforeSeq === null ? undefined : { beforeSeq: String(beforeSeq) }, signal);
+  return {
+    events: body.events ?? [],
+    oldestSeq: body.oldestSeq ?? beforeSeq ?? 0,
+    newestSeq: body.newestSeq ?? 0,
+    hasOlder: body.hasOlder ?? false,
+  };
+}
+
+/** p0388d: the forward delta an open step polls while the run is live. */
+export async function fetchRunStepEventDelta(
   runId: string,
   stepIndex: number,
   sinceSeq: number,
   signal?: AbortSignal,
-): Promise<RunStepEventPage> {
-  const params = new URLSearchParams({ sinceSeq: String(sinceSeq) });
+): Promise<RunStepEventDelta> {
+  const body = await getStepEvents(runId, stepIndex, { sinceSeq: String(sinceSeq) }, signal);
+  return {
+    events: body.events ?? [],
+    newestSeq: body.newestSeq ?? sinceSeq,
+    hasNewer: body.hasNewer ?? false,
+  };
+}
+
+type StepEventsBody = Partial<RunStepEventPage> & Partial<RunStepEventDelta>;
+
+async function getStepEvents(
+  runId: string,
+  stepIndex: number,
+  query: Record<string, string> | undefined,
+  signal?: AbortSignal,
+): Promise<StepEventsBody> {
+  const params = new URLSearchParams(query ?? {}).toString();
   const res = await fetch(
-    `${API_BASE}/api/runs/${encodeURIComponent(runId)}/steps/${stepIndex}/events?${params}`,
+    `${API_BASE}/api/runs/${encodeURIComponent(runId)}/steps/${stepIndex}/events${params ? `?${params}` : ""}`,
     { signal },
   );
   if (!res.ok) throw new Error(`HTTP ${res.status}`);
-  const body = (await res.json()) as Partial<RunStepEventPage>;
-  return { events: body.events ?? [], nextSeq: body.nextSeq ?? sinceSeq, hasMore: body.hasMore ?? false };
+  return (await res.json()) as StepEventsBody;
 }
 
 export async function fetchRunDecisions(

--- a/tests/AgentSmith.Tests/Server/RunRailServedTests.cs
+++ b/tests/AgentSmith.Tests/Server/RunRailServedTests.cs
@@ -99,27 +99,22 @@ public sealed class RunRailServedTests : IDisposable
     [Fact]
     public async Task StepEventsEndpoint_ClampsLimitAndReturnsCursor()
     {
-        var events = new List<AgentSmith.Contracts.Events.RunEvent>
-        {
-            new RunStartedEvent(RunId, "ticket", "fix-bug", ["primary"], T, "claude", "42"),
-            new StepStartedEvent(RunId, 0, "Implement", 1, T),
-        };
-        for (var i = 0; i < 40; i++) events.Add(SandboxCommand(0));
-        await ProjectAsync([.. events]);
+        await SeedStepCommandsAsync(40);
 
         // Over the ceiling: clamped to MaxStepPageCount, so the page never ships
         // the whole trail even when the caller asks for it.
-        var clamped = await ReadStepPageAsync(0, sinceSeq: 0, limit: 100_000);
+        var clamped = await ReadNewestPageAsync(0, limit: 100_000);
         clamped.Events.Count.Should().BeLessThanOrEqualTo(TrailReader.MaxStepPageCount);
 
-        var first = await ReadStepPageAsync(0, sinceSeq: 0, limit: 10);
+        var first = await ReadNewestPageAsync(0, limit: 10);
         first.Events.Should().HaveCount(10);
-        first.HasMore.Should().BeTrue();
-        first.NextSeq.Should().BeGreaterThan(0);
+        first.HasOlder.Should().BeTrue();
+        first.OldestSeq.Should().BeGreaterThan(0);
+        first.NewestSeq.Should().BeGreaterThan(first.OldestSeq);
 
-        var second = await ReadStepPageAsync(0, first.NextSeq, limit: 10);
-        second.Events.Should().HaveCount(10);
-        second.NextSeq.Should().BeGreaterThan(first.NextSeq);
+        var older = await ReadOlderPageAsync(0, first.OldestSeq, limit: 10);
+        older.Events.Should().HaveCount(10);
+        older.NewestSeq.Should().BeLessThan(first.OldestSeq);
     }
 
     [Fact]
@@ -129,11 +124,85 @@ public sealed class RunRailServedTests : IDisposable
             new RunStartedEvent(RunId, "ticket", "fix-bug", ["primary"], T, "claude", "42"),
             new StepStartedEvent(RunId, 0, "Implement", 1, T));
 
-        var page = await ReadStepPageAsync(stepIndex: 99, sinceSeq: 0, limit: null);
+        var page = await ReadNewestPageAsync(stepIndex: 99, limit: null);
 
         page.Events.Should().BeEmpty();
-        page.HasMore.Should().BeFalse();
-        page.NextSeq.Should().Be(0);
+        page.HasOlder.Should().BeFalse();
+        page.OldestSeq.Should().Be(0);
+        page.NewestSeq.Should().Be(0);
+    }
+
+    // p0388d: the anchor. Opening a step that has produced thousands of rows has
+    // to show its NEWEST ones — the p0388b query read ascending from Seq 0 and
+    // handed back the step's FIRST page, which is the beginning of a step whose
+    // interesting end is what the operator opened it for.
+    [Fact]
+    public async Task TrailReader_StepWithManyRows_ReturnsTheNewestPage()
+    {
+        await SeedStepCommandsAsync(40);
+
+        var page = await ReadNewestPageAsync(0, limit: 10);
+
+        Summaries(page.Events).Should().Equal(
+            "cmd-30", "cmd-31", "cmd-32", "cmd-33", "cmd-34",
+            "cmd-35", "cmd-36", "cmd-37", "cmd-38", "cmd-39");
+        page.HasOlder.Should().BeTrue();
+    }
+
+    // p0388d: newest-anchored is not a substitute for history. Walking the
+    // backwards cursor reaches the step's beginning, and the pages join without
+    // a gap or a repeat — an operator diagnosing a run gets the whole step.
+    [Fact]
+    public async Task TrailReader_BackwardsCursor_WalksIntoHistoryWithoutGaps()
+    {
+        await SeedStepCommandsAsync(25);
+
+        var page = await ReadNewestPageAsync(0, limit: 10);
+        var walked = new List<string>(Summaries(page.Events));
+        var pages = 1;
+        while (page.HasOlder)
+        {
+            page = await ReadOlderPageAsync(0, page.OldestSeq, limit: 10);
+            walked.InsertRange(0, Summaries(page.Events));
+            pages++;
+        }
+
+        pages.Should().Be(3);
+        walked.Should().Equal(Enumerable.Range(0, 25).Select(i => $"cmd-{i}"));
+    }
+
+    // p0388d: nothing re-read, so a step that was still producing rows looked
+    // finished. The forward delta is what the open step polls while the run is
+    // live — only what is new, in display order.
+    [Fact]
+    public async Task TrailReader_ForwardDelta_ShipsOnlyTheRowsAfterTheCursor()
+    {
+        await SeedStepCommandsAsync(25);
+
+        var opened = await ReadNewestPageAsync(0, limit: 10);
+        var idle = await ReadDeltaAsync(0, opened.NewestSeq, limit: 10);
+        idle.Events.Should().BeEmpty("nothing has been written since the page was read");
+        idle.NewestSeq.Should().Be(opened.NewestSeq);
+
+        await SeedStepCommandsAsync(3, startAt: 25);
+        var delta = await ReadDeltaAsync(0, opened.NewestSeq, limit: 10);
+
+        Summaries(delta.Events).Should().Equal("cmd-25", "cmd-26", "cmd-27");
+        delta.HasNewer.Should().BeFalse();
+        delta.NewestSeq.Should().BeGreaterThan(opened.NewestSeq);
+    }
+
+    // p0388d: a delta larger than one page says so, so a caller catching up on a
+    // busy step reads on immediately instead of trailing it a page per tick.
+    [Fact]
+    public async Task TrailReader_ForwardDeltaLargerThanAPage_SaysMoreIsWaiting()
+    {
+        await SeedStepCommandsAsync(30);
+
+        var delta = await ReadDeltaAsync(0, sinceSeq: 1, limit: 10);
+
+        delta.Events.Should().HaveCount(10);
+        delta.HasNewer.Should().BeTrue();
     }
 
     [Fact]
@@ -168,19 +237,44 @@ public sealed class RunRailServedTests : IDisposable
     private LlmCallFinishedEvent LlmCall(int stepIndex, decimal cost) =>
         new(RunId, "claude", "coding-agent", 100, 20, cost, 500, T) { OriginStepIndex = stepIndex };
 
-    private SandboxCommandEvent SandboxCommand(int stepIndex) =>
-        new(RunId, "primary", "run_command", 12, T, "build") { OriginStepIndex = stepIndex };
+    private SandboxCommandEvent SandboxCommand(int stepIndex, string summary = "build") =>
+        new(RunId, "primary", "run_command", 12, T, summary) { OriginStepIndex = stepIndex };
+
+    /// <summary>
+    /// p0388d: a step that has produced <paramref name="count"/> individually
+    /// identifiable rows, so a page can be checked for WHICH end of the step it
+    /// came from. Called again with <paramref name="startAt"/> set, it extends
+    /// the same step the way a live run does.
+    /// </summary>
+    private async Task SeedStepCommandsAsync(int count, int startAt = 0)
+    {
+        var events = new List<AgentSmith.Contracts.Events.RunEvent>();
+        if (startAt == 0)
+        {
+            events.Add(new RunStartedEvent(RunId, "ticket", "fix-bug", ["primary"], T, "claude", "42"));
+            events.Add(new StepStartedEvent(RunId, 0, "Implement", 1, T));
+        }
+        for (var i = startAt; i < startAt + count; i++) events.Add(SandboxCommand(0, $"cmd-{i}"));
+        await ProjectAsync([.. events]);
+    }
+
+    // One projector across the whole test, because Seq is assigned by its trail
+    // buffer: a fresh instance would restart the run's sequence at zero.
+    private readonly MutableTimeProvider _clock = new() { Now = T };
+    private RunDbProjector? _projector;
 
     private async Task ProjectAsync(params AgentSmith.Contracts.Events.RunEvent[] events)
     {
-        var clock = new MutableTimeProvider { Now = T };
-        var projector = new RunDbProjector(_scopes, new RunEventApplier(), clock);
-        foreach (var ev in events) await projector.ProjectAsync(ev, CancellationToken.None);
+        _projector ??= new RunDbProjector(_scopes, new RunEventApplier(), _clock);
+        foreach (var ev in events) await _projector.ProjectAsync(ev, CancellationToken.None);
         // A run without a terminal event keeps a partial trail buffer; age it past
         // the flush window so the rows the queries read actually exist.
-        clock.Now = T.AddSeconds(5);
-        await projector.FlushStaleAsync(CancellationToken.None);
+        _clock.Now = _clock.Now.AddSeconds(5);
+        await _projector.FlushStaleAsync(CancellationToken.None);
     }
+
+    private static List<string> Summaries(IEnumerable<object> events) =>
+        events.Cast<SandboxCommandEvent>().Select(e => e.Summary ?? "").ToList();
 
     private sealed class MutableTimeProvider : TimeProvider
     {
@@ -195,14 +289,32 @@ public sealed class RunRailServedTests : IDisposable
             await RunStepQueryEndpoints.GetRunStepsAsync(RunId, Steps(), CancellationToken.None),
             "steps");
 
-    private async Task<StepPageShape> ReadStepPageAsync(int stepIndex, long sinceSeq, int? limit)
+    // p0388d: no cursor means "the newest page" — what opening a step returns.
+    private Task<StepPageShape> ReadNewestPageAsync(int stepIndex, int? limit) =>
+        ReadStepPageAsync(stepIndex, beforeSeq: null, limit);
+
+    private Task<StepPageShape> ReadOlderPageAsync(int stepIndex, long beforeSeq, int? limit) =>
+        ReadStepPageAsync(stepIndex, beforeSeq, limit);
+
+    private async Task<StepPageShape> ReadStepPageAsync(int stepIndex, long? beforeSeq, int? limit)
     {
         var result = await RunStepQueryEndpoints.GetRunStepEventsAsync(
-            RunId, stepIndex, sinceSeq, limit, Trail(), CancellationToken.None);
+            RunId, stepIndex, sinceSeq: null, beforeSeq, limit, Trail(), CancellationToken.None);
         return new StepPageShape(
             ValueOf<IReadOnlyList<object>>(result, "events"),
-            ValueOf<long>(result, "nextSeq"),
-            ValueOf<bool>(result, "hasMore"));
+            ValueOf<long>(result, "oldestSeq"),
+            ValueOf<long>(result, "newestSeq"),
+            ValueOf<bool>(result, "hasOlder"));
+    }
+
+    private async Task<StepDeltaShape> ReadDeltaAsync(int stepIndex, long sinceSeq, int? limit)
+    {
+        var result = await RunStepQueryEndpoints.GetRunStepEventsAsync(
+            RunId, stepIndex, sinceSeq, beforeSeq: null, limit, Trail(), CancellationToken.None);
+        return new StepDeltaShape(
+            ValueOf<IReadOnlyList<object>>(result, "events"),
+            ValueOf<long>(result, "newestSeq"),
+            ValueOf<bool>(result, "hasNewer"));
     }
 
     private async Task<IReadOnlyList<RunDecisionView>> ReadDecisionsAsync(int limit) =>
@@ -219,5 +331,9 @@ public sealed class RunRailServedTests : IDisposable
         return value.Should().BeAssignableTo<T>().Subject;
     }
 
-    private sealed record StepPageShape(IReadOnlyList<object> Events, long NextSeq, bool HasMore);
+    private sealed record StepPageShape(
+        IReadOnlyList<object> Events, long OldestSeq, long NewestSeq, bool HasOlder);
+
+    private sealed record StepDeltaShape(
+        IReadOnlyList<object> Events, long NewestSeq, bool HasNewer);
 }


### PR DESCRIPTION
## Why

The operator watched a 103-minute run and reported this: **the counter on the left climbs while the pane on the right shows nothing new — even after a page reload.**

p0388a and p0388b moved the run RAIL onto database projections, so the spine survives a long run. The detail pane never moved with them. Two defects were left behind, and together they produce exactly that symptom.

**The anchor was at the wrong end.** `TrailReader`'s step page read ascending from `Seq > sinceSeq`, so opening a step that had since produced thousands of rows returned its *first* page — the beginning of a step whose interesting end is the reason someone opened it. No amount of reloading changes that, which is why the reload did not help.

**Nothing re-read.** `useRunStepEvents` and `useRunSteps` fetched once on mount. The only poll left after p0388b was the 2-second trail poll, and that feeds the rail, not the open step. So a step that was still producing rows looked finished.

## What changed

**Server — `TrailReader`.** `ReadStepPageAsync` is replaced by two directional reads over the same `(RunId, StepIndex, Seq)` index p0388a added:

- `ReadStepBackwardsAsync(beforeSeq: null)` — the newest page, scanned descending and returned in display order. `beforeSeq` set walks into history, each page contiguous with the one before it, so the walk has no gaps and no repeats. OFFSET paging was rejected: it skips or repeats rows exactly when the run is busiest.
- `ReadStepForwardAsync(sinceSeq)` — the delta the live poll asks for, with `hasNewer` when it outgrew a page.

The endpoint takes `sinceSeq` **or** `beforeSeq` **or** neither, and ships only the flag its direction established (`hasOlder` backwards, `hasNewer` forward). Filling both would mean asserting a `false` no query established — and a forward tick would then clear the "older rows exist" notice the opening read correctly set.

`sinceSeq=0` deliberately reads as *the newest page*, not as a forward read from the beginning: a caller with no cursor holds nothing, and reading forward from nothing is the defect itself. It also means a browser still running the p0388b bundle gets the right end for free.

**Dashboard.** `useRunStepEvents(runId, stepIndex, live)` opens on the newest page, polls the forward delta while the run is live, and stops when it is not. A tick that finds more than one page waiting drains the rest before resting — the poll interval bounds the gap *between* ticks, not what a tick reads, so the pane does not fall further behind the busier the step gets. `loadOlder()` walks history explicitly from the page's own oldest cursor.

Liveness is the **run's** status, not the step's: a step row reads `running` until its `StepFinished` lands, so deriving it per step would stop following a run that had moved on. `RunCard` already owned the terminal-status set for its cancel button; it now lives in `lib/runLiveness` and serves both, because "can this run still do something" is one question.

**The view says what it is not showing.** With a newest-anchored page the missing rows are *above*, so the notice and the "load older" control sit together above the body. The p0388b bottom "load more" button is gone — a bare button says nothing about whether anything is missing at all.

## No caps

p0388a/b exist *because* caps were the wrong answer: a four-hour pipeline cannot be bounded by a number nobody can defend, and a FIFO trim is the same eviction that ate the rail's spine. Nothing here caps the run or trims the client's list. What is bounded is the **request** — one page per read, in both directions — which is a property of the view. An open step grows only while an operator is watching it, and closing the step drops the page.

## Tests

Backend (`RunRailServedTests`, real SQLite through the endpoint handlers):
- `TrailReader_StepWithManyRows_ReturnsTheNewestPage` — 40 individually identifiable rows, page of 10, asserts `cmd-30…cmd-39`. The old query returned `cmd-0…cmd-9`.
- `TrailReader_BackwardsCursor_WalksIntoHistoryWithoutGaps` — walks 25 rows back in 3 pages and reassembles the step exactly.
- `TrailReader_ForwardDelta_ShipsOnlyTheRowsAfterTheCursor` and `..._LargerThanAPage_SaysMoreIsWaiting`.

Dashboard (`useRunStepEvents.test.tsx`, a fake that answers the endpoint's actual contract, and `StepDetailFollowsTheRun.test.tsx` against the real page):
- opening a long step shows its newest rows; `loadOlder` reassembles it without gaps
- `StepDetail_RunLive_PollsForwardAndAppendsNewRows`
- `StepDetail_RunFinished_StopsPolling` — asserted both at the hook (run turns terminal while the pane is open) and on the page (no request repeats over the poll interval)
- `StepDetail_MoreRowsThanShown_SaysOlderRowsExist`
- one tick drains a 25-row burst rather than taking three

**Counts, measured at the branch point and after:** backend 3662 → **3666** green (+4), dashboard 547 → **555** green (+8). `next build` clean, `tsc --noEmit` clean over non-test sources, eslint clean on every touched file.

## Not done here

`.agentsmith/contexts/default/context.yaml` and the phase-spec move from `planned/` to `done/` are left to the main session — they conflict on every parallel branch.

Decisions: `.agentsmith/decisions/p0388d.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
