### PR TITLE
feat: no startup path throws, and the Studio shows what is missing (p0391b + p0392)

### DIFF
--- a/.agentsmith/decisions/p0391b.yaml
+++ b/.agentsmith/decisions/p0391b.yaml
@@ -1,0 +1,119 @@
+# yaml-language-server: $schema=../decision.schema.json
+phase: p0391b
+
+decisions:
+  - category: Architecture
+    chose: "The inventory is a TEST over the source, not a list in this file"
+    over: "Writing the surviving throws down and trusting the next author to read it"
+    reason: |
+      p0391a ruled that aborting startup is never justifiable and converted what it found.
+      p0393 then found another one inside a path p0391a had already written a probe for.
+      A ruling is not a mechanism, and neither is a list — the same author who writes the
+      list writes the next throw. StartupThrowInventoryTests scans the composition, hosting
+      and configuration directories and fails on any throw that is not accounted for, with
+      the reason attached to the entry. A second test fails when an accounted throw no
+      longer exists, because an allowlist that outlives its throw reads to the next author
+      as permission for a throw nobody reviewed.
+
+  - category: Architecture
+    chose: "One finding per resolution error, carrying the project and the field"
+    over: "Keeping the aggregate and splitting the message on the reader side"
+    reason: |
+      ConfigCatalogResolver.ThrowIfErrors joined every error into one exception; the server's
+      loader caught it and recorded ONE finding with Field: 'configuration'. So the endpoint
+      that exists to say what is wrong said "the stored configuration is not usable" and
+      handed back the whole wall of text. Splitting on the reader side would have meant
+      parsing prose the producer had just discarded structure to build. The producers now
+      emit StartupFinding directly (ProjectFindings.Blocking), so the field survives from the
+      place that knows it to the operator who has to edit it.
+
+  - category: Architecture
+    chose: "An unresolvable project drops out; the rest of the configuration materializes"
+    over: "Refusing the whole configuration when any reference does not resolve"
+    reason: |
+      This is p0391a's blast-radius rule applied one level down. A project whose agent,
+      tracker or repos do not resolve cannot be run — but nothing about that makes the OTHER
+      projects unrunnable, and the old behaviour made them exactly that: the resolver threw,
+      DbConfigurationLoader returned AgentSmithConfig.Empty(), and a single typo took every
+      poller and webhook down with it. Composition test
+      Startup_UnmaterializableProject_DisablesOnlyThatProject is the claim.
+
+  - category: TradeOff
+    chose: "YamlConfigurationLoader STAYS FATAL"
+    over: "Converting every throw uniformly because the ruling says never abort"
+    reason: |
+      The ruling is about a SERVER: a dead process cannot report, and the operator is left
+      without the tool that would tell them what is broken. A one-shot CLI invocation is the
+      opposite case — the operator is standing there, the process exists to run one command
+      against one file they just named, and the exit code IS the report. Keeping alive is not
+      preserving anything. The server never takes this path (it loads from the DB through
+      DbConfigurationLoader, which never throws), so the two are not in conflict. The
+      findings behind the refusal are the same objects either way; `agentsmith config
+      validate` prints them instead of exiting on the first one.
+
+  - category: Implementation
+    chose: "REDIS_URL and DOCKER_HOST fall back to their defaults with a blocking finding"
+    over: "A null-object IConnectionMultiplexer / IDockerClient"
+    reason: |
+      Both threw on a value that could not be PARSED, which AbortOnConnectFail=false never
+      covered — the endpoint was not down, it was absent, and the multiplexer factory is
+      resolved from three unguarded startup points. A null object for IConnectionMultiplexer
+      is forty-odd members of shim, which is the wrapper shape this codebase has decided
+      against. Falling back to the default endpoint gives a real object that simply never
+      connects: every consumer already handles IsConnected=false, the subsystems stay idle,
+      and the finding names the variable and the value.
+
+  - category: Implementation
+    chose: "SubsystemTask catches its own prologue"
+    reason: |
+      HostOptions.BackgroundServiceExceptionBehavior=Ignore (p0391a) covers a fault AFTER the
+      first suspending await. The two GetRequiredService calls at the top of
+      RunRedisGatedAsync run before it, so a failure faults the task synchronously and
+      escapes host start — in FOUR leader loops sharing that prologue. Same shape in
+      ActiveRunReaperHostedService.ExecuteAsync. Both now record a finding and return, which
+      leaves the subsystem down and the server up.
+
+  - category: Implementation
+    chose: "BootstrapConfigReader catches Exception, not YamlException"
+    reason: |
+      The narrow catch was written for a malformed file and read as if it covered an
+      unreadable one. A file that EXISTS but cannot be read — wrong owner on a mounted
+      ConfigMap, a path that is a directory, a document that is not a mapping — threw out of
+      the DbContext factory on the first scope. The distinction between "bad YAML" and "bad
+      file" has no operator meaning here: either way the configured database is not being
+      used, and that is what the finding says.
+
+  - category: Implementation
+    chose: "`agentsmith config validate` composes the server's rules, and owns none"
+    over: "A CLI-side validator that checks the same things"
+    reason: |
+      ConfigValidator holds an IConfigurationLoader, the shared IStartupFindings and
+      AgentSmithConfigValidator, and does nothing except run them and hand back the findings.
+      A second implementation would be a second source of truth about what a valid
+      configuration is — the defect class this codebase has paid for repeatedly — and the two
+      would drift the first time one was extended. Exit 1 on any blocking finding: the SERVER
+      stays up and disables those units, but a check that exists to be gated on has to fail.
+
+  - category: Scope
+    chose: "The spec's 'convert the rest' does not apply to four request-time throws"
+    reason: |
+      The spec asks for every remaining throw to be converted or accounted for. Four are
+      neither: ConnectionRepoUrlBuilder, RepoGlobExpander, EffectiveTriggerBuilder and
+      RawRepoRefYamlConverter still throw, because they sit deep inside a per-project build
+      with no error list to write to. Converting each would have meant threading a findings
+      list through four call chains for no gain — they are caught ONE frame up
+      (ConfigCatalogResolver.TryBuildProject, RawConfigMaterializer.ApplyEffectiveTriggers)
+      and become the same project-scoped finding. Recorded here rather than silently done:
+      the inventory test carries the same reasons.
+
+  - category: Scope
+    chose: "The composition test proves project-scoping with a bad resolution key, not a bad agent reference"
+    reason: |
+      The obvious end-to-end case — a project naming an agent that does not exist — cannot be
+      SEEDED. The DB config store enforces referential integrity through config_ref edges, so
+      the import fails with a foreign-key violation before the server ever loads it. That is
+      a real (and welcome) guarantee, and it means the unresolved-reference findings are
+      reachable from the FILE path and the Studio's write path, not from a stored document.
+      The stored case is exercised with an unknown resolution shorthand, which carries no
+      edge and is exactly the failure the existing Startup_ConfigCannotBeLoaded test used to
+      report as one config-wide blob.

--- a/.agentsmith/decisions/p0392.yaml
+++ b/.agentsmith/decisions/p0392.yaml
@@ -1,0 +1,96 @@
+# yaml-language-server: $schema=../decision.schema.json
+phase: p0392
+
+decisions:
+  - category: Architecture
+    chose: "RE-MEASURED the gap first; the spec's list was wrong in both directions"
+    reason: |
+      Measured 2026-08-03 against the raw read models, the capabilities descriptor and the
+      Studio forms. TRACKER: the backend reads sixteen fields, the descriptor declared four
+      (triggerStatuses, openStates, doneStatus, failedStatus). Undeclared and unofferable:
+      needs_clarification_status, not_implementable_status, close_transition_name,
+      extra_fields, zero_match_comment, pipeline_from_label, lifecycle_status_names.
+      TRIGGER (WebhookTriggerConfig): project_resolution is the only surfaced field; the
+      wrappers themselves are not editable, and the tracker-owned fields reach a trigger by
+      `??=` merge — so declaring them on the TRACKER makes them settable for the common
+      case, which is what the outage needed. CONNECTION: `host` (self-hosted GitLab / GitHub
+      Enterprise) was read and unofferable. PROJECT: default_pipeline was read and
+      unofferable. Corrections to the spec's list: `endpoints` is NOT a gap because
+      RawTrackerEntry has no such property at all — the YAML block is silently dropped and
+      the code always uses the JiraEndpoints defaults, which is a different (worse) defect
+      than an unofferable field. And `pipeline_from_label` was already on TrackerEntity and
+      round-tripping, but typed `string` in the dashboard against a backend dictionary.
+
+  - category: Architecture
+    chose: "CapabilityField declares its value SHAPE; the client stops deciding"
+    over: "Keeping the dashboard's hardcoded set of which keys are lists"
+    reason: |
+      The descriptor was already backend truth about WHICH fields exist, but the dashboard
+      held a LIST_FIELD_KEYS constant deciding how to render them. So a backend field of any
+      shape other than string or string-list could not be declared without editing
+      TypeScript too — which is exactly why zero_match_comment (bool) and
+      pipeline_from_label (map) were never offered. Kind is on the wire now, and the new
+      map/bool renderers mean the next declared field of either shape needs no UI change.
+
+  - category: Architecture
+    chose: "The Studio ASKS the server about an unsaved draft"
+    over: "Declaring conditional requiredness in the descriptor and evaluating it client-side"
+    reason: |
+      needs_clarification_status is not statically required — ClarificationParkStatusRule
+      demands it only where a park can happen: a project with a tracker trigger AND a
+      declared pipeline whose command list carries a clarification step. Expressing that in
+      the descriptor would have meant inventing a condition language and then a TypeScript
+      evaluator for it — a second statement of what a valid configuration is, drifting from
+      the first the day either changed. POST /api/config/{projects,trackers}/validate runs
+      the server's own rule objects over the projected raw shapes and returns findings; the
+      Studio renders them and holds no opinion.
+
+  - category: Implementation
+    chose: "ProjectConfigNormalizer.Inspect returns the findings; Normalize is Inspect plus recording"
+    reason: |
+      The draft check needs the same evaluation without the side effect — a draft must not
+      appear in the installation's live findings, and the shared IStartupFindings is a
+      singleton that startup clears and repopulates per load. Splitting the pure part out
+      gives one implementation and two callers rather than a scratch copy of the rule
+      sequence in the studio layer.
+
+  - category: Implementation
+    chose: "The pipeline picker offers Names and labels an unlisted stored value as retired"
+    reason: |
+      p0393's distinction, preserved: IsAcceptedName is what a configuration may CARRY
+      (including fix-bug, fix-no-test, add-feature, phase-execution), Names is what
+      agent-smith may OFFER. SelectField already kept an unlisted current value selectable,
+      so a stored `fix-bug` loaded — silently, looking like any other choice. It now says
+      what it is, which is the difference between "still works" and "still recommended".
+      The picker's option list is capabilities.pipelines, which is PipelinePresets.Names.
+
+  - category: Scope
+    chose: "The descriptor is now COMPLETE for trackers and connections; the other sections are p0392a"
+    over: "Claiming the done-list item and leaving the guard test to a smaller surface"
+    reason: |
+      CapabilityCoverageTests walks RawTrackerEntry and RawConnectionEntry against the
+      descriptor with NO allowlist — those two are genuinely closed, and a field added to
+      either fails the build until it is declared. The measurement found the same class of
+      gap in five more places, which this phase does NOT close and must not pretend to:
+      (1) repos — type, organization, project and auth are read and unofferable, so a repo
+      cannot be given a secret from the Studio; (2) projects — polling, sandbox,
+      orchestrator, skills_path, coding_principles_path, the per-platform trigger wrappers,
+      and the inner fields of pipelines[]; (3) agents — rate_limit and eight loop knobs;
+      (4) pipeline_triggers — no CRUD endpoint and no UI at all, though the taxonomy
+      declares the type; (5) the twelve settings singletons, which are hardcoded forms with
+      no descriptor, and where a TS shape that omits a backend field sends its DEFAULT back
+      on save — a silent overwrite, and the most severe of the five. Named as p0392a rather
+      than left as an implicit backlog.
+
+  - category: Scope
+    chose: "tracker `endpoints:` is reported, not implemented"
+    reason: |
+      The spec's measurement listed it as a missing Studio field. It is not: TrackerConnection
+      .Endpoints exists and is consumed by TicketProviderFactory and
+      TicketStatusTransitionerFactory, but RawTrackerEntry has no Endpoints property and
+      TrackerCatalogBuilder never assigns it — nothing under Infrastructure.Core so much as
+      mentions the key. So an operator's `endpoints:` block is silently discarded and the
+      Jira defaults always win. Declaring it in the descriptor would have made the Studio
+      offer a field that does nothing, which is worse than not offering it. It needs the raw
+      model and the builder first; recorded here so the next phase starts from the real
+      defect rather than the symptom.

--- a/src/backend/AgentSmith.Cli/Commands/ConfigCommand.cs
+++ b/src/backend/AgentSmith.Cli/Commands/ConfigCommand.cs
@@ -1,5 +1,6 @@
 using System.CommandLine;
 using System.CommandLine.Invocation;
+using AgentSmith.Cli.Services;
 using AgentSmith.Contracts.Models.ConfigStudio;
 using AgentSmith.Contracts.Services;
 using AgentSmith.Domain.Exceptions;
@@ -46,7 +47,33 @@ internal static class ConfigCommand
             ctx.ParseResult.GetValueForArgument(file),
             ctx.ParseResult.GetValueForOption(force)));
 
-        return new Command("config", "Config store DR + cutover (server mode).") { export, import };
+        var validate = new Command(
+            "validate",
+            "Report what the server would report about this configuration, without starting one.")
+        {
+            configOption, verboseOption,
+        };
+        validate.SetHandler((InvocationContext ctx) => ctx.ExitCode = Validate(
+            ctx.ParseResult.GetValueForOption(configOption)!,
+            ctx.ParseResult.GetValueForOption(verboseOption)));
+
+        return new Command("config", "Config store DR + cutover (server mode).")
+        {
+            export, import, validate,
+        };
+    }
+
+    /// <summary>
+    /// p0391b: same rules, same findings, printed. Exit 1 on any blocking finding — the
+    /// server would stay up and disable those units, but a one-shot check exists to be
+    /// gated on, and an operator who runs this before a rollout wants the non-zero code.
+    /// </summary>
+    private static int Validate(string configPath, bool verbose)
+    {
+        using var services = ServiceProviderFactory.Build(verbose, headless: true, configPath: configPath);
+        var findings = services.GetRequiredService<ConfigValidator>().Validate(configPath);
+        StartupFindingPrinter.Print(findings, Console.Out);
+        return findings.Any(f => f.IsBlocking) ? 1 : 0;
     }
 
     private static async Task<int> ExportAsync(string configPath, bool verbose, string? output)

--- a/src/backend/AgentSmith.Cli/ServiceProviderFactory.cs
+++ b/src/backend/AgentSmith.Cli/ServiceProviderFactory.cs
@@ -68,6 +68,8 @@ internal static class ServiceProviderFactory
         services.AddAgentSmithCommands();
         services.AddInProcessSandbox();
         services.AddSingleton<Commands.ValidateConceptsCommand>();
+        // p0391b: `agentsmith config validate` runs the server's own rules over a file.
+        services.AddSingleton<ConfigValidator>();
         RegisterDialogueAndProgress(services, headless, jobId, redisUrl);
 
         if (configPath is not null)

--- a/src/backend/AgentSmith.Cli/Services/ConfigValidator.cs
+++ b/src/backend/AgentSmith.Cli/Services/ConfigValidator.cs
@@ -1,0 +1,45 @@
+using AgentSmith.Application.Services.Configuration;
+using AgentSmith.Contracts.Models.Configuration;
+using AgentSmith.Contracts.Services;
+using AgentSmith.Domain.Exceptions;
+
+namespace AgentSmith.Cli.Services;
+
+/// <summary>
+/// p0391b: answers "would the server accept this configuration?" without starting one.
+///
+/// It runs the SERVER's rules — the shared raw-to-typed pipeline behind
+/// <see cref="IConfigurationLoader"/>, which records into <see cref="IStartupFindings"/>,
+/// followed by <see cref="AgentSmithConfigValidator"/>, which is what the server's
+/// ConfigurationProbe asks. There is deliberately no CLI-side rule: a second validator
+/// would be a second source of truth about what a valid configuration is, and the two
+/// would drift the first time one of them was extended.
+/// </summary>
+public sealed class ConfigValidator(
+    IConfigurationLoader loader,
+    IStartupFindings findings,
+    AgentSmithConfigValidator validator)
+{
+    public IReadOnlyList<StartupFinding> Validate(string configPath)
+    {
+        try
+        {
+            var config = loader.LoadConfig(configPath);
+            foreach (var finding in validator.Findings(config)) findings.Record(finding);
+        }
+        catch (ConfigurationException ex)
+        {
+            // The file loader refuses a configuration it cannot materialize (p0391b: the
+            // one-shot path's exit code is its report). The findings behind that refusal are
+            // already recorded; only an unparseable FILE has none, so that one is added here.
+            if (!findings.All.Any(f => f.IsBlocking)) findings.Record(Unparseable(configPath, ex));
+        }
+        return findings.All;
+    }
+
+    private static StartupFinding Unparseable(string configPath, ConfigurationException ex) => new(
+        StartupSubsystems.ConfigFile,
+        StartupFindingSeverity.Blocking,
+        $"'{configPath}' could not be read as a configuration: {ex.Message}",
+        Field: "CONFIG_PATH");
+}

--- a/src/backend/AgentSmith.Cli/Services/StartupFindingPrinter.cs
+++ b/src/backend/AgentSmith.Cli/Services/StartupFindingPrinter.cs
@@ -1,0 +1,35 @@
+using AgentSmith.Contracts.Models.Configuration;
+
+namespace AgentSmith.Cli.Services;
+
+/// <summary>
+/// p0391b: renders the findings the server would record. One line per finding with its
+/// unit and its field — an operator fixing six things needs six lines, each naming the key
+/// to edit, not one aggregated wall of text.
+/// </summary>
+public static class StartupFindingPrinter
+{
+    public static void Print(IReadOnlyList<StartupFinding> findings, TextWriter writer)
+    {
+        if (findings.Count == 0)
+        {
+            writer.WriteLine("Configuration is valid — no findings.");
+            return;
+        }
+
+        foreach (var finding in findings)
+            writer.WriteLine($"{Severity(finding)} {Unit(finding)}: {finding.Reason}");
+
+        var blocking = findings.Count(f => f.IsBlocking);
+        writer.WriteLine(
+            $"{findings.Count} finding(s), {blocking} blocking. "
+            + "The server would start and report these; a run on a blocked unit would not.");
+    }
+
+    private static string Severity(StartupFinding finding) => finding.IsBlocking ? "[blocking]" : "[advisory]";
+
+    private static string Unit(StartupFinding finding) => string.Join(
+        " / ",
+        new[] { finding.Subsystem, finding.Project, finding.Trigger, finding.Field }
+            .Where(part => !string.IsNullOrEmpty(part)));
+}

--- a/src/backend/AgentSmith.Contracts/Models/ConfigStudio/ConfigCapabilities.cs
+++ b/src/backend/AgentSmith.Contracts/Models/ConfigStudio/ConfigCapabilities.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace AgentSmith.Contracts.Models.ConfigStudio;
 
 /// <summary>
@@ -15,8 +17,29 @@ public sealed record ConfigCapabilities(
     IReadOnlyList<string> Pipelines,
     IReadOnlyList<ModelRoleCapability> Roles);
 
-/// <summary>One form field of a typed entity: wire key, display label, requiredness.</summary>
-public sealed record CapabilityField(string Key, string Label, bool Required);
+/// <summary>
+/// One form field of a typed entity: wire key, display label, requiredness and the SHAPE
+/// of its value. p0392: the shape used to be client knowledge — a hardcoded "these keys
+/// are lists" set in the dashboard — so a backend field of any other shape could not be
+/// declared without editing TypeScript as well. It is declared here now, which is what
+/// lets a newly declared field render without a UI change.
+/// </summary>
+public sealed record CapabilityField(
+    string Key, string Label, bool Required, CapabilityFieldKind Kind = CapabilityFieldKind.Text);
+
+/// <summary>The value shape of a <see cref="CapabilityField"/>, as the form must edit it.</summary>
+[JsonConverter(typeof(JsonStringEnumConverter<CapabilityFieldKind>))]
+public enum CapabilityFieldKind
+{
+    /// <summary>A single string.</summary>
+    Text,
+    /// <summary>A list of strings (a YAML sequence).</summary>
+    List,
+    /// <summary>A boolean flag.</summary>
+    Bool,
+    /// <summary>A string-to-string map (a YAML mapping).</summary>
+    Map,
+}
 
 /// <summary>
 /// One model-routing role the agent form renders as a fixed row (not free text).

--- a/src/backend/AgentSmith.Contracts/Models/ConfigStudio/ConnectionEntity.cs
+++ b/src/backend/AgentSmith.Contracts/Models/ConfigStudio/ConnectionEntity.cs
@@ -15,7 +15,11 @@ public sealed record ConnectionEntity(
     string? Organization,
     string? Project,
     string? AuthSecret,
-    string? DefaultBranch)
+    string? DefaultBranch,
+    // p0392: the self-hosted base URL ConnectionRepoUrlBuilder reads for every host kind.
+    // Without it a GitHub Enterprise or self-hosted GitLab connection could be written in
+    // YAML and then never edited from the studio.
+    string? Host = null)
 {
     public ConnectionEntity() : this(string.Empty, string.Empty, null, null, null, null) { }
 }

--- a/src/backend/AgentSmith.Contracts/Models/ConfigStudio/ProjectEntity.cs
+++ b/src/backend/AgentSmith.Contracts/Models/ConfigStudio/ProjectEntity.cs
@@ -17,7 +17,11 @@ public sealed record ProjectEntity(
     IReadOnlyList<string> Repos,
     string? Pipeline,
     IReadOnlyList<string> Pipelines,
-    ProjectResolution? Resolution = null)
+    ProjectResolution? Resolution = null,
+    // p0392: what PipelineConfigResolver picks when a ticket carries no routing label.
+    // ProjectConfigNormalizer disables the project when it names an undeclared pipeline,
+    // and the studio could neither set it nor see why the project had stopped.
+    string? DefaultPipeline = null)
 {
     public ProjectEntity() : this(string.Empty, string.Empty, string.Empty, [], null, []) { }
 }

--- a/src/backend/AgentSmith.Contracts/Models/ConfigStudio/TrackerEntity.cs
+++ b/src/backend/AgentSmith.Contracts/Models/ConfigStudio/TrackerEntity.cs
@@ -22,7 +22,16 @@ public sealed record TrackerEntity(
     string? FailedStatus = null,
     IReadOnlyList<string>? TriggerStatuses = null,
     IReadOnlyDictionary<string, string>? PipelineFromLabel = null,
-    TrackerPollingSettings? Polling = null)
+    TrackerPollingSettings? Polling = null,
+    // p0392: the rest of the raw tracker's workflow surface. needs_clarification_status is
+    // the field the 2026-07-31 outage was about — the server refused to boot without it and
+    // it could not be set here, so the way out was a rollback and a hand-edited export.
+    string? NeedsClarificationStatus = null,
+    string? NotImplementableStatus = null,
+    string? CloseTransitionName = null,
+    IReadOnlyList<string>? ExtraFields = null,
+    bool? ZeroMatchComment = null,
+    IReadOnlyDictionary<string, string>? LifecycleStatusNames = null)
 {
     public TrackerEntity() : this(string.Empty, string.Empty, null) { }
 }

--- a/src/backend/AgentSmith.Contracts/Services/ConfigStudioCapabilities.cs
+++ b/src/backend/AgentSmith.Contracts/Services/ConfigStudioCapabilities.cs
@@ -147,12 +147,26 @@ public static class ConfigStudioCapabilities
     // descriptor entry the studio form never rendered them, so a failed run
     // could not be given a native failed_status from the UI and the ticket
     // stayed claimable (the re-trigger loop observed live on 2026-07-27).
+    //
+    // p0392: the four that were declared were the four the UI happened to render.
+    // RawTrackerEntry reads eleven, and the missing seven included
+    // needs_clarification_status — the field whose absence refused a boot on
+    // 2026-07-31 and could not be set from the UI at all, so no amount of care
+    // would have prevented it. TrackerFieldCoverageTests is what keeps this list
+    // level with the raw model from here on.
     private static readonly IReadOnlyList<CapabilityField> WorkflowFields =
     [
-        new CapabilityField("triggerStatuses", "Trigger statuses", Required: false),
-        new CapabilityField("openStates", "Open states", Required: false),
+        new CapabilityField("triggerStatuses", "Trigger statuses", Required: false, CapabilityFieldKind.List),
+        new CapabilityField("openStates", "Open states", Required: false, CapabilityFieldKind.List),
         new CapabilityField("doneStatus", "Done status", Required: false),
         new CapabilityField("failedStatus", "Failed status", Required: false),
+        new CapabilityField("needsClarificationStatus", "Needs-clarification status", Required: false),
+        new CapabilityField("notImplementableStatus", "Not-implementable status", Required: false),
+        new CapabilityField("closeTransitionName", "Close transition name", Required: false),
+        new CapabilityField("extraFields", "Extra ticket fields", Required: false, CapabilityFieldKind.List),
+        new CapabilityField("zeroMatchComment", "Comment when nothing matched", Required: false, CapabilityFieldKind.Bool),
+        new CapabilityField("pipelineFromLabel", "Pipeline by label", Required: false, CapabilityFieldKind.Map),
+        new CapabilityField("lifecycleStatusNames", "Lifecycle status names", Required: false, CapabilityFieldKind.Map),
     ];
 
     private static IReadOnlyList<CapabilityField> ConnectionFields(RepoType type) => type switch
@@ -164,12 +178,16 @@ public static class ConfigStudioCapabilities
             new CapabilityField("organization", "Organization", Required: true),
             new CapabilityField("project", "Project", Required: true),
             new CapabilityField("authSecret", "Auth secret", Required: true),
+            new CapabilityField("host", "Base URL", Required: false),
             new CapabilityField("defaultBranch", "Default branch", Required: false),
         ],
         RepoType.GitHub or RepoType.GitLab =>
         [
             new CapabilityField("organization", type == RepoType.GitHub ? "Owner" : "Group", Required: true),
             new CapabilityField("authSecret", "Auth secret", Required: true),
+            // p0392: ConnectionRepoUrlBuilder reads host on every type, so a self-hosted
+            // GitLab or GitHub Enterprise was configurable in YAML and nowhere else.
+            new CapabilityField("host", "Base URL", Required: false),
             new CapabilityField("defaultBranch", "Default branch", Required: false),
         ],
         _ => throw new ConfigurationException(
@@ -199,6 +217,11 @@ public static class ConfigStudioCapabilities
         "organization" => tracker.Organization,
         "project" => tracker.Project,
         "authSecret" => tracker.AuthSecret,
+        "doneStatus" => tracker.DoneStatus,
+        "failedStatus" => tracker.FailedStatus,
+        "needsClarificationStatus" => tracker.NeedsClarificationStatus,
+        "notImplementableStatus" => tracker.NotImplementableStatus,
+        "closeTransitionName" => tracker.CloseTransitionName,
         _ => null,
     };
 

--- a/src/backend/AgentSmith.Infrastructure.Core/ServiceCollectionExtensions.cs
+++ b/src/backend/AgentSmith.Infrastructure.Core/ServiceCollectionExtensions.cs
@@ -49,6 +49,9 @@ public static class ServiceCollectionExtensions
         // p0349: the type<->model assembly map, shared by DbConfigStore + the
         // server's DB configuration loader; and the bootstrap reader that pulls
         // persistence + secret names from the file before the DB is reachable.
+        // p0392: what the server would say about an unsaved studio draft, from the
+        // server's own rule objects.
+        services.AddSingleton<Services.Configuration.Studio.ConfigDraftRules>();
         services.AddSingleton<ConfigDocumentAssembler>();
         services.AddSingleton<BootstrapConfigReader>();
         services.AddSingleton<ConceptVocabularyLoader>();

--- a/src/backend/AgentSmith.Infrastructure.Core/Services/Configuration/BootstrapConfigReader.cs
+++ b/src/backend/AgentSmith.Infrastructure.Core/Services/Configuration/BootstrapConfigReader.cs
@@ -10,8 +10,11 @@ namespace AgentSmith.Infrastructure.Core.Services.Configuration;
 /// A missing/unparseable file yields defaults so the server can still boot
 /// unconfigured (sqlite default) and the DI graph validates without a file present.
 /// </summary>
-public sealed class BootstrapConfigReader(IConfigStoreLocation location)
+public sealed class BootstrapConfigReader(
+    IConfigStoreLocation location, IStartupFindings? findings = null)
 {
+    private readonly IStartupFindings _findings = findings ?? new StartupFindings();
+
     public BootstrapConfig Read()
     {
         var path = location.ConfigPath;
@@ -21,11 +24,22 @@ public sealed class BootstrapConfigReader(IConfigStoreLocation location)
             var raw = RawConfigYaml.Deserialize(File.ReadAllText(path));
             return new BootstrapConfig(raw.Persistence, raw.Secrets);
         }
-        catch (YamlDotNet.Core.YamlException)
+        catch (Exception ex)
         {
-            // A malformed bootstrap file must not crash the DI graph build; the full
-            // loader surfaces the parse error with detail on the next real load.
+            // p0391b: the catch used to be YamlException only, so a file that EXISTS but
+            // cannot be READ — wrong owner on a mounted ConfigMap, a directory where a file
+            // was expected — threw out of the DbContext factory and killed the server on the
+            // first scope. Any failure to read the bootstrap slice is now the same finding.
+            _findings.Record(Unreadable(path, ex));
             return BootstrapConfig.Default();
         }
     }
+
+    private static StartupFinding Unreadable(string path, Exception ex) => new(
+        StartupSubsystems.ConfigFile,
+        StartupFindingSeverity.Blocking,
+        $"The bootstrap config at '{path}' could not be read, so the built-in defaults "
+        + "(sqlite, no secret names) are in use and the configured database is NOT being "
+        + $"used. Cause: {ex.Message}",
+        Field: "CONFIG_PATH");
 }

--- a/src/backend/AgentSmith.Infrastructure.Core/Services/Configuration/ConfigCatalogResolver.cs
+++ b/src/backend/AgentSmith.Infrastructure.Core/Services/Configuration/ConfigCatalogResolver.cs
@@ -7,31 +7,49 @@ namespace AgentSmith.Infrastructure.Core.Services.Configuration;
 /// <summary>
 /// Converts a <see cref="RawAgentSmithConfig"/> (the YAML-bound shape) into
 /// the public <see cref="AgentSmithConfig"/> with all catalog references
-/// materialized. Fails fast on unresolved references with an aggregated
-/// <see cref="ConfigurationException"/> listing every issue.
+/// materialized.
+///
+/// p0391b: an unresolved reference is ONE <see cref="StartupFinding"/> naming its project
+/// and its field, not one aggregated throw. Six mistakes give an operator six lines to fix
+/// rather than one wall of text, and the project that carries them is the only unit that
+/// drops out — every other project still materializes and still runs.
 /// </summary>
 public sealed class ConfigCatalogResolver(
     RepoGlobExpander? globExpander = null,
-    IConnectionRepoUrlBuilder? urlBuilder = null)
+    IConnectionRepoUrlBuilder? urlBuilder = null,
+    IStartupFindings? findings = null)
 {
+    private readonly IStartupFindings _findings = findings ?? new StartupFindings();
     private readonly RepoCatalogBuilder _repos = new();
     private readonly TrackerCatalogBuilder _trackers = new();
     private readonly ConnectionCatalogBuilder _connections = new();
     private readonly ResolvedProjectBuilder _projects = new(urlBuilder ?? new ConnectionRepoUrlBuilder());
 
+    /// <summary>
+    /// What the LAST <see cref="Resolve"/> call could not materialize. The server reads
+    /// these off the shared findings list; the one-shot file loader reads them here to
+    /// tell its operator, on stderr, why the configuration they just passed is unusable.
+    /// </summary>
+    public IReadOnlyList<StartupFinding> LastFindings { get; private set; } = [];
+
     public AgentSmithConfig Resolve(RawAgentSmithConfig raw)
     {
-        var errors = new List<string>();
-        var repos = _repos.Build(raw.Repos, errors);
-        var trackers = _trackers.Build(raw.Trackers, errors);
+        var collected = new List<StartupFinding>();
+        var repos = _repos.Build(raw.Repos);
+        var trackers = _trackers.Build(raw.Trackers);
         var connections = _connections.Build(raw.Connections);
-        ThrowIfErrors(errors);
 
-        var projects = ResolveProjects(raw, repos, trackers, connections, errors);
-        ThrowIfErrors(errors);
+        var projects = ResolveProjects(raw, repos, trackers, connections, collected);
+        Publish(collected);
 
         var registries = BuildRegistries(raw);
         return Compose(raw, repos, trackers, connections, projects, registries);
+    }
+
+    private void Publish(List<StartupFinding> collected)
+    {
+        LastFindings = collected;
+        foreach (var finding in collected) _findings.Record(finding);
     }
 
     private static IReadOnlyList<RegistryConfig> BuildRegistries(RawAgentSmithConfig raw)
@@ -48,16 +66,40 @@ public sealed class ConfigCatalogResolver(
         Dictionary<string, RepoConnection> repos,
         Dictionary<string, TrackerConnection> trackers,
         Dictionary<string, ResolvedConnection> connections,
-        List<string> errors)
+        List<StartupFinding> findings)
     {
         var result = new Dictionary<string, ResolvedProject>(raw.Projects.Count);
         foreach (var (name, entry) in raw.Projects)
         {
-            var resolved = _projects.TryBuild(
-                name, entry, raw.Agents, trackers, repos, connections, globExpander, errors);
+            var resolved = TryBuildProject(name, entry, raw, repos, trackers, connections, findings);
             if (resolved is not null) result[name] = resolved;
         }
         return result;
+    }
+
+    // Repo-glob expansion and static connection-URL building still signal by exception —
+    // they are reached from deep inside the repo list and have no error list to write to.
+    // Catching here keeps the blast radius at one project instead of the whole config,
+    // which is what letting it escape used to cost.
+    private ResolvedProject? TryBuildProject(
+        string name,
+        RawProjectEntry entry,
+        RawAgentSmithConfig raw,
+        Dictionary<string, RepoConnection> repos,
+        Dictionary<string, TrackerConnection> trackers,
+        Dictionary<string, ResolvedConnection> connections,
+        List<StartupFinding> findings)
+    {
+        try
+        {
+            return _projects.TryBuild(
+                name, entry, raw.Agents, trackers, repos, connections, globExpander, findings);
+        }
+        catch (ConfigurationException ex)
+        {
+            findings.Add(ProjectFindings.Blocking(name, "repos", ex.Message));
+            return null;
+        }
     }
 
     private static AgentSmithConfig Compose(
@@ -89,12 +131,4 @@ public sealed class ConfigCatalogResolver(
             Persistence = raw.Persistence,
             PipelineCostCap = raw.PipelineCostCap,
         };
-
-    private static void ThrowIfErrors(List<string> errors)
-    {
-        if (errors.Count == 0) return;
-        var joined = string.Join(Environment.NewLine + "  - ", errors);
-        throw new ConfigurationException(
-            $"Configuration error(s):{Environment.NewLine}  - {joined}");
-    }
 }

--- a/src/backend/AgentSmith.Infrastructure.Core/Services/Configuration/ProjectConfigNormalizer.cs
+++ b/src/backend/AgentSmith.Infrastructure.Core/Services/Configuration/ProjectConfigNormalizer.cs
@@ -26,8 +26,19 @@ public sealed class ProjectConfigNormalizer(
 
     public void Normalize(string projectName, RawProjectEntry project)
     {
+        foreach (var finding in Inspect(projectName, project)) RecordAndLog(finding);
+    }
+
+    /// <summary>
+    /// p0392: the same normalization and the same rules, RETURNED rather than recorded —
+    /// the config studio asks this about a draft the operator has not saved, and a draft
+    /// must not appear in the installation's live findings. One implementation, two
+    /// callers: <see cref="Normalize"/> is this plus recording.
+    /// </summary>
+    public IReadOnlyList<StartupFinding> Inspect(string projectName, RawProjectEntry project)
+    {
         ApplyLegacyShim(project);
-        foreach (var finding in Evaluate(projectName, project)) RecordAndLog(finding);
+        return Evaluate(projectName, project).ToList();
     }
 
     private static IEnumerable<StartupFinding> Evaluate(string projectName, RawProjectEntry project)

--- a/src/backend/AgentSmith.Infrastructure.Core/Services/Configuration/ProjectFindings.cs
+++ b/src/backend/AgentSmith.Infrastructure.Core/Services/Configuration/ProjectFindings.cs
@@ -1,0 +1,16 @@
+using AgentSmith.Contracts.Models.Configuration;
+
+namespace AgentSmith.Infrastructure.Core.Services.Configuration;
+
+/// <summary>
+/// p0391b: the one place a configuration-resolution error becomes a finding. Every error
+/// the raw-to-typed pipeline used to aggregate into a single throw is now built here, so
+/// each one carries the project and the field an operator has to edit — six mistakes are
+/// six lines, each pointing at its own key.
+/// </summary>
+public static class ProjectFindings
+{
+    public static StartupFinding Blocking(string project, string field, string reason) =>
+        new(StartupSubsystems.Configuration, StartupFindingSeverity.Blocking,
+            reason, project, Field: field);
+}

--- a/src/backend/AgentSmith.Infrastructure.Core/Services/Configuration/RawConfigMaterializer.cs
+++ b/src/backend/AgentSmith.Infrastructure.Core/Services/Configuration/RawConfigMaterializer.cs
@@ -20,27 +20,51 @@ public sealed class RawConfigMaterializer(
     IStartupFindings? findings = null)
 {
     private readonly IStartupFindings _findings = findings ?? new StartupFindings();
+    private readonly List<StartupFinding> _unmaterializable = [];
+
+    /// <summary>
+    /// p0391b: what the LAST materialization could not resolve. A configuration whose
+    /// references do not resolve is not a degraded configuration, it is an absent one for
+    /// the projects concerned — the one-shot file loader turns these into its exit code,
+    /// the server records them and stays up.
+    /// </summary>
+    public IReadOnlyList<StartupFinding> LastResolutionFindings { get; private set; } = [];
 
     public AgentSmithConfig Materialize(RawAgentSmithConfig raw)
     {
         // p0391a: every load republishes the configuration findings, so a fault an
         // operator has fixed stops being reported without a restart.
         _findings.Clear(StartupSubsystems.Configuration);
+        _unmaterializable.Clear();
         ResolveSecrets(raw);
         ResolveRegistryTokens(raw);
         deploymentDefaults.Apply(raw);
         ApplyEffectiveTriggers(raw);
         NormalizeProjects(raw);
         FillSkillsDefaults(raw);
-        return resolver.Resolve(raw);
+        var config = resolver.Resolve(raw);
+        LastResolutionFindings = [.. _unmaterializable, .. resolver.LastFindings];
+        return config;
     }
 
+    // p0391b: an unknown resolution shorthand key used to throw out of here, and the
+    // server's loader turned that into "the whole configuration is unusable" — one typo
+    // in one project silenced every other project. It is now that project's finding.
     private void ApplyEffectiveTriggers(RawAgentSmithConfig raw)
     {
         foreach (var (name, project) in raw.Projects)
         {
             raw.Trackers.TryGetValue(project.Tracker, out var tracker);
-            effectiveTriggers.Apply(name, project, tracker);
+            try
+            {
+                effectiveTriggers.Apply(name, project, tracker);
+            }
+            catch (Domain.Exceptions.ConfigurationException ex)
+            {
+                var finding = ProjectFindings.Blocking(name, "resolution", ex.Message);
+                _unmaterializable.Add(finding);
+                _findings.Record(finding);
+            }
         }
     }
 

--- a/src/backend/AgentSmith.Infrastructure.Core/Services/Configuration/RepoCatalogBuilder.cs
+++ b/src/backend/AgentSmith.Infrastructure.Core/Services/Configuration/RepoCatalogBuilder.cs
@@ -9,8 +9,7 @@ namespace AgentSmith.Infrastructure.Core.Services.Configuration;
 /// </summary>
 public sealed class RepoCatalogBuilder
 {
-    public Dictionary<string, RepoConnection> Build(
-        IReadOnlyDictionary<string, RawRepoEntry> raw, List<string> _)
+    public Dictionary<string, RepoConnection> Build(IReadOnlyDictionary<string, RawRepoEntry> raw)
     {
         var result = new Dictionary<string, RepoConnection>(raw.Count);
 

--- a/src/backend/AgentSmith.Infrastructure.Core/Services/Configuration/ResolvedProjectBuilder.cs
+++ b/src/backend/AgentSmith.Infrastructure.Core/Services/Configuration/ResolvedProjectBuilder.cs
@@ -5,8 +5,12 @@ namespace AgentSmith.Infrastructure.Core.Services.Configuration;
 
 /// <summary>
 /// Builds one <see cref="ResolvedProject"/> from a <see cref="RawProjectEntry"/>
-/// plus the already-built agents/repos/trackers catalogs. Unresolved name
-/// references go into the errors list with precise messages.
+/// plus the already-built agents/repos/trackers catalogs.
+///
+/// p0391b: an unresolved name reference is one blocking <see cref="StartupFinding"/> on
+/// this project, naming the field that carries the bad name. The project itself drops out
+/// (it cannot be run without its agent, tracker or repos); the rest of the configuration
+/// materializes and keeps working.
 /// </summary>
 public sealed class ResolvedProjectBuilder(IConnectionRepoUrlBuilder urlBuilder)
 {
@@ -20,12 +24,12 @@ public sealed class ResolvedProjectBuilder(IConnectionRepoUrlBuilder urlBuilder)
         Dictionary<string, RepoConnection> repos,
         Dictionary<string, ResolvedConnection> connections,
         RepoGlobExpander? globExpander,
-        List<string> errors)
+        List<StartupFinding> findings)
     {
-        var agent = ResolveAgent(name, raw.Agent, agents, errors);
-        var tracker = ResolveTracker(name, raw.Tracker, trackers, errors);
-        var repoList = ResolveRepos(name, raw.Repos, repos, connections, globExpander, errors);
-        var pipelines = ResolvePipelines(name, raw.Pipelines, agents, errors);
+        var agent = ResolveAgent(name, raw.Agent, agents, findings);
+        var tracker = ResolveTracker(name, raw.Tracker, trackers, findings);
+        var repoList = ResolveRepos(name, raw.Repos, repos, connections, globExpander, findings);
+        var pipelines = ResolvePipelines(name, raw.Pipelines, agents, findings);
 
         if (agent is null || tracker is null || repoList is null || pipelines is null) return null;
 
@@ -34,7 +38,7 @@ public sealed class ResolvedProjectBuilder(IConnectionRepoUrlBuilder urlBuilder)
 
     private static IReadOnlyList<PipelineDefinition>? ResolvePipelines(
         string project, IReadOnlyList<RawPipelineEntry> raws,
-        IReadOnlyDictionary<string, AgentConfig> agents, List<string> errors)
+        IReadOnlyDictionary<string, AgentConfig> agents, List<StartupFinding> findings)
     {
         var result = new List<PipelineDefinition>(raws.Count);
         var anyError = false;
@@ -42,7 +46,8 @@ public sealed class ResolvedProjectBuilder(IConnectionRepoUrlBuilder urlBuilder)
         {
             if (string.IsNullOrEmpty(r.Name))
             {
-                errors.Add($"Project '{project}': pipelines entry is missing required field 'name'.");
+                findings.Add(ProjectFindings.Blocking(project, "pipelines",
+                    $"Project '{project}': pipelines entry is missing required field 'name'."));
                 anyError = true;
                 continue;
             }
@@ -52,18 +57,18 @@ public sealed class ResolvedProjectBuilder(IConnectionRepoUrlBuilder urlBuilder)
             {
                 if (!agents.TryGetValue(r.Agent, out resolvedAgent))
                 {
-                    errors.Add(
+                    findings.Add(ProjectFindings.Blocking(project, "pipelines",
                         $"Project '{project}': pipeline '{r.Name}' references agent '{r.Agent}' " +
-                        $"which is not defined in agents: catalog.");
+                        "which is not defined in agents: catalog."));
                     anyError = true;
                 }
             }
 
             if (r.ConfidenceThreshold is < 0 or > 100)
             {
-                errors.Add(
+                findings.Add(ProjectFindings.Blocking(project, "pipelines",
                     $"Project '{project}': pipeline '{r.Name}' has confidence_threshold " +
-                    $"{r.ConfidenceThreshold} — must be between 0 and 100.");
+                    $"{r.ConfidenceThreshold} — must be between 0 and 100."));
                 anyError = true;
             }
 
@@ -82,31 +87,35 @@ public sealed class ResolvedProjectBuilder(IConnectionRepoUrlBuilder urlBuilder)
 
     private static AgentConfig? ResolveAgent(
         string project, string agentName,
-        IReadOnlyDictionary<string, AgentConfig> agents, List<string> errors)
+        IReadOnlyDictionary<string, AgentConfig> agents, List<StartupFinding> findings)
     {
         if (string.IsNullOrEmpty(agentName))
         {
-            errors.Add($"Project '{project}': missing required reference 'agent'.");
+            findings.Add(ProjectFindings.Blocking(project, "agent",
+                $"Project '{project}': missing required reference 'agent'."));
             return null;
         }
         if (agents.TryGetValue(agentName, out var agent)) return agent;
 
-        errors.Add($"Project '{project}': references agent '{agentName}' which is not defined in agents: catalog.");
+        findings.Add(ProjectFindings.Blocking(project, "agent",
+            $"Project '{project}': references agent '{agentName}' which is not defined in agents: catalog."));
         return null;
     }
 
     private static TrackerConnection? ResolveTracker(
         string project, string trackerName,
-        IReadOnlyDictionary<string, TrackerConnection> trackers, List<string> errors)
+        IReadOnlyDictionary<string, TrackerConnection> trackers, List<StartupFinding> findings)
     {
         if (string.IsNullOrEmpty(trackerName))
         {
-            errors.Add($"Project '{project}': missing required reference 'tracker'.");
+            findings.Add(ProjectFindings.Blocking(project, "tracker",
+                $"Project '{project}': missing required reference 'tracker'."));
             return null;
         }
         if (trackers.TryGetValue(trackerName, out var tracker)) return tracker;
 
-        errors.Add($"Project '{project}': references tracker '{trackerName}' which is not defined in trackers: catalog.");
+        findings.Add(ProjectFindings.Blocking(project, "tracker",
+            $"Project '{project}': references tracker '{trackerName}' which is not defined in trackers: catalog."));
         return null;
     }
 
@@ -114,11 +123,12 @@ public sealed class ResolvedProjectBuilder(IConnectionRepoUrlBuilder urlBuilder)
         string project, IReadOnlyList<RawRepoRef> repoEntries,
         IReadOnlyDictionary<string, RepoConnection> repos,
         IReadOnlyDictionary<string, ResolvedConnection> connections,
-        RepoGlobExpander? globExpander, List<string> errors)
+        RepoGlobExpander? globExpander, List<StartupFinding> findings)
     {
         if (repoEntries.Count == 0)
         {
-            errors.Add($"Project '{project}': 'repos' must list at least one repo (catalog name or connection/glob).");
+            findings.Add(ProjectFindings.Blocking(project, "repos",
+                $"Project '{project}': 'repos' must list at least one repo (catalog name or connection/glob)."));
             return null;
         }
 
@@ -129,14 +139,14 @@ public sealed class ResolvedProjectBuilder(IConnectionRepoUrlBuilder urlBuilder)
         var connectionRefs = repoEntries.Where(e => RepoGlobRef.IsConnectionRef(e.Ref)).ToList();
         var legacyNames = repoEntries.Where(e => !RepoGlobRef.IsConnectionRef(e.Ref)).Select(e => e.Ref).ToList();
 
-        var resolved = ResolveLegacyRepos(project, legacyNames, repos, errors);
+        var resolved = ResolveLegacyRepos(project, legacyNames, repos, findings);
         if (resolved is null) return null;
 
         var exact = connectionRefs.Where(e => IsExactRef(e.Ref)).ToList();
         var globEntries = connectionRefs.Where(e => !IsExactRef(e.Ref)).ToList();
 
-        if (!ResolveExactRefs(project, exact, connections, resolved, errors)) return null;
-        if (!ResolveGlobRefs(project, globEntries, connections, globExpander, resolved, errors)) return null;
+        if (!ResolveExactRefs(project, exact, connections, resolved, findings)) return null;
+        if (!ResolveGlobRefs(project, globEntries, connections, globExpander, resolved, findings)) return null;
 
         return resolved;
     }
@@ -150,7 +160,7 @@ public sealed class ResolvedProjectBuilder(IConnectionRepoUrlBuilder urlBuilder)
     private bool ResolveExactRefs(
         string project, IReadOnlyList<RawRepoRef> exact,
         IReadOnlyDictionary<string, ResolvedConnection> connections,
-        List<RepoConnection> resolved, List<string> errors)
+        List<RepoConnection> resolved, List<StartupFinding> findings)
     {
         var anyError = false;
         foreach (var entry in exact)
@@ -158,9 +168,9 @@ public sealed class ResolvedProjectBuilder(IConnectionRepoUrlBuilder urlBuilder)
             var parsed = RepoGlobRef.Parse(entry.Ref);
             if (!connections.TryGetValue(parsed.Connection, out var connection))
             {
-                errors.Add(
+                findings.Add(ProjectFindings.Blocking(project, "repos",
                     $"Project '{project}': repo reference uses connection '{parsed.Connection}' which is not " +
-                    "defined in connections: catalog.");
+                    "defined in connections: catalog."));
                 anyError = true;
                 continue;
             }
@@ -172,14 +182,14 @@ public sealed class ResolvedProjectBuilder(IConnectionRepoUrlBuilder urlBuilder)
     private static bool ResolveGlobRefs(
         string project, IReadOnlyList<RawRepoRef> globEntries,
         IReadOnlyDictionary<string, ResolvedConnection> connections,
-        RepoGlobExpander? globExpander, List<RepoConnection> resolved, List<string> errors)
+        RepoGlobExpander? globExpander, List<RepoConnection> resolved, List<StartupFinding> findings)
     {
         if (globEntries.Count == 0) return true;
         if (globExpander is null)
         {
-            errors.Add(
+            findings.Add(ProjectFindings.Blocking(project, "repos",
                 $"Project '{project}': connection/glob repo references require repo discovery, " +
-                "which is not available in this context.");
+                "which is not available in this context."));
             return false;
         }
 
@@ -190,14 +200,15 @@ public sealed class ResolvedProjectBuilder(IConnectionRepoUrlBuilder urlBuilder)
 
     private static List<RepoConnection>? ResolveLegacyRepos(
         string project, IReadOnlyList<string> names,
-        IReadOnlyDictionary<string, RepoConnection> repos, List<string> errors)
+        IReadOnlyDictionary<string, RepoConnection> repos, List<StartupFinding> findings)
     {
         var resolved = new List<RepoConnection>(names.Count);
         var anyMissing = false;
         foreach (var n in names)
         {
             if (repos.TryGetValue(n, out var r)) { resolved.Add(r); continue; }
-            errors.Add($"Project '{project}': references repo '{n}' which is not defined in repos: catalog.");
+            findings.Add(ProjectFindings.Blocking(project, "repos",
+                $"Project '{project}': references repo '{n}' which is not defined in repos: catalog."));
             anyMissing = true;
         }
         return anyMissing ? null : resolved;

--- a/src/backend/AgentSmith.Infrastructure.Core/Services/Configuration/Studio/ConfigCatalogMapper.cs
+++ b/src/backend/AgentSmith.Infrastructure.Core/Services/Configuration/Studio/ConfigCatalogMapper.cs
@@ -95,7 +95,13 @@ internal static class ConfigCatalogMapper
             tracker.PipelineFromLabel is { Count: > 0 } labels ? labels : null,
             tracker.Polling is { } polling
                 ? new TrackerPollingSettings(polling.Enabled, polling.IntervalSeconds, polling.JitterPercent)
-                : null);
+                : null,
+            tracker.NeedsClarificationStatus,
+            tracker.NotImplementableStatus,
+            tracker.CloseTransitionName,
+            tracker.ExtraFields.Count > 0 ? tracker.ExtraFields : null,
+            tracker.ZeroMatchComment,
+            tracker.LifecycleStatusNames is { Count: > 0 } lifecycle ? lifecycle : null);
 
     private static RepoEntity ToRepo(string id, RawRepoEntry repo) =>
         new(id, repo.Url ?? repo.Path ?? string.Empty, repo.DefaultBranch);
@@ -112,7 +118,8 @@ internal static class ConfigCatalogMapper
             project.Repos.Select(r => r.Ref).ToList(),
             string.IsNullOrWhiteSpace(project.Pipeline) ? null : project.Pipeline,
             pipelines,
-            ToResolution(project));
+            ToResolution(project),
+            project.DefaultPipeline);
     }
 
     // p0345c: surface the flat resolution shorthand; when the project instead
@@ -152,7 +159,8 @@ internal static class ConfigCatalogMapper
             connection.Organization ?? connection.Owner ?? connection.Group,
             connection.Project,
             string.IsNullOrWhiteSpace(connection.Auth) ? null : connection.Auth,
-            connection.DefaultBranch);
+            connection.DefaultBranch,
+            connection.Host);
 
     private static string RepoTypeName(RepoType type) => type switch
     {

--- a/src/backend/AgentSmith.Infrastructure.Core/Services/Configuration/Studio/ConfigDraftRules.cs
+++ b/src/backend/AgentSmith.Infrastructure.Core/Services/Configuration/Studio/ConfigDraftRules.cs
@@ -1,0 +1,63 @@
+using AgentSmith.Contracts.Models.ConfigStudio;
+using AgentSmith.Contracts.Models.Configuration;
+using AgentSmith.Contracts.Services;
+using AgentSmith.Domain.Exceptions;
+
+namespace AgentSmith.Infrastructure.Core.Services.Configuration.Studio;
+
+/// <summary>
+/// p0392: what the server would say about an entity the operator has not saved yet.
+///
+/// p0391a made the server report what is missing once it is RUNNING. A configuration that
+/// stops a unit is worth catching in the editor that produced it, before the save — the
+/// 2026-07-31 outage was a trigger without needs_clarification_status, and the operator had
+/// no way to know until a boot refused.
+///
+/// Every rule here is the server's own rule object, called on the same raw shapes the
+/// loader builds: <see cref="RawConfigPatch"/> projects the draft, EffectiveTriggerBuilder
+/// merges the tracker-owned workflow exactly as materialization does, and
+/// <see cref="ProjectConfigNormalizer.Inspect"/> evaluates. Nothing is restated: a
+/// second copy of "what a valid configuration is" would drift the first time either was
+/// extended, which is the defect class this codebase keeps paying for.
+/// </summary>
+public sealed class ConfigDraftRules(
+    EffectiveTriggerBuilder effectiveTriggers,
+    ProjectConfigNormalizer normalizer)
+{
+    /// <summary>
+    /// The findings this project draft would carry, judged against the rest of the stored
+    /// catalog (its tracker owns half the workflow, so the draft alone cannot be judged).
+    /// </summary>
+    public IReadOnlyList<StartupFinding> ForProject(ProjectEntity draft, ConfigCatalog catalog)
+    {
+        var project = RawConfigPatch.Project(draft, existing: null);
+        var tracker = catalog.Trackers.FirstOrDefault(t => t.Id == draft.Tracker);
+        var rawTracker = tracker is null ? null : RawConfigPatch.Tracker(tracker, existing: null);
+
+        effectiveTriggers.Apply(draft.Id, project, rawTracker);
+        return normalizer.Inspect(draft.Id, project);
+    }
+
+    /// <summary>
+    /// The findings this tracker draft would carry. The descriptor's requiredness is
+    /// enforced on upsert by <see cref="ConfigStudioCapabilities.ValidateTracker"/>; here
+    /// the same call reports instead of refusing, so the form can name the field first.
+    /// </summary>
+    public IReadOnlyList<StartupFinding> ForTracker(TrackerEntity draft)
+    {
+        try
+        {
+            ConfigStudioCapabilities.ValidateTracker(draft);
+            return [];
+        }
+        catch (ConfigurationException ex)
+        {
+            return
+            [
+                new StartupFinding(
+                    StartupSubsystems.Configuration, StartupFindingSeverity.Blocking,
+                    ex.Message, Field: "type"),
+            ];
+        }
+    }
+}

--- a/src/backend/AgentSmith.Infrastructure.Core/Services/Configuration/Studio/RawConfigPatch.cs
+++ b/src/backend/AgentSmith.Infrastructure.Core/Services/Configuration/Studio/RawConfigPatch.cs
@@ -105,6 +105,15 @@ public static class RawConfigPatch
         if (entity.TriggerStatuses is { } triggerStatuses) tracker.TriggerStatuses = [.. triggerStatuses];
         if (entity.PipelineFromLabel is { } labels)
             tracker.PipelineFromLabel = labels.ToDictionary(kv => kv.Key, kv => kv.Value);
+        // p0392: the workflow fields the studio could not reach. Null keeps the stored
+        // value (patch semantics); the park status is the one the 2026-07-31 outage needed.
+        tracker.NeedsClarificationStatus = entity.NeedsClarificationStatus;
+        tracker.NotImplementableStatus = entity.NotImplementableStatus;
+        tracker.CloseTransitionName = entity.CloseTransitionName;
+        if (entity.ExtraFields is { } extraFields) tracker.ExtraFields = [.. extraFields];
+        if (entity.ZeroMatchComment is { } zeroMatch) tracker.ZeroMatchComment = zeroMatch;
+        if (entity.LifecycleStatusNames is { } lifecycle)
+            tracker.LifecycleStatusNames = lifecycle.ToDictionary(kv => kv.Key, kv => kv.Value);
         if (entity.Polling is { } polling)
             tracker.Polling = new RawPollingEntry
             {
@@ -139,6 +148,9 @@ public static class RawConfigPatch
         project.Tracker = entity.Tracker;
         project.Repos = entity.Repos.Select(r => new RawRepoRef(r)).ToList();
         if (!string.IsNullOrWhiteSpace(entity.Pipeline)) project.Pipeline = entity.Pipeline!;
+        if (entity.DefaultPipeline is not null) // p0392
+            project.DefaultPipeline = string.IsNullOrWhiteSpace(entity.DefaultPipeline)
+                ? null : entity.DefaultPipeline;
         if (entity.Resolution is { } resolution)
             project.Resolution = new Dictionary<string, string> { [resolution.Strategy] = resolution.Value };
         if (entity.Pipelines.Count > 0)
@@ -158,6 +170,7 @@ public static class RawConfigPatch
         connection.Project = connection.Type == RepoType.AzureDevOps ? entity.Project : null;
         connection.Auth = entity.AuthSecret ?? string.Empty;
         connection.DefaultBranch = entity.DefaultBranch;
+        connection.Host = entity.Host; // p0392: self-hosted base URL
         return connection;
     }
 

--- a/src/backend/AgentSmith.Infrastructure.Core/Services/Configuration/TrackerCatalogBuilder.cs
+++ b/src/backend/AgentSmith.Infrastructure.Core/Services/Configuration/TrackerCatalogBuilder.cs
@@ -9,8 +9,7 @@ namespace AgentSmith.Infrastructure.Core.Services.Configuration;
 /// </summary>
 public sealed class TrackerCatalogBuilder
 {
-    public Dictionary<string, TrackerConnection> Build(
-        IReadOnlyDictionary<string, RawTrackerEntry> raw, List<string> _)
+    public Dictionary<string, TrackerConnection> Build(IReadOnlyDictionary<string, RawTrackerEntry> raw)
     {
         var result = new Dictionary<string, TrackerConnection>(raw.Count);
 

--- a/src/backend/AgentSmith.Infrastructure.Core/Services/Configuration/YamlConfigurationLoader.cs
+++ b/src/backend/AgentSmith.Infrastructure.Core/Services/Configuration/YamlConfigurationLoader.cs
@@ -31,9 +31,27 @@ public sealed class YamlConfigurationLoader(
         var yaml = ReadFile(configPath);
         var raw = Deserialize(yaml, configPath);
         var config = materializer.Materialize(raw);
+        RefuseUnresolvable();
         EmitConfigRead(configPath, yaml.Length);
         LastRead = new ConfigFileReadFact(configPath, DateTimeOffset.UtcNow);
         return config;
+    }
+
+    /// <summary>
+    /// p0391b: this is the ONE-SHOT loader — the CLI, the sandbox agent, the harness. Its
+    /// process exists to run one command against one configuration the operator just named,
+    /// so an unresolvable reference is refused here and the exit code IS the report. The
+    /// server never takes this path: it loads from the DB and stays up to say what is wrong.
+    /// The findings are the same findings either way; only what is done with them differs.
+    /// </summary>
+    private void RefuseUnresolvable()
+    {
+        var findings = materializer.LastResolutionFindings;
+        if (findings.Count == 0) return;
+        var joined = string.Join(
+            Environment.NewLine + "  - ", findings.Select(f => f.Reason));
+        throw new ConfigurationException(
+            $"Configuration error(s):{Environment.NewLine}  - {joined}");
     }
 
     private readonly object _emitLock = new();

--- a/src/backend/AgentSmith.Server/Extensions/ConfigStudioEndpoints.cs
+++ b/src/backend/AgentSmith.Server/Extensions/ConfigStudioEndpoints.cs
@@ -53,6 +53,19 @@ internal static class ConfigStudioEndpoints
         app.MapGet("/api/config/capabilities", ([FromServices] IEnumerable<IChatClientBuilder> builders) =>
             Results.Ok(ConfigStudioCapabilities.Build(builders.SelectMany(b => b.SupportedTypes))));
 
+        // p0392: what the server would say about a draft the operator has not saved.
+        // p0391a made the server report what is missing once it is running; the editor
+        // that PRODUCED the configuration is a better place to hear it. Same rules, one
+        // source — ConfigDraftRules calls the server's own rule objects, so the studio
+        // never restates a requirement in TypeScript.
+        app.MapPost("/api/config/projects/validate",
+            ([FromBody] ProjectEntity draft, IConfigStore store, [FromServices] ConfigDraftRules rules) =>
+                Results.Ok(Views(rules.ForProject(draft, store.Catalog))));
+
+        app.MapPost("/api/config/trackers/validate",
+            ([FromBody] TrackerEntity draft, [FromServices] ConfigDraftRules rules) =>
+                Results.Ok(Views(rules.ForTracker(draft))));
+
         // p0345c: the repo picker's discovery cache — the p0281a last-good snapshot.
         // Unknown connection → 404; known-but-undiscovered → 200 with
         // discoveredAt null + empty repos (honest "not discovered yet").
@@ -173,6 +186,10 @@ internal static class ConfigStudioEndpoints
             GuardSignalingAsync(ctx, reload, events,
                 () => { delete(store, id, Attribution(ctx)); return Results.NoContent(); }));
     }
+
+    private static IReadOnlyList<Models.StartupFindingView> Views(
+        IReadOnlyList<AgentSmith.Contracts.Models.Configuration.StartupFinding> findings) =>
+        findings.Select(Models.StartupFindingView.From).ToList();
 
     private static ChangeAttribution Attribution(HttpContext ctx)
     {

--- a/src/backend/AgentSmith.Server/Services/Hosting/ActiveRunReaperHostedService.cs
+++ b/src/backend/AgentSmith.Server/Services/Hosting/ActiveRunReaperHostedService.cs
@@ -1,4 +1,6 @@
 using AgentSmith.Application.Services.Lifecycle;
+using AgentSmith.Contracts.Models.Configuration;
+using AgentSmith.Contracts.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
@@ -15,9 +17,25 @@ public sealed class ActiveRunReaperHostedService(IServiceProvider services) : Ba
     private static readonly TimeSpan StaleThreshold = TimeSpan.FromMinutes(3);
     private static readonly TimeSpan ScanInterval = TimeSpan.FromMinutes(1);
 
+    // p0391b: the resolve happens before the first suspending await, so a failure faults
+    // StartAsync synchronously and kills the host — the one place in this service where
+    // BackgroundServiceExceptionBehavior.Ignore does not apply. A reaper that cannot be
+    // built is a finding; runs then stay leased longer, and the server says why.
     protected override Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        var reaper = services.GetRequiredService<ActiveRunReaper>();
+        ActiveRunReaper reaper;
+        try
+        {
+            reaper = services.GetRequiredService<ActiveRunReaper>();
+        }
+        catch (Exception ex)
+        {
+            services.GetService<IStartupFindings>()?.Record(new StartupFinding(
+                StartupSubsystems.Database, StartupFindingSeverity.Blocking,
+                "The active-run reaper could not be composed, so a run whose sandbox died keeps "
+                + $"its lease until an operator releases it. Cause: {ex.Message}"));
+            return Task.CompletedTask;
+        }
         return reaper.RunAsync(StaleThreshold, ScanInterval, stoppingToken);
     }
 }

--- a/src/backend/AgentSmith.Server/Services/OrphanJobDetector.cs
+++ b/src/backend/AgentSmith.Server/Services/OrphanJobDetector.cs
@@ -23,8 +23,13 @@ public sealed class OrphanJobDetector(
     private static readonly TimeSpan MinRuntime = TimeSpan.FromMinutes(1);
     private static readonly TimeSpan MaxRuntime = TimeSpan.FromMinutes(120);
 
+    // p0391b: a FIELD INITIALIZER on a hosted service runs during host construction, where
+    // nothing catches. ToDictionary throws on a duplicate key, so two adapters claiming the
+    // same platform would have taken the process down before any of them could be used.
+    // First registration wins and the process lives.
     private readonly Dictionary<string, IPlatformAdapter> _adapters =
-        adapters.ToDictionary(a => a.Platform, StringComparer.OrdinalIgnoreCase);
+        adapters.GroupBy(a => a.Platform, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(g => g.Key, g => g.First(), StringComparer.OrdinalIgnoreCase);
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {

--- a/src/backend/AgentSmith.Server/Services/RedisExtensions.cs
+++ b/src/backend/AgentSmith.Server/Services/RedisExtensions.cs
@@ -1,6 +1,7 @@
 using AgentSmith.Application.Services.Events;
 using AgentSmith.Contracts.Dialogue;
 using AgentSmith.Contracts.Events;
+using AgentSmith.Contracts.Models.Configuration;
 using AgentSmith.Contracts.Persistence;
 using AgentSmith.Contracts.Services;
 using AgentSmith.Infrastructure.Services.Dialogue;
@@ -33,7 +34,8 @@ internal static class RedisExtensions
         // services resolve Redis-dependent singletons at startup, so the
         // connection still happens immediately on real start; fast-tier
         // tests that never touch Redis-backed services now don't trip it.
-        services.AddSingleton<IConnectionMultiplexer>(_ => Connect());
+        services.AddSingleton<IConnectionMultiplexer>(
+            sp => Connect(sp.GetRequiredService<IStartupFindings>()));
         services.AddSingleton<IRedisJobQueue, RedisJobQueue>();
         services.AddSingleton<IRedisClaimLock, RedisClaimLock>();
         services.AddSingleton<IRedisLeaderLease, RedisLeaderLease>();
@@ -62,11 +64,40 @@ internal static class RedisExtensions
     // starts any — so an aborting Connect() threw out of host start and killed a server
     // that could otherwise have said "Redis is down". Now the multiplexer comes up in a
     // reconnecting state, the queue stays idle, and RedisProbe names the cause.
-    private static IConnectionMultiplexer Connect()
+    //
+    // p0391b: AbortOnConnectFail only covers an endpoint that is DOWN. A REDIS_URL that
+    // does not parse, or that parses to no endpoint at all (REDIS_URL=""), still threw —
+    // out of a lazy factory resolved from three unguarded places, so a typo in one env-var
+    // killed the server. An unusable URL is now a finding plus the default endpoint, which
+    // simply never connects: the queue stays idle and RedisProbe names the cause.
+    private static IConnectionMultiplexer Connect(IStartupFindings findings)
     {
-        var redisUrl = Environment.GetEnvironmentVariable("REDIS_URL") ?? DispatcherDefaults.RedisUrl;
-        var options = ConfigurationOptions.Parse(redisUrl);
+        var options = ParseOptions(findings);
         options.AbortOnConnectFail = false;
         return ConnectionMultiplexer.Connect(options);
     }
+
+    private static ConfigurationOptions ParseOptions(IStartupFindings findings)
+    {
+        var redisUrl = Environment.GetEnvironmentVariable("REDIS_URL") ?? DispatcherDefaults.RedisUrl;
+        try
+        {
+            var parsed = ConfigurationOptions.Parse(redisUrl);
+            if (parsed.EndPoints.Count > 0) return parsed;
+            findings.Record(Unusable(redisUrl, "it names no endpoint"));
+        }
+        catch (Exception ex)
+        {
+            findings.Record(Unusable(redisUrl, ex.Message));
+        }
+        return ConfigurationOptions.Parse(DispatcherDefaults.RedisUrl);
+    }
+
+    private static StartupFinding Unusable(string redisUrl, string reason) => new(
+        StartupSubsystems.Redis,
+        StartupFindingSeverity.Blocking,
+        $"REDIS_URL '{redisUrl}' cannot be used as a Redis endpoint ({reason}), so the queue, "
+        + $"the leader lease and the event stream stay down. Falling back to "
+        + $"'{DispatcherDefaults.RedisUrl}'. Expected form: host:port.",
+        Field: "REDIS_URL");
 }

--- a/src/backend/AgentSmith.Server/Services/Sandbox/SandboxBackendRegistrations.cs
+++ b/src/backend/AgentSmith.Server/Services/Sandbox/SandboxBackendRegistrations.cs
@@ -58,7 +58,7 @@ internal static class SandboxBackendRegistrations
         services.AddSingleton(new DockerSandboxOptions
         {
             RedisUrl = Environment.GetEnvironmentVariable("REDIS_URL") ?? "redis:6379",
-            DockerSocketUri = Environment.GetEnvironmentVariable("DOCKER_HOST") ?? "unix:///var/run/docker.sock",
+            DockerSocketUri = Environment.GetEnvironmentVariable("DOCKER_HOST") ?? DefaultDockerSocket,
             Network = Environment.GetEnvironmentVariable("DOCKER_NETWORK") ?? "",
             MaxConcurrentSandboxes =
                 int.TryParse(Environment.GetEnvironmentVariable("SANDBOX_MAX_CONCURRENT"), out var cap)
@@ -68,7 +68,8 @@ internal static class SandboxBackendRegistrations
         services.AddSingleton<IDockerClient>(sp =>
         {
             var opts = sp.GetRequiredService<DockerSandboxOptions>();
-            return new DockerClientConfiguration(new Uri(opts.DockerSocketUri)).CreateClient();
+            var uri = SocketUri(opts.DockerSocketUri, sp.GetRequiredService<IStartupFindings>());
+            return new DockerClientConfiguration(uri).CreateClient();
         });
         services.AddSingleton<DockerContainerSpecBuilder>();
         services.AddSingleton<ISandboxFactory>(sp => new DockerSandboxFactory(
@@ -93,11 +94,34 @@ internal static class SandboxBackendRegistrations
             sp.GetRequiredService<IRunCancellationRegistry>(),
             sp.GetRequiredService<IEventPublisher>(),
             sp.GetRequiredService<ILoggerFactory>()));
-        // p0201: orphan reaper as singleton hosted service.
+        // p0201: orphan reaper as singleton hosted service. p0391b: it takes IDockerClient
+        // by constructor, so the host builds it before it starts anything — which is why a
+        // malformed DOCKER_HOST used to kill the whole server rather than the Docker backend.
         services.AddHostedService(sp => new SandboxOrphanReaper(
             sp.GetRequiredService<IDockerClient>(),
             sp.GetRequiredService<IConnectionMultiplexer>(),
             sp.GetRequiredService<IActiveRunLease>(),
             sp.GetRequiredService<ILogger<SandboxOrphanReaper>>()));
     }
+
+    /// <summary>
+    /// p0391b: a DOCKER_HOST that is not a URI is an operator typo, not a reason to refuse
+    /// to start. The default socket is used instead and the finding names the variable — the
+    /// Docker backend then simply fails to reach it, which is a state the server can describe.
+    /// </summary>
+    private static Uri SocketUri(string configured, IStartupFindings findings)
+    {
+        if (Uri.TryCreate(configured, UriKind.Absolute, out var uri)) return uri;
+
+        findings.Record(new StartupFinding(
+            StartupSubsystems.Spawner,
+            StartupFindingSeverity.Blocking,
+            $"DOCKER_HOST '{configured}' is not a valid URI, so the Docker sandbox backend "
+            + $"falls back to '{DefaultDockerSocket}'. Expected form: unix:///var/run/docker.sock "
+            + "or tcp://host:port.",
+            Field: "DOCKER_HOST"));
+        return new Uri(DefaultDockerSocket);
+    }
+
+    private const string DefaultDockerSocket = "unix:///var/run/docker.sock";
 }

--- a/src/backend/AgentSmith.Server/Services/Startup/ServerHostFactory.cs
+++ b/src/backend/AgentSmith.Server/Services/Startup/ServerHostFactory.cs
@@ -1,3 +1,5 @@
+using AgentSmith.Contracts.Models.Configuration;
+using AgentSmith.Contracts.Services;
 using AgentSmith.Server.Contracts;
 using AgentSmith.Server.Extensions;
 using Microsoft.Extensions.DependencyInjection;
@@ -33,8 +35,29 @@ public static class ServerHostFactory
         var app = builder.Build();
         app.MapServerEndpoints();
         if (DashboardApiExtensions.IsEnabled) app.MapDashboardApi();
-        await app.Services.GetRequiredService<IStartupProbeRunner>().RunAsync();
+        await RunProbesAsync(app);
         return app;
+    }
+
+    // p0391b: this is the first eager singleton resolution, and it drags in the loaded
+    // configuration, the Redis multiplexer and the composed spawner. The runner turns a
+    // probe that throws into a finding — but only once it exists, so a failure to BUILD it
+    // was still an unreported dead process. The findings list is registered unconditionally
+    // and needs nothing, so it can always carry the reason.
+    private static async Task RunProbesAsync(WebApplication app)
+    {
+        try
+        {
+            await app.Services.GetRequiredService<IStartupProbeRunner>().RunAsync();
+        }
+        catch (Exception ex)
+        {
+            app.Logger.LogError(ex, "Startup probes could not run");
+            app.Services.GetService<IStartupFindings>()?.Record(new StartupFinding(
+                StartupSubsystems.Configuration, StartupFindingSeverity.Blocking,
+                "The startup probes could not run, so nothing else on this page was checked. "
+                + $"Cause: {ex.Message}"));
+        }
     }
 
     private static void ConfigureServices(WebApplicationBuilder builder)

--- a/src/backend/AgentSmith.Server/Services/SubsystemTask.cs
+++ b/src/backend/AgentSmith.Server/Services/SubsystemTask.cs
@@ -1,4 +1,5 @@
 using AgentSmith.Application.Services.Health;
+using AgentSmith.Contracts.Models.Configuration;
 using AgentSmith.Contracts.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -35,8 +36,23 @@ public static class SubsystemTask
             return;
         }
 
-        var service = provider.GetRequiredService<TService>();
-        var multiplexer = provider.GetRequiredService<IConnectionMultiplexer>();
+        // p0391b: this runs BEFORE the first suspending await, so a failure here faults the
+        // BackgroundService's task synchronously — which HostOptions.BackgroundServiceException
+        // Behavior.Ignore does NOT cover, and the host start throws. Four leader loops share
+        // this prologue, so one unresolvable dependency took the whole server down.
+        TService service;
+        IConnectionMultiplexer multiplexer;
+        try
+        {
+            service = provider.GetRequiredService<TService>();
+            multiplexer = provider.GetRequiredService<IConnectionMultiplexer>();
+        }
+        catch (Exception ex)
+        {
+            RecordUnavailable(provider, health, ex, logger);
+            return;
+        }
+
         while (!cancellationToken.IsCancellationRequested)
         {
             if (!await WaitUntilConnectedAsync(
@@ -46,6 +62,18 @@ public static class SubsystemTask
             await RunOnceAsync(service, work, health, logger, cancellationToken);
             if (cancellationToken.IsCancellationRequested) return;
         }
+    }
+
+    private static void RecordUnavailable(
+        IServiceProvider provider, SubsystemHealth health, Exception ex, ILogger logger)
+    {
+        var reason =
+            $"The {health.Name} subsystem could not compose its dependencies, so it stays down "
+            + $"while the rest of the server runs. Cause: {ex.Message}";
+        health.SetDegraded(reason);
+        logger.LogError(ex, "{Subsystem} could not compose its dependencies — subsystem disabled", health.Name);
+        provider.GetService<IStartupFindings>()?.Record(new StartupFinding(
+            health.Name, StartupFindingSeverity.Blocking, reason));
     }
 
     private static async Task<bool> WaitUntilConnectedAsync(

--- a/src/dashboard/src/components/config/EntityDrawer.tsx
+++ b/src/dashboard/src/components/config/EntityDrawer.tsx
@@ -12,6 +12,7 @@ import type {
 import { ENTITY_CLIENT, ENTITY_ICON, ENTITY_SINGULAR } from "./entities";
 import { EntityForm } from "./EntityForm";
 import { requiredFieldsFilled } from "./capabilityFields";
+import { blockingFindings, useDraftFindings } from "./useDraftFindings";
 import { projectIntegrity } from "./integrity";
 import type { ConfigCatalog } from "./useConfigCatalog";
 
@@ -43,13 +44,19 @@ export function EntityDrawer({
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  // p0392: the server's own rules over the unsaved draft. p0391a made the server report
+  // what is missing once it is running; a configuration that would disable a unit is
+  // worth catching in the editor that produced it.
+  const findings = useDraftFindings(kind, draft);
+  const blocking = blockingFindings(findings);
+
   const idOk = draft.id.trim().length > 0;
   const projectOk =
     kind !== "projects" || projectIntegrity(catalog, draft as StudioProject).ok;
   // p0345c: typed entities need a TYPE, and the capabilities descriptor's
   // required per-type fields must be filled before saving.
   const typedOk = typedEntityOk(kind, draft, capabilities);
-  const canSave = idOk && projectOk && typedOk && !busy;
+  const canSave = idOk && projectOk && typedOk && blocking.length === 0 && !busy;
 
   async function save() {
     setBusy(true);
@@ -109,6 +116,7 @@ export function EntityDrawer({
             catalog={catalog}
             capabilities={capabilities}
             isNew={isNew}
+            findings={findings}
           />
           {error && (
             <p data-testid="config-drawer-error" style={{ color: "var(--bad)", fontSize: "12.5px" }}>
@@ -118,11 +126,24 @@ export function EntityDrawer({
         </div>
 
         <div className="df">
-          <span className="vmsg" data-testid={kind === "projects" && !projectOk ? "config-drawer-blocked" : undefined}>
+          <span
+            className="vmsg"
+            data-testid={
+              blocking.length > 0
+                ? "config-drawer-blocked"
+                : kind === "projects" && !projectOk
+                ? "config-drawer-blocked"
+                : undefined
+            }
+          >
             {canSave
               ? isNew
                 ? "Ready to create"
                 : "Ready to save"
+              : blocking.length > 0
+              ? blocking[0].field
+                ? `${blocking[0].field} is required here — see the field below`
+                : blocking[0].reason
               : kind === "projects" && !projectOk
               ? "resolve all references to save"
               : !typedOk

--- a/src/dashboard/src/components/config/EntityForm.tsx
+++ b/src/dashboard/src/components/config/EntityForm.tsx
@@ -3,6 +3,7 @@
 import type {
   ConfigCapabilities,
   ConfigEntityKind,
+  ConfigFinding,
   StudioAgent,
   StudioConnection,
   StudioEntity,
@@ -54,6 +55,7 @@ export function EntityForm({
   catalog,
   capabilities,
   isNew,
+  findings = [],
 }: {
   kind: ConfigEntityKind;
   draft: StudioEntity;
@@ -61,6 +63,8 @@ export function EntityForm({
   catalog: ConfigCatalog;
   capabilities: ConfigCapabilities | null;
   isNew: boolean;
+  /** p0392: what the server says about this unsaved draft, from its own rules. */
+  findings?: ConfigFinding[];
 }) {
   const idField = (
     <TextField
@@ -104,6 +108,7 @@ export function EntityForm({
               fields={descriptor.fields}
               values={t as unknown as Record<string, unknown>}
               onFieldChange={(key, value) => onChange({ ...t, [key]: value })}
+              findings={findings}
             />
           )}
           <RefSelect
@@ -138,6 +143,7 @@ export function EntityForm({
               values={c as unknown as Record<string, unknown>}
               onFieldChange={(key, value) => onChange({ ...c, [key]: value })}
               orgLabel={descriptor.orgLabel}
+              findings={findings}
             />
           )}
           <RefSelect
@@ -204,17 +210,27 @@ export function EntityForm({
             label="pipeline"
             value={p.pipeline}
             options={capabilities?.pipelines ?? []}
-            help={capabilities ? "the pipeline a triggered ticket runs" : "capabilities unavailable"}
+            help={pipelineHelp(p.pipeline, capabilities)}
             testId="form-field-pipeline"
             onChange={(v) => onChange({ ...p, pipeline: v })}
+          />
+          <SelectField
+            label="default pipeline"
+            value={p.defaultPipeline ?? ""}
+            options={capabilities?.pipelines ?? []}
+            placeholder="— same as pipeline —"
+            help={pipelineHelp(p.defaultPipeline ?? "", capabilities, "what runs when a ticket carries no routing label")}
+            testId="form-field-defaultPipeline"
+            onChange={(v) => onChange({ ...p, defaultPipeline: v === "" ? undefined : v })}
           />
           <ListField
             label="pipelines (comma separated)"
             values={p.pipelines}
             testId="form-field-pipelines"
-            placeholder="feature-implementation, api-scan"
+            placeholder="code, security-scan"
             onChange={(v) => onChange({ ...p, pipelines: v })}
           />
+          <DraftFindings findings={findings} />
           <SelectField
             label="resolution strategy"
             value={p.resolution?.strategy ?? ""}
@@ -277,6 +293,48 @@ export function EntityForm({
       );
     }
   }
+}
+
+// p0393/p0392: `Names` is what the studio may OFFER; `IsAcceptedName` is what a stored
+// configuration may CARRY. A retired alias (fix-bug) must keep loading and must never be
+// presented as a choice for a new project — SelectField keeps an unlisted current value
+// selectable, and this labels it for what it is.
+function pipelineHelp(
+  value: string,
+  capabilities: ConfigCapabilities | null,
+  fallback = "the pipeline a triggered ticket runs",
+): string {
+  if (!capabilities) return "capabilities unavailable";
+  if (value && !capabilities.pipelines.includes(value))
+    return `'${value}' is a retired name — it still runs, but pick a current one to replace it`;
+  return fallback;
+}
+
+// p0392: what the server would say about this project, before it is saved. The rules run
+// on the server (ConfigDraftRules); this only renders the answer. A finding that names a
+// field is ALSO shown on that field — the summary here is for the ones that name the unit.
+function DraftFindings({ findings }: { findings: ConfigFinding[] }) {
+  if (findings.length === 0) return null;
+  return (
+    <div className="field" data-testid="form-draft-findings">
+      <label>
+        what the server would report <span className="help">before you save</span>
+      </label>
+      <ul style={{ margin: 0, paddingLeft: "1.1rem" }}>
+        {findings.map((f, i) => (
+          <li
+            key={`${f.field ?? "unit"}-${i}`}
+            data-testid={f.field ? `form-draft-finding-${f.field}` : "form-draft-finding"}
+            data-severity={f.severity}
+            className="help"
+            style={{ color: f.severity === "blocking" ? "var(--bad)" : undefined }}
+          >
+            {f.reason}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
 }
 
 // p0345c: polling is part of the v2 tracker CONTRACT (not per-type) — an

--- a/src/dashboard/src/components/config/__tests__/CapabilitiesForms.test.tsx
+++ b/src/dashboard/src/components/config/__tests__/CapabilitiesForms.test.tsx
@@ -25,6 +25,8 @@ vi.mock("@/lib/configApi", () => {
     fetchChanges: vi.fn().mockResolvedValue([]),
     revertChange: vi.fn(),
     fetchConfigExportYml: vi.fn(),
+    validateProjectDraft: vi.fn().mockResolvedValue([]),
+    validateTrackerDraft: vi.fn().mockResolvedValue([]),
     fetchCapabilities: vi.fn().mockResolvedValue({
       trackerTypes: [
         {
@@ -32,7 +34,7 @@ vi.mock("@/lib/configApi", () => {
           fields: [
             { key: "organization", label: "organization", required: true },
             { key: "project", label: "project", required: true },
-            { key: "triggerStatuses", label: "trigger statuses", required: false },
+            { key: "triggerStatuses", label: "trigger statuses", required: false, kind: "list" },
             { key: "failedStatus", label: "failed status", required: false },
           ],
         },
@@ -40,7 +42,7 @@ vi.mock("@/lib/configApi", () => {
           type: "github",
           fields: [
             { key: "url", label: "repository url", required: true },
-            { key: "openStates", label: "open states", required: false },
+            { key: "openStates", label: "open states", required: false, kind: "list" },
           ],
         },
       ],

--- a/src/dashboard/src/components/config/__tests__/ConfigStudio.test.tsx
+++ b/src/dashboard/src/components/config/__tests__/ConfigStudio.test.tsx
@@ -47,6 +47,8 @@ vi.mock("@/lib/configApi", () => {
     fetchChanges: vi.fn().mockResolvedValue([]),
     revertChange: vi.fn(),
     fetchConfigExportYml: vi.fn().mockResolvedValue("agents:\n  - id: gpt5\n"),
+    validateProjectDraft: vi.fn().mockResolvedValue([]),
+    validateTrackerDraft: vi.fn().mockResolvedValue([]),
     fetchCapabilities: vi.fn().mockResolvedValue({
       trackerTypes: [{ type: "azure", fields: [{ key: "organization", label: "organization", required: true }] }],
       connectionTypes: [{ type: "azure-devops", orgLabel: "organization", fields: [] }],

--- a/src/dashboard/src/components/config/__tests__/ConnectionsStudio.test.tsx
+++ b/src/dashboard/src/components/config/__tests__/ConnectionsStudio.test.tsx
@@ -50,6 +50,8 @@ vi.mock("@/lib/configApi", () => {
     fetchConfigExportYml: vi.fn().mockResolvedValue(""),
     // p0345c: the connection form renders its fields from the capabilities
     // descriptor once a type is picked; orgLabel names the org field.
+    validateProjectDraft: vi.fn().mockResolvedValue([]),
+    validateTrackerDraft: vi.fn().mockResolvedValue([]),
     fetchCapabilities: vi.fn().mockResolvedValue({
       trackerTypes: [],
       connectionTypes: [

--- a/src/dashboard/src/components/config/__tests__/MissingRequiredFields.test.tsx
+++ b/src/dashboard/src/components/config/__tests__/MissingRequiredFields.test.tsx
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { ConfigStudio } from "../ConfigStudio";
+import { ConfigCatalogProvider } from "../ConfigCatalogProvider";
+
+// p0392: the studio says what is missing BEFORE the save. On 2026-07-31 a trigger was
+// missing needs_clarification_status, the server refused to start, and the way out was a
+// rollback, a CLI export, a hand edit, an import and a roll-forward — because the field
+// could not be set in the UI at all. Two halves: the field is now offered (from the
+// capabilities descriptor, not a hand-written list), and the SERVER's own rules are asked
+// about the draft, so the studio never restates a requirement of its own.
+
+vi.mock("@/lib/configApi", () => {
+  const parkFinding = {
+    subsystem: "configuration",
+    severity: "blocking",
+    reason:
+      "Project 'demo' github_trigger: pipeline 'code' can park a run on an operator question, " +
+      "but needs_clarification_status is not set.",
+    project: "demo",
+    trigger: "github_trigger",
+    field: "needs_clarification_status",
+  };
+  const client = <T,>(rows: T[]) => ({
+    list: vi.fn().mockResolvedValue(rows),
+    create: vi.fn().mockResolvedValue(rows[0] ?? { id: "x" }),
+    update: vi.fn().mockResolvedValue(rows[0] ?? { id: "x" }),
+    remove: vi.fn().mockResolvedValue(undefined),
+  });
+  return {
+    agentsApi: client([{ id: "claude" }]),
+    trackersApi: client([
+      {
+        id: "gh",
+        type: "github",
+        authSecret: "PAT",
+        url: "https://github.com/acme",
+      },
+    ]),
+    connectionsApi: client([]),
+    reposApi: client([{ id: "repo", name: "https://github.com/acme/repo", branch: "main" }]),
+    projectsApi: client([
+      {
+        id: "legacy",
+        agent: "claude",
+        tracker: "gh",
+        repos: ["repo"],
+        // p0393: a RETIRED preset name. It still runs, so it must still load.
+        pipeline: "fix-bug",
+        pipelines: ["fix-bug"],
+        resolution: { strategy: "tag", value: "legacy" },
+      },
+    ]),
+    mcpServersApi: client([]),
+    secretsApi: client([{ id: "PAT" }]),
+    fetchChanges: vi.fn().mockResolvedValue([]),
+    revertChange: vi.fn(),
+    fetchConfigExportYml: vi.fn(),
+    validateProjectDraft: vi.fn().mockResolvedValue([parkFinding]),
+    validateTrackerDraft: vi.fn().mockResolvedValue([]),
+    fetchCapabilities: vi.fn().mockResolvedValue({
+      trackerTypes: [
+        {
+          type: "github",
+          fields: [
+            { key: "url", label: "repository url", required: true, kind: "text" },
+            { key: "authSecret", label: "auth secret", required: true, kind: "text" },
+            {
+              key: "needsClarificationStatus",
+              label: "needs-clarification status",
+              required: false,
+              kind: "text",
+            },
+            { key: "zeroMatchComment", label: "comment when nothing matched", required: false, kind: "bool" },
+            { key: "pipelineFromLabel", label: "pipeline by label", required: false, kind: "map" },
+          ],
+        },
+      ],
+      connectionTypes: [],
+      agentProviders: ["anthropic"],
+      resolutionStrategies: ["tag"],
+      // The OFFERABLE set (PipelinePresets.Names) — retired aliases are absent by design.
+      pipelines: ["code", "security-scan"],
+      roles: [{ key: "coding", optional: false }],
+    }),
+    fetchConnectionRepos: vi.fn().mockResolvedValue({ discoveredAt: null, repos: [] }),
+  };
+});
+
+beforeEach(() => vi.clearAllMocks());
+
+async function openProject(id: string) {
+  render(
+    <ConfigCatalogProvider>
+      <ConfigStudio section="projects" />
+    </ConfigCatalogProvider>,
+  );
+  fireEvent.click(await screen.findByTestId(`config-card-edit-${id}`));
+}
+
+describe("Config Studio shows what is missing (p0392)", () => {
+  it("Studio_TriggerMissingNeedsClarificationStatus_IsFlaggedBeforeSave", async () => {
+    await openProject("legacy");
+
+    // The rule ran on the SERVER; the studio renders what it was told, naming the field.
+    const finding = await screen.findByTestId("form-draft-finding-needs_clarification_status");
+    expect(finding.textContent).toContain("needs_clarification_status");
+    expect(finding).toHaveAttribute("data-severity", "blocking");
+  });
+
+  it("Studio_RequiredFieldEmpty_BlocksSaveAndNamesTheField", async () => {
+    await openProject("legacy");
+
+    await screen.findByTestId("form-draft-finding-needs_clarification_status");
+    await waitFor(() => expect(screen.getByTestId("config-drawer-save")).toBeDisabled());
+    expect(screen.getByTestId("config-drawer-blocked").textContent).toContain(
+      "needs_clarification_status",
+    );
+  });
+
+  it("Studio_StoredRetiredPipelineName_LoadsAndIsLabelledRetired", async () => {
+    await openProject("legacy");
+
+    const pipeline = (await screen.findByTestId("form-field-pipeline")) as HTMLSelectElement;
+    // It LOADS: the stored value survives opening the form.
+    expect(pipeline.value).toBe("fix-bug");
+    expect(pipeline.querySelector('option[value="fix-bug"]')).not.toBeNull();
+    // And it is named for what it is, rather than silently rewritten.
+    expect(pipeline.closest(".field")?.textContent).toContain("retired");
+  });
+
+  it("Studio_PipelinePicker_OffersOnlyCurrentNames", async () => {
+    render(
+      <ConfigCatalogProvider>
+        <ConfigStudio section="projects" />
+      </ConfigCatalogProvider>,
+    );
+    fireEvent.click(await screen.findByTestId("config-new-projects"));
+
+    const pipeline = (await screen.findByTestId("form-field-pipeline")) as HTMLSelectElement;
+    const offered = [...pipeline.querySelectorAll("option")]
+      .map((o) => o.getAttribute("value"))
+      .filter((v) => v !== "");
+    expect(offered).toEqual(["code", "security-scan"]);
+    expect(offered).not.toContain("fix-bug");
+  });
+
+  it("Studio_TrackerForm_OffersTheParkStatusAndEveryDeclaredShape", async () => {
+    render(
+      <ConfigCatalogProvider>
+        <ConfigStudio section="trackers" />
+      </ConfigCatalogProvider>,
+    );
+    fireEvent.click(await screen.findByTestId("config-card-edit-gh"));
+
+    // The field the outage was about is editable at all — it was not, before p0392.
+    expect(await screen.findByTestId("form-field-needsClarificationStatus")).toBeInTheDocument();
+    // And the shapes come from the descriptor, so a map/bool field needs no UI change.
+    expect(screen.getByTestId("form-field-zeroMatchComment")).toBeInTheDocument();
+    expect(screen.getByTestId("form-field-pipelineFromLabel").tagName).toBe("TEXTAREA");
+  });
+});

--- a/src/dashboard/src/components/config/__tests__/RepositoriesPage.test.tsx
+++ b/src/dashboard/src/components/config/__tests__/RepositoriesPage.test.tsx
@@ -51,6 +51,8 @@ vi.mock("@/lib/configApi", () => {
     fetchChanges: vi.fn().mockResolvedValue([]),
     revertChange: vi.fn(),
     fetchConfigExportYml: vi.fn(),
+    validateProjectDraft: vi.fn().mockResolvedValue([]),
+    validateTrackerDraft: vi.fn().mockResolvedValue([]),
     fetchCapabilities: vi.fn().mockResolvedValue({
       trackerTypes: [],
       connectionTypes: [],

--- a/src/dashboard/src/components/config/capabilityFields.tsx
+++ b/src/dashboard/src/components/config/capabilityFields.tsx
@@ -1,59 +1,135 @@
 "use client";
 
-import type { CapabilityField } from "@/lib/configApi";
-import { TextField, ListField } from "./formFields";
+import type { CapabilityField, ConfigFinding } from "@/lib/configApi";
+import { TextField, ListField, CheckField, MapField } from "./formFields";
 
 // p0345c: renders the per-TYPE field set the capabilities descriptor declares
 // for the selected tracker/connection type. The field LIST comes entirely from
-// the backend; the only client knowledge is the v2 entity contract's value
-// shapes — which keys are string lists rather than scalars.
-
-const LIST_FIELD_KEYS = new Set(["openStates", "triggerStatuses"]);
+// the backend.
+// p0392: so does the value SHAPE. The client used to hold a hardcoded set of
+// "these keys are lists", which meant a backend field of any other shape could not be
+// offered without editing this file — and the twelve tracker fields the descriptor did
+// not declare included needs_clarification_status, whose absence refused a boot on
+// 2026-07-31 and could not be fixed from the UI at all.
 
 export function CapabilityFieldInputs({
   fields,
   values,
   onFieldChange,
   orgLabel,
+  findings = [],
 }: {
   fields: CapabilityField[];
   /** The entity draft, read as a loose record keyed by field key. */
   values: Record<string, unknown>;
-  onFieldChange: (key: string, value: string | string[] | undefined) => void;
+  onFieldChange: (key: string, value: FieldValue) => void;
   /** Connection types name their org scope (organization/owner/…) — overrides
    *  the label of the `organization` field. */
   orgLabel?: string;
+  /** What the server said about this draft; a finding naming a field is shown on it. */
+  findings?: ConfigFinding[];
 }) {
   return (
     <>
       {fields.map((f) => {
         const label = orgLabel && f.key === "organization" ? orgLabel : f.label;
-        if (LIST_FIELD_KEYS.has(f.key)) {
-          const current = Array.isArray(values[f.key]) ? (values[f.key] as string[]) : [];
-          return (
-            <ListField
-              key={f.key}
-              label={`${label} (comma separated)`}
-              values={current}
-              testId={`form-field-${f.key}`}
-              onChange={(v) => onFieldChange(f.key, v.length > 0 ? v : undefined)}
-            />
-          );
+        const finding = findingFor(findings, f.key);
+        const help = finding?.reason;
+
+        switch (f.kind) {
+          case "list": {
+            const current = Array.isArray(values[f.key]) ? (values[f.key] as string[]) : [];
+            return (
+              <FieldSlot key={f.key} finding={finding} fieldKey={f.key}>
+                <ListField
+                  label={`${label} (comma separated)`}
+                  values={current}
+                  testId={`form-field-${f.key}`}
+                  onChange={(v) => onFieldChange(f.key, v.length > 0 ? v : undefined)}
+                />
+              </FieldSlot>
+            );
+          }
+          case "bool":
+            return (
+              <FieldSlot key={f.key} finding={finding} fieldKey={f.key}>
+                <CheckField
+                  label={label}
+                  value={values[f.key] === true}
+                  testId={`form-field-${f.key}`}
+                  onChange={(v) => onFieldChange(f.key, v)}
+                />
+              </FieldSlot>
+            );
+          case "map": {
+            const current =
+              values[f.key] && typeof values[f.key] === "object"
+                ? (values[f.key] as Record<string, string>)
+                : {};
+            return (
+              <FieldSlot key={f.key} finding={finding} fieldKey={f.key}>
+                <MapField
+                  label={label}
+                  values={current}
+                  testId={`form-field-${f.key}`}
+                  onChange={(v) => onFieldChange(f.key, v)}
+                />
+              </FieldSlot>
+            );
+          }
+          default: {
+            const current = typeof values[f.key] === "string" ? (values[f.key] as string) : "";
+            return (
+              <FieldSlot key={f.key} finding={finding} fieldKey={f.key}>
+                <TextField
+                  label={label}
+                  value={current}
+                  required={f.required}
+                  help={help}
+                  testId={`form-field-${f.key}`}
+                  onChange={(v) => onFieldChange(f.key, v === "" ? undefined : v)}
+                />
+              </FieldSlot>
+            );
+          }
         }
-        const current = typeof values[f.key] === "string" ? (values[f.key] as string) : "";
-        return (
-          <TextField
-            key={f.key}
-            label={label}
-            value={current}
-            required={f.required}
-            testId={`form-field-${f.key}`}
-            onChange={(v) => onFieldChange(f.key, v === "" ? undefined : v)}
-          />
-        );
       })}
     </>
   );
+}
+
+export type FieldValue = string | string[] | boolean | Record<string, string> | undefined;
+
+/** Wraps a field so a server finding about it is visible ON the field, not only in a
+ *  banner — an operator fixing six things needs six markers, each next to its input. */
+function FieldSlot({
+  finding,
+  fieldKey,
+  children,
+}: {
+  finding: ConfigFinding | undefined;
+  fieldKey: string;
+  children: React.ReactNode;
+}) {
+  if (!finding) return <>{children}</>;
+  return (
+    <div data-testid={`form-finding-${fieldKey}`} data-severity={finding.severity}>
+      {children}
+      <p className="help" style={{ color: finding.severity === "blocking" ? "var(--bad)" : undefined }}>
+        {finding.reason}
+      </p>
+    </div>
+  );
+}
+
+/** The server names findings by the YAML field (needs_clarification_status); the form
+ *  keys them camelCase. One conversion, in one place. */
+export function findingFor(findings: ConfigFinding[], key: string): ConfigFinding | undefined {
+  return findings.find((f) => f.field && camelCase(f.field) === key);
+}
+
+export function camelCase(yamlKey: string): string {
+  return yamlKey.replace(/_([a-z])/g, (_, c: string) => c.toUpperCase());
 }
 
 /** Switching type prunes per-type fields the NEW type does not declare —
@@ -80,6 +156,7 @@ export function requiredFieldsFilled(
     .every((f) => {
       const v = values[f.key];
       if (Array.isArray(v)) return v.length > 0;
+      if (typeof v === "boolean") return true;
       return typeof v === "string" && v.trim().length > 0;
     });
 }

--- a/src/dashboard/src/components/config/formFields.tsx
+++ b/src/dashboard/src/components/config/formFields.tsx
@@ -246,6 +246,57 @@ export function CheckField({
   );
 }
 
+// p0392: a string->string map, edited as `key: value` lines. The backend declares this
+// shape (pipeline_from_label, lifecycle_status_names); before it did, such a field could
+// not be offered at all — a text box would have silently flattened the mapping.
+export function MapField({
+  label,
+  values,
+  onChange,
+  placeholder,
+  testId,
+  help,
+}: {
+  label: string;
+  values: Record<string, string>;
+  onChange: (v: Record<string, string> | undefined) => void;
+  placeholder?: string;
+  testId?: string;
+  help?: string;
+}) {
+  const text = Object.entries(values)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join("\n");
+  return (
+    <div className="field">
+      <label>
+        {label} <span className="help">{help ?? "one key: value per line"}</span>
+      </label>
+      <textarea
+        data-testid={testId}
+        rows={Math.max(2, Object.keys(values).length + 1)}
+        value={text}
+        placeholder={placeholder}
+        className="mono"
+        onChange={(e) => onChange(parseMap(e.target.value))}
+      />
+    </div>
+  );
+}
+
+function parseMap(text: string): Record<string, string> | undefined {
+  const entries = text
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const at = line.indexOf(":");
+      return at < 0 ? null : ([line.slice(0, at).trim(), line.slice(at + 1).trim()] as const);
+    })
+    .filter((e): e is readonly [string, string] => e !== null && e[0].length > 0);
+  return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+}
+
 // p0345c: one collapsible drawer section (the agent form's Provider & endpoint /
 // Models / Pricing / Cache / Compaction / Retry). The header shows whether the
 // section carries values; an empty optional section is simply not persisted.

--- a/src/dashboard/src/components/config/useDraftFindings.ts
+++ b/src/dashboard/src/components/config/useDraftFindings.ts
@@ -1,0 +1,58 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  validateProjectDraft,
+  validateTrackerDraft,
+  type ConfigEntityKind,
+  type ConfigFinding,
+  type StudioEntity,
+  type StudioProject,
+  type StudioTracker,
+} from "@/lib/configApi";
+
+// p0392: ask the SERVER what it would say about this draft, while it is still a draft.
+// p0391a made the server report what is missing once it is running — after a deploy, from
+// a container. The editor that produced the configuration is a better place to hear it,
+// and it is the same answer: the studio holds no rules, it renders what it is told.
+//
+// Only the two kinds with rules beyond referential integrity are asked. A failed request
+// yields NO findings rather than a fake one: the studio must never invent a block.
+
+const DEBOUNCE_MS = 250;
+
+export function useDraftFindings(kind: ConfigEntityKind, draft: StudioEntity): ConfigFinding[] {
+  const [findings, setFindings] = useState<ConfigFinding[]>([]);
+  const key = JSON.stringify(draft);
+
+  useEffect(() => {
+    if (kind !== "projects" && kind !== "trackers") {
+      setFindings([]);
+      return;
+    }
+    const controller = new AbortController();
+    const timer = setTimeout(() => {
+      const parsed = JSON.parse(key) as StudioEntity;
+      try {
+        const ask =
+          kind === "projects"
+            ? validateProjectDraft(parsed as StudioProject, controller.signal)
+            : validateTrackerDraft(parsed as StudioTracker, controller.signal);
+        ask.then(setFindings).catch(() => setFindings([]));
+      } catch {
+        setFindings([]);
+      }
+    }, DEBOUNCE_MS);
+
+    return () => {
+      clearTimeout(timer);
+      controller.abort();
+    };
+  }, [kind, key]);
+
+  return findings;
+}
+
+export function blockingFindings(findings: ConfigFinding[]): ConfigFinding[] {
+  return findings.filter((f) => f.severity === "blocking");
+}

--- a/src/dashboard/src/lib/configApi.ts
+++ b/src/dashboard/src/lib/configApi.ts
@@ -171,10 +171,16 @@ export type ConfigChangeKind = ConfigEntityKind | "settings";
 // and resolution strategies are known, and the pipeline names. The forms render
 // FROM this; no type knowledge is hardcoded client-side.
 
+/** p0392: `kind` is the VALUE SHAPE, declared by the backend. It used to be client
+ *  knowledge (a hardcoded "these keys are lists" set), so a backend field of any other
+ *  shape could not be declared without editing this file too. */
+export type CapabilityFieldKind = "text" | "list" | "bool" | "map";
+
 export interface CapabilityField {
   key: string;
   label: string;
   required: boolean;
+  kind: CapabilityFieldKind;
 }
 
 export interface TrackerTypeDescriptor {
@@ -208,6 +214,48 @@ export interface ConfigCapabilities {
 
 export async function fetchCapabilities(signal?: AbortSignal): Promise<ConfigCapabilities> {
   return readJson<ConfigCapabilities>(await fetch(`${API_BASE}/api/config/capabilities`, { signal }));
+}
+
+// --- p0392: what the SERVER would say about a draft, before it is saved. p0391a made the
+// server report what is missing once it is running; the editor that produced the
+// configuration is a better place to hear it. The studio holds no rules of its own — it
+// asks, and renders the answer.
+
+export interface ConfigFinding {
+  subsystem: string;
+  severity: "blocking" | "advisory";
+  reason: string;
+  project?: string | null;
+  trigger?: string | null;
+  field?: string | null;
+}
+
+export async function validateProjectDraft(
+  draft: StudioProject,
+  signal?: AbortSignal,
+): Promise<ConfigFinding[]> {
+  return readJson<ConfigFinding[]>(
+    await fetch(`${API_BASE}/api/config/projects/validate`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(draft),
+      signal,
+    }),
+  );
+}
+
+export async function validateTrackerDraft(
+  draft: StudioTracker,
+  signal?: AbortSignal,
+): Promise<ConfigFinding[]> {
+  return readJson<ConfigFinding[]>(
+    await fetch(`${API_BASE}/api/config/trackers/validate`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(draft),
+      signal,
+    }),
+  );
 }
 
 /** p0345c: one repo the discovery cache knows inside a connection. */
@@ -305,8 +353,17 @@ export interface StudioTracker {
   doneStatus?: string;
   failedStatus?: string;
   triggerStatuses?: string[];
-  pipelineFromLabel?: string;
+  pipelineFromLabel?: Record<string, string>;
   polling?: TrackerPollingConfig;
+  // p0392: the rest of the tracker-owned workflow. needsClarificationStatus is the field
+  // the 2026-07-31 outage was about — the server refused to boot without it and it could
+  // not be set here, so the way out was a rollback and a hand-edited export.
+  needsClarificationStatus?: string;
+  notImplementableStatus?: string;
+  closeTransitionName?: string;
+  extraFields?: string[];
+  zeroMatchComment?: boolean;
+  lifecycleStatusNames?: Record<string, string>;
 }
 
 /** p0345b: a repo-discovery connection (p0281a) — org/project scope + a FK to
@@ -322,6 +379,8 @@ export interface StudioConnection {
   organization?: string;
   project?: string;
   defaultBranch?: string;
+  /** p0392: self-hosted base URL (GitHub Enterprise, self-hosted GitLab). */
+  host?: string;
 }
 
 export interface StudioRepo {
@@ -349,6 +408,8 @@ export interface StudioProject {
   pipeline: string;
   pipelines: string[];
   resolution: ProjectResolution | null;
+  /** p0392: what runs when a ticket carries no routing label. */
+  defaultPipeline?: string;
 }
 
 export interface StudioMcpServer {

--- a/tests/AgentSmith.Tests/Architecture/StartupThrowInventoryTests.cs
+++ b/tests/AgentSmith.Tests/Architecture/StartupThrowInventoryTests.cs
@@ -1,0 +1,135 @@
+using FluentAssertions;
+
+namespace AgentSmith.Tests.Architecture;
+
+/// <summary>
+/// p0391b — THE INVENTORY, as a mechanism rather than a list in a document.
+///
+/// p0391a ruled that aborting startup is never justifiable and converted the paths it
+/// found. p0393 then found another one in a path p0391a had already written a probe for.
+/// A ruling is not a mechanism: what stops the next one is that every throw on a
+/// composition or configuration path has to be ACCOUNTED FOR here, either by being
+/// converted to a finding or by carrying a reason it stays fatal.
+///
+/// Adding a throw to one of the scanned files fails this test until its author writes down
+/// which of the two it is.
+/// </summary>
+public sealed class StartupThrowInventoryTests
+{
+    // Composition, hosting and configuration. Everything here runs before or during host
+    // start, or produces the configuration that does — the places where a throw is a dead
+    // process rather than a failed request.
+    private static readonly string[] ScannedDirectories =
+    [
+        "AgentSmith.Server/Services/Startup",
+        "AgentSmith.Server/Services/Hosting",
+        "AgentSmith.Server/Extensions",
+        "AgentSmith.Server/Services",
+        "AgentSmith.Infrastructure.Core/Services/Configuration",
+    ];
+
+    /// <summary>
+    /// file name -> why a throw in it does not kill the server. Each entry is a claim that
+    /// has to stay true; the accompanying assertions in this suite and in
+    /// StartupResilienceTests are what keep it honest.
+    /// </summary>
+    private static readonly Dictionary<string, string> Accounted = new()
+    {
+        ["UnavailableJobSpawner.cs"] =
+            "Refuses the WORK, not the process: a run dispatched with no sandbox backend fails "
+            + "with the reason. p0391a's rule permits exactly this.",
+        ["DockerJobSpawner.cs"] =
+            "Per-run spawn failure at request time, not composition.",
+        ["ConnectionRepoUrlBuilder.cs"] =
+            "Caught by ConfigCatalogResolver.TryBuildProject — becomes that project's finding.",
+        ["RepoGlobExpander.cs"] =
+            "Caught by ConfigCatalogResolver.TryBuildProject — becomes that project's finding.",
+        ["EffectiveTriggerBuilder.cs"] =
+            "Caught by RawConfigMaterializer.ApplyEffectiveTriggers — becomes that project's finding.",
+        ["RawRepoRefYamlConverter.cs"] =
+            "YAML binding; both loaders catch it (the file loader as a parse error, the DB "
+            + "loader as a configuration finding).",
+        ["SecretsProvider.cs"] =
+            "Not on a startup path: the materializer resolves env references with a null-coalesce, "
+            + "so a missing secret is a provider-construction failure at request time.",
+        ["YamlConfigurationLoader.cs"] =
+            "STAYS FATAL, deliberately. This is the one-shot loader — CLI, sandbox agent, harness. "
+            + "That process exists to run one command against one file the operator just named, so "
+            + "the exit code IS the report and there is nothing to keep alive. The server never "
+            + "takes this path; it loads from the DB via DbConfigurationLoader, which never throws. "
+            + "Operator action: `agentsmith config validate` prints the same findings.",
+    };
+
+    [Fact]
+    public void StartupPaths_NoRemainingThrow_IsUnaccountedFor()
+    {
+        var unaccounted = ScanThrows()
+            .Where(hit => !Accounted.ContainsKey(hit.File))
+            .Select(hit => $"{hit.File}:{hit.Line} — {hit.Text}")
+            .ToList();
+
+        unaccounted.Should().BeEmpty(
+            "every throw on a composition or configuration path must either become a "
+            + "StartupFinding (p0391a's ruling: a dead process reports nothing) or be listed "
+            + "in StartupThrowInventoryTests.Accounted with the reason it stays fatal and what "
+            + "an operator can do about it. Unaccounted: "
+            + string.Join(" | ", unaccounted));
+    }
+
+    [Fact]
+    public void StartupPaths_EveryAccountedEntry_StillExists()
+    {
+        // An allowlist that outlives its throw is a lie about what the code does — the next
+        // author reads it as permission for a throw nobody reviewed.
+        var scannedFiles = ScanThrows().Select(hit => hit.File).ToHashSet();
+
+        Accounted.Keys.Where(file => !scannedFiles.Contains(file)).Should().BeEmpty(
+            "an accounted throw that no longer exists must be removed from the inventory");
+    }
+
+    private static IEnumerable<(string File, int Line, string Text)> ScanThrows()
+    {
+        var root = ResolveSrcBackendRoot();
+        foreach (var relative in ScannedDirectories)
+        {
+            var directory = Path.Combine(root, relative.Replace('/', Path.DirectorySeparatorChar));
+            if (!Directory.Exists(directory)) continue;
+
+            // Top level only: a nested folder is its own concern and is listed explicitly
+            // when it belongs to composition.
+            foreach (var file in Directory.EnumerateFiles(directory, "*.cs", SearchOption.TopDirectoryOnly))
+                foreach (var hit in ThrowsIn(file))
+                    yield return hit;
+        }
+    }
+
+    private static IEnumerable<(string File, int Line, string Text)> ThrowsIn(string path)
+    {
+        var name = Path.GetFileName(path);
+        var lines = File.ReadAllLines(path);
+        for (var i = 0; i < lines.Length; i++)
+        {
+            var text = lines[i].Trim();
+            if (text.StartsWith("//") || text.StartsWith("///")) continue;
+            if (!text.Contains("throw new")
+                && !text.Contains("Environment.Exit(")
+                && !text.Contains("Environment.FailFast(")) continue;
+            yield return (name, i + 1, text);
+        }
+    }
+
+    private static string ResolveSrcBackendRoot()
+    {
+        var dir = AppContext.BaseDirectory;
+        for (var i = 0; i < 10; i++)
+        {
+            var candidate = Path.Combine(dir, "src", "backend");
+            if (Directory.Exists(candidate)) return candidate;
+            var parent = Directory.GetParent(dir);
+            if (parent is null) break;
+            dir = parent.FullName;
+        }
+        throw new InvalidOperationException(
+            $"Could not locate src/backend from test base directory '{AppContext.BaseDirectory}'");
+    }
+}

--- a/tests/AgentSmith.Tests/Cli/Services/ConfigValidatorTests.cs
+++ b/tests/AgentSmith.Tests/Cli/Services/ConfigValidatorTests.cs
@@ -1,0 +1,164 @@
+using AgentSmith.Application.Services.Configuration;
+using AgentSmith.Application.Services.Events;
+using AgentSmith.Cli.Services;
+using AgentSmith.Contracts.Models.Configuration;
+using AgentSmith.Infrastructure.Core.Services;
+using AgentSmith.Infrastructure.Core.Services.Configuration;
+using FluentAssertions;
+
+namespace AgentSmith.Tests.Cli.Services;
+
+/// <summary>
+/// p0391b: `agentsmith config validate` exists so an operator learns what the server would
+/// say about a configuration BEFORE rolling it out, instead of from a container that comes
+/// up degraded. It runs the server's own rules — there is no CLI-side validator, because a
+/// second one would be a second source of truth about what a valid configuration is.
+/// </summary>
+public sealed class ConfigValidatorTests : IDisposable
+{
+    private readonly string _tempFile = Path.Combine(
+        Path.GetTempPath(), $"agentsmith-validate-{Guid.NewGuid():N}.yml");
+
+    public void Dispose()
+    {
+        if (File.Exists(_tempFile)) File.Delete(_tempFile);
+    }
+
+    [Fact]
+    public void Cli_Validate_ReportsTheSameFindingsAsTheServer()
+    {
+        // A trigger without project_resolution: a rule the server's ConfigurationProbe owns.
+        Write("""
+            agents:
+              a: { type: Claude }
+            repos:
+              r: { type: GitHub, url: https://x, auth: t }
+            trackers:
+              t: { type: GitHub, auth: t, trigger_statuses: [open], done_status: closed }
+            projects:
+              demo:
+                agent: a
+                tracker: t
+                repos: [r]
+                github_trigger:
+                  trigger_statuses: [open]
+                  done_status: closed
+            """);
+
+        var findings = NewValidator(out var loader).Validate(_tempFile);
+
+        // What the server would publish for the same file, from the same rule object.
+        var serverFindings = new AgentSmithConfigValidator().Findings(loader.LoadConfig(_tempFile));
+
+        serverFindings.Should().NotBeEmpty();
+        findings.Select(f => (f.Project, f.Trigger, f.Field, f.Severity))
+            .Should().Contain(serverFindings.Select(f => (f.Project, f.Trigger, f.Field, f.Severity)));
+        findings.Should().Contain(f => f.Field == "project_resolution" && f.Project == "demo");
+    }
+
+    [Fact]
+    public void Cli_Validate_ValidConfig_ExitsZero()
+    {
+        Write("""
+            agents:
+              a: { type: Claude }
+            repos:
+              r: { type: GitHub, url: https://x, auth: t }
+            trackers:
+              t: { type: GitHub, auth: t }
+            projects:
+              demo:
+                agent: a
+                tracker: t
+                repos: [r]
+                resolution: { tag: demo }
+                github_trigger:
+                  trigger_statuses: [open]
+                  done_status: closed
+                  needs_clarification_status: question
+            """);
+
+        var findings = NewValidator(out _).Validate(_tempFile);
+
+        findings.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Cli_Validate_UnresolvableReference_NamesTheProjectAndField()
+    {
+        Write("""
+            agents:
+              a: { type: Claude }
+            repos:
+              r: { type: GitHub, url: https://x, auth: t }
+            trackers:
+              t: { type: GitHub, auth: t }
+            projects:
+              demo: { agent: ghost, tracker: t, repos: [r] }
+            """);
+
+        var findings = NewValidator(out _).Validate(_tempFile);
+
+        findings.Should().ContainSingle(f =>
+            f.Project == "demo" && f.Field == "agent" && f.IsBlocking);
+    }
+
+    [Fact]
+    public void Cli_Validate_UnparseableFile_IsOneFindingNotACrash()
+    {
+        File.WriteAllText(_tempFile, "agents: [ this is not: valid: yaml");
+
+        var findings = NewValidator(out _).Validate(_tempFile);
+
+        findings.Should().ContainSingle(f =>
+            f.Subsystem == StartupSubsystems.ConfigFile && f.IsBlocking);
+    }
+
+    [Fact]
+    public void Print_FindingsCarryTheirField_SoSixMistakesAreSixLines()
+    {
+        var findings = new List<StartupFinding>
+        {
+            new(StartupSubsystems.Configuration, StartupFindingSeverity.Blocking,
+                "first", "one", "github_trigger", "needs_clarification_status"),
+            new(StartupSubsystems.Configuration, StartupFindingSeverity.Blocking,
+                "second", "two", Field: "agent"),
+        };
+        var writer = new StringWriter();
+
+        StartupFindingPrinter.Print(findings, writer);
+
+        var lines = writer.ToString().Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+        lines.Should().HaveCount(3); // one per finding plus the summary
+        lines[0].Should().Contain("one").And.Contain("needs_clarification_status");
+        lines[1].Should().Contain("two").And.Contain("agent");
+        lines[2].Should().Contain("2 blocking");
+    }
+
+    [Fact]
+    public void Print_NoFindings_SaysSo()
+    {
+        var writer = new StringWriter();
+
+        StartupFindingPrinter.Print([], writer);
+
+        writer.ToString().Should().Contain("no findings");
+    }
+
+    private void Write(string yaml) => File.WriteAllText(_tempFile, yaml);
+
+    private ConfigValidator NewValidator(out YamlConfigurationLoader loader)
+    {
+        var findings = new StartupFindings();
+        loader = new YamlConfigurationLoader(
+            new RawConfigMaterializer(
+                new ProjectConfigNormalizer(findings: findings),
+                new EffectiveTriggerBuilder(),
+                new DeploymentDefaultsApplier(),
+                new ConfigCatalogResolver(findings: findings),
+                new AgentSmithPaths(),
+                findings),
+            new NoOpSystemEventPublisher());
+        return new ConfigValidator(loader, findings, new AgentSmithConfigValidator());
+    }
+}

--- a/tests/AgentSmith.Tests/ConfigStudio/CapabilityCoverageTests.cs
+++ b/tests/AgentSmith.Tests/ConfigStudio/CapabilityCoverageTests.cs
@@ -1,0 +1,112 @@
+using AgentSmith.Contracts.Models.ConfigStudio;
+using AgentSmith.Contracts.Services;
+using AgentSmith.Infrastructure.Core.Services.Configuration;
+using FluentAssertions;
+
+namespace AgentSmith.Tests.ConfigStudio;
+
+/// <summary>
+/// p0392 — the guard. The tracker section read sixteen backend fields and the descriptor
+/// declared four; the twelve it did not declare included needs_clarification_status, the
+/// field whose absence refused a boot on 2026-07-31 and which could not be set in the UI
+/// at all, so no amount of operator care would have prevented the outage.
+///
+/// The defect is not any one missing input — it is that a field could be ADDED to the
+/// backend and stay invisible. This test walks the raw read models against the capabilities
+/// descriptor, so the next added field fails until the descriptor declares it or the gap is
+/// written down here with the phase that closes it.
+/// </summary>
+public sealed class CapabilityCoverageTests
+{
+    private static readonly ConfigCapabilities Capabilities = ConfigStudioCapabilities.Build(["claude"]);
+
+    // Raw properties that are NOT form fields: the discriminator the type list already is,
+    // and the contract-level blocks the form renders as their own section.
+    private static readonly Dictionary<string, string> NotAField = new()
+    {
+        ["type"] = "the type list itself — every descriptor is keyed by it",
+        ["polling"] = "a contract-level block, not per-type; the tracker form renders it as its own section",
+    };
+
+    // A raw property whose wire key differs from its camelCased name.
+    private static readonly Dictionary<string, string> WireKey = new()
+    {
+        ["auth"] = "authSecret",   // the studio stores the env-NAME, never a value
+        ["owner"] = "organization", // GitHub's org segment; the descriptor's orgLabel renames the label
+        ["group"] = "organization", // GitLab's
+    };
+
+    [Fact]
+    public void Capabilities_EveryBackendReadField_IsDeclared_ForTrackers()
+    {
+        var declared = Capabilities.TrackerTypes.SelectMany(t => t.Fields).Select(f => f.Key).ToHashSet();
+
+        Undeclared<RawTrackerEntry>(declared).Should().BeEmpty(
+            "a tracker field the backend reads but the descriptor does not declare cannot be "
+            + "edited in the Config Studio, and its absence only shows up as a failed run or a "
+            + "refused boot (p0392)");
+    }
+
+    [Fact]
+    public void Capabilities_EveryBackendReadField_IsDeclared_ForConnections()
+    {
+        var declared = Capabilities.ConnectionTypes.SelectMany(t => t.Fields).Select(f => f.Key).ToHashSet();
+
+        Undeclared<RawConnectionEntry>(declared).Should().BeEmpty(
+            "a connection field the backend reads but the descriptor does not declare cannot be "
+            + "edited in the Config Studio (p0392)");
+    }
+
+    [Fact]
+    public void Capabilities_DeclaredFields_CarryTheirRequiredness()
+    {
+        var fields = Capabilities.TrackerTypes.SelectMany(t => t.Fields)
+            .Concat(Capabilities.ConnectionTypes.SelectMany(t => t.Fields))
+            .ToList();
+
+        fields.Should().NotBeEmpty();
+        fields.Should().OnlyContain(f => !string.IsNullOrWhiteSpace(f.Label));
+        // Requiredness is only worth declaring if it is enforced: every required field must
+        // be one the write-side validator can actually read off the entity.
+        foreach (var type in Capabilities.TrackerTypes)
+        {
+            var required = type.Fields.Where(f => f.Required).Select(f => f.Key).ToList();
+            var blank = new TrackerEntity(Id: "t", Type: type.Type, AuthSecret: null);
+            var act = () => ConfigStudioCapabilities.ValidateTracker(blank);
+
+            required.Should().NotBeEmpty($"tracker type '{type.Type}' declares an identity it needs");
+            act.Should().Throw<AgentSmith.Domain.Exceptions.ConfigurationException>()
+                .Which.Message.Should().ContainAll(required);
+        }
+    }
+
+    [Fact]
+    public void Capabilities_EveryDeclaredField_HasAValueShape()
+    {
+        // The shape is what the form renders from. A list rendered as a text box silently
+        // corrupts the stored value, which is why the client no longer decides it.
+        var fields = Capabilities.TrackerTypes.SelectMany(t => t.Fields)
+            .Concat(Capabilities.ConnectionTypes.SelectMany(t => t.Fields));
+
+        fields.Should().OnlyContain(f => Enum.IsDefined(f.Kind));
+    }
+
+    [Fact]
+    public void Capabilities_PipelinesOffered_ExcludeRetiredAliases()
+    {
+        // p0393's distinction, which p0392 must preserve: a stored `fix-bug` keeps
+        // validating (IsAcceptedName) and is never presented as a choice (Names).
+        Capabilities.Pipelines.Should().NotContain("fix-bug");
+        AgentSmith.Contracts.Commands.PipelinePresets.IsAcceptedName("fix-bug").Should().BeTrue();
+        Capabilities.Pipelines.Should().BeEquivalentTo(AgentSmith.Contracts.Commands.PipelinePresets.Names);
+    }
+
+    private static IReadOnlyList<string> Undeclared<TRaw>(HashSet<string> declared) =>
+        typeof(TRaw).GetProperties()
+            .Select(p => char.ToLowerInvariant(p.Name[0]) + p.Name[1..])
+            .Select(key => WireKey.GetValueOrDefault(key, key))
+            .Where(key => !NotAField.ContainsKey(key))
+            .Where(key => !declared.Contains(key))
+            .Distinct()
+            .ToList();
+}

--- a/tests/AgentSmith.Tests/ConfigStudio/ConfigDraftRulesTests.cs
+++ b/tests/AgentSmith.Tests/ConfigStudio/ConfigDraftRulesTests.cs
@@ -1,0 +1,92 @@
+using AgentSmith.Contracts.Models.ConfigStudio;
+using AgentSmith.Infrastructure.Core.Services.Configuration;
+using AgentSmith.Infrastructure.Core.Services.Configuration.Studio;
+using FluentAssertions;
+
+namespace AgentSmith.Tests.ConfigStudio;
+
+/// <summary>
+/// p0392: the editor asks the server what it would say, before the save. The rules are the
+/// server's own — ClarificationParkStatusRule and ProjectTriggerRules through
+/// ProjectConfigNormalizer.Inspect, and the descriptor's requiredness through
+/// ConfigStudioCapabilities.ValidateTracker — so the studio can name a missing field
+/// without holding an opinion about what a valid configuration is.
+/// </summary>
+public sealed class ConfigDraftRulesTests
+{
+    private readonly ConfigDraftRules _rules = new(new EffectiveTriggerBuilder(), new ProjectConfigNormalizer());
+
+    [Fact]
+    public void Studio_TriggerMissingNeedsClarificationStatus_IsFlaggedBeforeSave()
+    {
+        // The 2026-07-31 configuration, as the studio would submit it: a parking pipeline
+        // and a tracker whose needs_clarification_status was never set. The server refused
+        // to boot on this; the editor now refuses it first.
+        var catalog = CatalogWith(Tracker(needsClarificationStatus: null));
+
+        var findings = _rules.ForProject(Project(pipeline: "code"), catalog);
+
+        findings.Should().ContainSingle(f =>
+            f.Field == "needs_clarification_status" && f.IsBlocking && f.Project == "demo");
+    }
+
+    [Fact]
+    public void Studio_TrackerSuppliesTheParkStatus_IsNotFlagged()
+    {
+        // The tracker OWNS the workflow (p0281b) and the trigger inherits it — so the check
+        // has to run the real merge, not look at the project alone.
+        var catalog = CatalogWith(Tracker(needsClarificationStatus: "question"));
+
+        var findings = _rules.ForProject(Project(pipeline: "code"), catalog);
+
+        findings.Should().NotContain(f => f.Field == "needs_clarification_status");
+    }
+
+    [Fact]
+    public void Studio_NonParkingPipeline_IsNotFlagged()
+    {
+        // A scan-only project cannot park, so demanding the field would be noise.
+        var catalog = CatalogWith(Tracker(needsClarificationStatus: null));
+
+        var findings = _rules.ForProject(Project(pipeline: "security-scan"), catalog);
+
+        findings.Should().NotContain(f => f.Field == "needs_clarification_status");
+    }
+
+    [Fact]
+    public void Studio_RequiredFieldEmpty_BlocksSaveAndNamesTheField()
+    {
+        var draft = new TrackerEntity(Id: "gh", Type: "github", AuthSecret: null);
+
+        var findings = _rules.ForTracker(draft);
+
+        findings.Should().ContainSingle().Which.Reason
+            .Should().Contain("url").And.Contain("authSecret");
+    }
+
+    [Fact]
+    public void Studio_TrackerComplete_HasNoFindings()
+    {
+        var draft = new TrackerEntity(
+            Id: "gh", Type: "github", AuthSecret: "GITHUB_TOKEN", Url: "https://github.com/x/y");
+
+        _rules.ForTracker(draft).Should().BeEmpty();
+    }
+
+    private static ProjectEntity Project(string pipeline) => new(
+        "demo", "claude", "gh", ["repo"], pipeline, [pipeline],
+        new ProjectResolution("tag", "demo"));
+
+    private static TrackerEntity Tracker(string? needsClarificationStatus) => new(
+        Id: "gh",
+        Type: "github",
+        AuthSecret: "GITHUB_TOKEN",
+        Url: "https://github.com/x/y",
+        TriggerStatuses: ["open"],
+        DoneStatus: "closed",
+        NeedsClarificationStatus: needsClarificationStatus);
+
+    private static ConfigCatalog CatalogWith(TrackerEntity tracker) =>
+        new(Agents: [], Trackers: [tracker], Repos: [], Projects: [],
+            McpServers: [], Secrets: [], Connections: []);
+}

--- a/tests/AgentSmith.Tests/ConfigStudio/ConfigStudioApiSmokeTests.cs
+++ b/tests/AgentSmith.Tests/ConfigStudio/ConfigStudioApiSmokeTests.cs
@@ -324,6 +324,54 @@ public sealed class ConfigStudioApiSmokeTests
         }
     }
 
+    [Fact]
+    public async Task ConfigStudioApi_ValidateDraft_ReportsWhatTheServerWouldReport()
+    {
+        // p0392: the wire seam behind "the Studio asks the same validation the server uses".
+        // The rule is ClarificationParkStatusRule — the one that refused a boot on
+        // 2026-07-31 — reached over HTTP with a draft that was never saved.
+        var path = Path.Combine(Path.GetTempPath(), $"agentsmith-smoke-validate-{Guid.NewGuid():N}.yml");
+        File.WriteAllText(path, Yaml);
+        try
+        {
+            await using var app = await StartAppAsync(path);
+            using var http = NewClient(app);
+
+            // The seeded tracker has no needs_clarification_status, and `code` can park.
+            var parking = await http.PostAsJsonAsync("/api/config/projects/validate",
+                new ProjectEntity("draft", "claude-default", "test-ado", ["test-repo"], "code", ["code"],
+                    new ProjectResolution("tag", "draft")));
+            parking.StatusCode.Should().Be(HttpStatusCode.OK);
+            var findings = await parking.Content.ReadFromJsonAsync<List<AgentSmith.Server.Models.StartupFindingView>>();
+            findings.Should().Contain(f =>
+                f!.Field == "needs_clarification_status" && f.Severity == "blocking" && f.Project == "draft");
+
+            // A scan-only project cannot park, so demanding the field would be noise.
+            var scan = await http.PostAsJsonAsync("/api/config/projects/validate",
+                new ProjectEntity("draft", "claude-default", "test-ado", ["test-repo"],
+                    "security-scan", ["security-scan"], new ProjectResolution("tag", "draft")));
+            (await scan.Content.ReadFromJsonAsync<List<AgentSmith.Server.Models.StartupFindingView>>())
+                .Should().NotContain(f => f!.Field == "needs_clarification_status");
+
+            // The tracker route reports the descriptor's requiredness instead of refusing.
+            var tracker = await http.PostAsJsonAsync("/api/config/trackers/validate",
+                new TrackerEntity("draft", "azure_devops", AuthSecret: null));
+            var trackerFindings =
+                await tracker.Content.ReadFromJsonAsync<List<AgentSmith.Server.Models.StartupFindingView>>();
+            trackerFindings.Should().ContainSingle().Which.Reason
+                .Should().Contain("organization").And.Contain("authSecret");
+
+            // Nothing the draft carried leaked into the installation's live findings.
+            app.Services.GetService<IStartupFindings>()?.All.Should().BeNullOrEmpty();
+
+            await app.StopAsync();
+        }
+        finally
+        {
+            DeleteConfigAndDb(path);
+        }
+    }
+
     private static StringContent JsonBody(string json) => new(json, Encoding.UTF8, "application/json");
 
     private static StringContent YamlBody(string yaml) => new(yaml, Encoding.UTF8, "text/yaml");
@@ -370,6 +418,10 @@ public sealed class ConfigStudioApiSmokeTests
         builder.Services.AddSingleton<IAgentSmithPaths>(
             new TempPaths(cacheRoot ?? Path.Combine(Path.GetTempPath(), $"agentsmith-cache-{Guid.NewGuid():N}")));
         builder.Services.AddSingleton<IConnectionRepoSnapshotStore, DiskConnectionRepoSnapshotStore>();
+        // p0392: the draft-validation endpoints run the server's own rule objects.
+        builder.Services.AddSingleton<EffectiveTriggerBuilder>();
+        builder.Services.AddSingleton<ProjectConfigNormalizer>();
+        builder.Services.AddSingleton<ConfigDraftRules>();
 
         var app = builder.Build();
         // SQL Server DBs are pre-migrated (the SqlServer migrations assembly is not

--- a/tests/AgentSmith.Tests/Configuration/ConfigCatalogResolverFindingsTests.cs
+++ b/tests/AgentSmith.Tests/Configuration/ConfigCatalogResolverFindingsTests.cs
@@ -1,0 +1,132 @@
+using AgentSmith.Contracts.Models.Configuration;
+using AgentSmith.Infrastructure.Core.Services;
+using AgentSmith.Infrastructure.Core.Services.Configuration;
+using FluentAssertions;
+
+namespace AgentSmith.Tests.Configuration;
+
+/// <summary>
+/// p0391b: ConfigCatalogResolver used to aggregate every configuration error into one
+/// throw, which the server's loader then turned into a single "the stored configuration is
+/// not usable" line — six mistakes, one sentence, and every healthy project silenced with
+/// them. Each error is now its own finding, naming the project and the field to edit, and
+/// only the project that carries it drops out.
+/// </summary>
+public sealed class ConfigCatalogResolverFindingsTests
+{
+    [Fact]
+    public void ConfigCatalogResolver_SixErrors_ProducesSixFindingsWithTheirFields()
+    {
+        var raw = RawConfigYaml.Deserialize("""
+            agents:
+              real: { type: Claude }
+            repos:
+              real: { type: GitHub, auth: t }
+            trackers:
+              real: { type: GitHub, auth: t }
+            projects:
+              one: { agent: typo-a, tracker: typo-t, repos: [typo-r] }
+              two: { agent: typo-a2, tracker: typo-t2, repos: [typo-r2] }
+            """);
+
+        var findings = Resolve(raw).Findings;
+
+        findings.Should().HaveCount(6);
+        findings.Should().OnlyContain(f => f.Subsystem == StartupSubsystems.Configuration);
+        findings.Should().OnlyContain(f => f.IsBlocking);
+        findings.Select(f => (f.Project, f.Field)).Should().BeEquivalentTo(
+        [
+            ("one", "agent"), ("one", "tracker"), ("one", "repos"),
+            ("two", "agent"), ("two", "tracker"), ("two", "repos"),
+        ]);
+    }
+
+    [Fact]
+    public void ConfigCatalogResolver_NoErrors_ProducesNone()
+    {
+        var raw = RawConfigYaml.Deserialize("""
+            agents:
+              a: { type: Claude }
+            repos:
+              r: { type: GitHub, url: https://x, auth: t }
+            trackers:
+              t: { type: GitHub, auth: t }
+            projects:
+              demo: { agent: a, tracker: t, repos: [r] }
+            """);
+
+        var resolved = Resolve(raw);
+
+        resolved.Findings.Should().BeEmpty();
+        resolved.Config.Projects.Should().ContainKey("demo");
+    }
+
+    [Fact]
+    public void ConfigCatalogResolver_OneBrokenProject_KeepsTheOthers()
+    {
+        // The point of the conversion: an unresolvable reference disables ITS project, not
+        // the configuration. Before p0391b this threw and the server ran with nothing.
+        var raw = RawConfigYaml.Deserialize("""
+            agents:
+              a: { type: Claude }
+            repos:
+              r: { type: GitHub, url: https://x, auth: t }
+            trackers:
+              t: { type: GitHub, auth: t }
+            projects:
+              healthy: { agent: a, tracker: t, repos: [r] }
+              broken: { agent: ghost, tracker: t, repos: [r] }
+            """);
+
+        var resolved = Resolve(raw);
+
+        resolved.Config.Projects.Should().ContainKey("healthy");
+        resolved.Config.Projects.Should().NotContainKey("broken");
+        resolved.Findings.Should().ContainSingle().Which.Project.Should().Be("broken");
+    }
+
+    [Fact]
+    public void ConfigCatalogResolver_UnknownResolutionStrategy_IsThatProjectsFinding()
+    {
+        // Used to throw out of EffectiveTriggerBuilder before the resolver ran at all, so
+        // the whole configuration came back empty for one typo in one project.
+        var raw = RawConfigYaml.Deserialize("""
+            agents:
+              a: { type: Claude }
+            repos:
+              r: { type: GitHub, url: https://x, auth: t }
+            trackers:
+              t: { type: GitHub, auth: t }
+            projects:
+              healthy:
+                agent: a
+                tracker: t
+                repos: [r]
+                resolution: { tag: ok }
+              broken:
+                agent: a
+                tracker: t
+                repos: [r]
+                resolution: { not_a_strategy: whatever }
+            """);
+
+        var resolved = Resolve(raw);
+
+        resolved.Config.Projects.Should().ContainKey("healthy");
+        resolved.Findings.Should().ContainSingle(f =>
+            f.Project == "broken" && f.Field == "resolution" && f.IsBlocking);
+    }
+
+    private static (AgentSmithConfig Config, IReadOnlyList<StartupFinding> Findings) Resolve(
+        RawAgentSmithConfig raw)
+    {
+        var materializer = new RawConfigMaterializer(
+            new ProjectConfigNormalizer(),
+            new EffectiveTriggerBuilder(),
+            new DeploymentDefaultsApplier(),
+            new ConfigCatalogResolver(),
+            new AgentSmithPaths());
+        var config = materializer.Materialize(raw);
+        return (config, materializer.LastResolutionFindings);
+    }
+}

--- a/tests/AgentSmith.Tests/Configuration/RepoCatalogDefaultBranchTests.cs
+++ b/tests/AgentSmith.Tests/Configuration/RepoCatalogDefaultBranchTests.cs
@@ -41,7 +41,7 @@ public sealed class RepoCatalogDefaultBranchTests
             """;
 
         var raw = Deserializer.Deserialize<Dictionary<string, RawRepoEntry>>(yaml);
-        var catalog = new RepoCatalogBuilder().Build(raw, new List<string>());
+        var catalog = new RepoCatalogBuilder().Build(raw);
 
         catalog.Should().ContainKey("sample-server");
         catalog["sample-server"].DefaultBranch.Should().Be("develop");
@@ -58,7 +58,7 @@ public sealed class RepoCatalogDefaultBranchTests
             """;
 
         var raw = Deserializer.Deserialize<Dictionary<string, RawRepoEntry>>(yaml);
-        var catalog = new RepoCatalogBuilder().Build(raw, new List<string>());
+        var catalog = new RepoCatalogBuilder().Build(raw);
 
         catalog["repo-without-override"].DefaultBranch.Should().BeNull();
     }
@@ -88,7 +88,7 @@ public sealed class RepoCatalogDefaultBranchTests
             """;
 
         var raw = Deserializer.Deserialize<Dictionary<string, RawRepoEntry>>(yaml);
-        var catalog = new RepoCatalogBuilder().Build(raw, new List<string>());
+        var catalog = new RepoCatalogBuilder().Build(raw);
 
         catalog["sample-server"].DefaultBranch.Should().Be("develop");
         catalog["sample-docs"].DefaultBranch.Should().Be("main");

--- a/tests/AgentSmith.Tests/Configuration/TrackerCatalogBuilderTests.cs
+++ b/tests/AgentSmith.Tests/Configuration/TrackerCatalogBuilderTests.cs
@@ -30,11 +30,8 @@ public sealed class TrackerCatalogBuilderTests
                 },
             }
         };
-        var errors = new List<string>();
 
-        var built = _sut.Build(raw, errors);
-
-        errors.Should().BeEmpty();
+        var built = _sut.Build(raw);
         var tracker = built.Should().ContainKey("tr1").WhoseValue;
         tracker.Polling.Enabled.Should().BeTrue();
         tracker.Polling.IntervalSeconds.Should().Be(120);
@@ -48,11 +45,8 @@ public sealed class TrackerCatalogBuilderTests
         {
             ["tr1"] = new RawTrackerEntry { Type = TrackerType.GitHub, Auth = "token", Polling = null }
         };
-        var errors = new List<string>();
 
-        var built = _sut.Build(raw, errors);
-
-        errors.Should().BeEmpty();
+        var built = _sut.Build(raw);
         built["tr1"].Polling.Enabled.Should().BeFalse();
     }
 
@@ -68,11 +62,8 @@ public sealed class TrackerCatalogBuilderTests
                 ZeroMatchComment = true,
             }
         };
-        var errors = new List<string>();
 
-        var built = _sut.Build(raw, errors);
-
-        errors.Should().BeEmpty();
+        var built = _sut.Build(raw);
         built["tr1"].ZeroMatchComment.Should().BeTrue();
     }
 }

--- a/tests/AgentSmith.Tests/Server/StartupResilienceTests.cs
+++ b/tests/AgentSmith.Tests/Server/StartupResilienceTests.cs
@@ -124,12 +124,64 @@ public sealed class StartupResilienceTests : IDisposable
         finding.Reason.Should().Contain("needs_clarification_status");
     }
 
+    // p0391b — the converted paths. Each of these used to be a throw that escaped startup:
+    // the server died on a typo and the operator got a container that never answered.
+
+    [Fact]
+    public async Task Startup_RedisUrlUnusable_ServerStartsAndReportsIt()
+    {
+        // REDIS_URL="" parses to no endpoint, so Connect() threw ArgumentException out of a
+        // lazy factory that three unguarded startup paths resolve. AbortOnConnectFail=false
+        // never covered this: the endpoint was not down, it was absent.
+        var configPath = WriteConfig(Bootstrap("sqlite", $"Data Source={NewDbPath()}"));
+
+        var findings = await BootAndReadFindingsAsync(configPath, redisUrl: "");
+
+        findings.Findings.Should().Contain(f =>
+            f.Severity == "blocking" && f.Subsystem == "redis" && f.Field == "REDIS_URL");
+    }
+
+    [Fact]
+    public async Task Startup_BootstrapConfigUnreadable_ServerStartsAndReportsIt()
+    {
+        // The bootstrap reader caught YamlException only, so a file that exists but does not
+        // deserialize into the config shape threw out of the DbContext factory — on the first
+        // scope, before anything could report it.
+        var configPath = WriteConfig("- this is a sequence, not a configuration\n");
+
+        var findings = await BootAndReadFindingsAsync(configPath);
+
+        findings.Findings.Should().Contain(f =>
+            f.Severity == "blocking" && f.Subsystem == "config-file");
+    }
+
+    [Fact]
+    public async Task Startup_UnmaterializableProject_DisablesOnlyThatProject()
+    {
+        // p0391b's headline. An unknown resolution shorthand threw out of the raw-to-typed
+        // pipeline, the loader caught it as "the stored configuration is not usable", and the
+        // server ran with an EMPTY config — one typo in one project silenced every other one.
+        // Now the broken project is the only casualty and the finding names its field.
+        var dbPath = NewDbPath();
+        var configPath = WriteConfig(
+            Bootstrap("sqlite", $"Data Source={dbPath}") + OneBrokenOneHealthyYaml);
+        Seed(dbPath, configPath);
+
+        var findings = await BootAndReadFindingsAsync(configPath);
+
+        findings.Findings.Should().Contain(f =>
+            f.Project == "broken" && f.Field == "resolution" && f.Severity == "blocking");
+        findings.Findings.Should().NotContain(f => f.Project == "healthy");
+        findings.Findings.Should().NotContain(f => f.Field == "configuration");
+    }
+
     // Every case above boots the whole server: /health answering is the claim under test,
     // and the findings body is how the server says what it is missing.
-    private async Task<StartupFindingsResponse> BootAndReadFindingsAsync(string configPath)
+    private async Task<StartupFindingsResponse> BootAndReadFindingsAsync(
+        string configPath, string redisUrl = HealthyRedisPlaceholder)
     {
         Environment.SetEnvironmentVariable("CONFIG_PATH", configPath);
-        Environment.SetEnvironmentVariable("REDIS_URL", HealthyRedisPlaceholder);
+        Environment.SetEnvironmentVariable("REDIS_URL", redisUrl);
 
         var app = await ServerHostFactory.CreateAsync([]);
         var started = false;
@@ -204,6 +256,46 @@ public sealed class StartupResilienceTests : IDisposable
             tracker: gh
             repos: [shared-repo]
             pipeline: fix-bug
+            resolution:
+              not_a_strategy: whatever
+            github_trigger:
+              trigger_statuses: [open]
+              done_status: closed
+              needs_clarification_status: question
+        """;
+
+    private const string OneBrokenOneHealthyYaml = """
+        agents:
+          claude-default:
+            type: claude
+            model: sonnet-4
+        repos:
+          shared-repo:
+            type: github
+            url: https://github.com/test/repo
+            auth: token
+        trackers:
+          gh:
+            type: github
+            organization: testorg
+            auth: token
+        projects:
+          healthy:
+            agent: claude-default
+            tracker: gh
+            repos: [shared-repo]
+            pipeline: code
+            resolution:
+              tag: healthy
+            github_trigger:
+              trigger_statuses: [open]
+              done_status: closed
+              needs_clarification_status: question
+          broken:
+            agent: claude-default
+            tracker: gh
+            repos: [shared-repo]
+            pipeline: code
             resolution:
               not_a_strategy: whatever
             github_trigger:


### PR DESCRIPTION
Two phases, in this order because the second depends on the first: p0391b turns the
remaining startup throws into findings, and p0392 is the Config Studio asking for those
findings about a configuration the operator has not saved yet.

## Why

Both come out of the same night. On 2026-07-31 one trigger of one project was missing
`needs_clarification_status`, the server refused to boot, and the recovery was a rollback
to an older image, a CLI export, a hand edit, an import and a roll-forward. The
configuration lives in the DB and is edited through the running server, so the failure was
self-sealing: the tool needed for the fix was the thing that would not start.

p0391a ruled on the general case — **aborting startup is never justifiable, because a dead
process reports nothing and an operator who cannot be told what is broken is as incapable
as the service** — and converted the paths it found. p0393 then found another one inside a
path p0391a had already written a probe for. That is the actual lesson: a ruling is not a
mechanism.

## p0391b — no startup path throws

The mechanism is `StartupThrowInventoryTests`. It scans the composition, hosting and
configuration directories and fails on any throw that is not accounted for — converted, or
listed with the reason it stays fatal and what an operator can do about it. A second test
fails when an accounted throw disappears, because an allowlist that outlives its throw
reads to the next author as permission for a throw nobody reviewed.

Converted:

- **`ConfigCatalogResolver`** — the biggest one. It aggregated every configuration error
  into a single throw; the server's loader caught that and recorded ONE finding with
  `Field: "configuration"`, so the endpoint that exists to say what is wrong answered with a
  wall of text. Each error is now its own finding carrying its project and its field, and an
  unresolvable project drops out on its own instead of taking every other project's poller
  and webhook down with it.
- **`RedisExtensions` / `SandboxBackendRegistrations`** — a `REDIS_URL` or `DOCKER_HOST`
  that does not PARSE was never covered by `AbortOnConnectFail`: the endpoint was not down,
  it was absent. Both fall back to their default with a blocking finding naming the variable.
- **`SubsystemTask` / `ActiveRunReaperHostedService`** — the `GetRequiredService` prologue
  runs before the first suspending await, which `BackgroundServiceExceptionBehavior.Ignore`
  does not cover, so the fault escaped host start. Four leader loops shared that prologue.
- **`BootstrapConfigReader`** — caught `YamlException` only, so a file that exists but
  cannot be READ (wrong owner on a mounted ConfigMap, a path that is a directory) threw out
  of the DbContext factory on the first scope.
- **`OrphanJobDetector`** — a duplicate-platform `ToDictionary` in a field initializer,
  which runs during host construction where nothing catches.

Kept fatal, deliberately: `YamlConfigurationLoader`. The ruling is about a SERVER. A
one-shot CLI invocation is the opposite case — the operator is standing there, the process
exists to run one command against one file they just named, and the exit code IS the
report. The server never takes that path.

`agentsmith config validate` prints the findings the server would record, from the server's
own rules. No second validator: that would be a second source of truth about what a valid
configuration is, which is the defect class this codebase keeps paying for.

## p0392 — the Studio shows what is missing

Step one was to re-measure, and the spec's list was wrong in both directions. The tracker
section reads sixteen backend fields; the descriptor declared four — the four the UI
happened to render. Seven were undeclared and unofferable, including the one the outage was
about. Connections were missing `host` (self-hosted GitLab / GHE), projects
`default_pipeline`. All are declared and round-trip now, and `CapabilityCoverageTests` walks
the raw read models against the descriptor **with no allowlist**, so a field added to either
fails the build until it is declared.

`CapabilityField` now carries its value SHAPE. That used to be client knowledge — a
hardcoded "these keys are lists" set in the dashboard — which is precisely why a bool or a
map field could not be declared: doing so would have needed a UI change too.

Missing-required is reported before the save, by the server's own rules.
`needs_clarification_status` is not statically required — `ClarificationParkStatusRule`
demands it only where a park can actually happen — so declaring it "required" would have
been wrong, and evaluating that condition in TypeScript would have been a second statement
of what a valid configuration is. `POST /api/config/{projects,trackers}/validate` runs the
real rule objects over the projected raw shapes; the Studio renders the answer on the
section and on the field, and gates Save. It holds no rules of its own.

p0393's distinction is preserved: the picker offers `PipelinePresets.Names`, a stored
retired alias still loads, and it is labelled retired rather than presented as an equal
choice.

## What this does NOT close

Named rather than left as an implicit backlog (**p0392a**): the same class of gap in repos
(type/organization/project/auth — a repo cannot be given a secret from the Studio), project
blocks (polling, sandbox, orchestrator, the per-platform trigger wrappers), agent knobs
(rate_limit and eight loop settings), `pipeline_triggers` (no CRUD endpoint and no UI at
all), and the twelve settings singletons — where a TS shape that omits a backend field
sends its DEFAULT back on save, a silent overwrite and the most severe of the five.

Also recorded: tracker `endpoints:` is not an unofferable field but a **dead** one.
`RawTrackerEntry` has no such property, so the block is silently discarded and the Jira
defaults always win. Declaring it would have made the Studio offer a control that does
nothing.

## Verification

- Backend: **3688 green** (3662 measured at the branch point, +26)
- Dashboard: **552 green** (121 files)
- Decisions in `.agentsmith/decisions/p0391b.yaml` and `p0392.yaml`, including the two
  places the code contradicted the spec.

Phase files and `context.yaml` are deliberately untouched — the main session does that
bookkeeping when this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
