### PR TITLE
feat: done stays done, and the durable-dialogue spine gets its proof back (p0374a + p0393b)

### DIFF
--- a/.agentsmith/decisions/p0374a.yaml
+++ b/.agentsmith/decisions/p0374a.yaml
@@ -1,0 +1,87 @@
+# yaml-language-server: $schema=../decision.schema.json
+phase: p0374a
+
+decisions:
+  - category: Implementation
+    chose: "Re-wire the existing LedgerMergePolicy rather than rebuild it"
+    reason: |
+      The spec says p0374 "removed" the merge. It did not: LedgerMergePolicy and its
+      seven unit tests have been in the tree, compiling and green, since p0368 —
+      p0374 deleted only the CALL in ProgressLedgerToolHost.UpdateProgress, leaving
+      the class orphaned, the host's doc-comment still describing the merge, and the
+      update_progress tool description still promising the model that "a step already
+      marked done STAYS done even if you omit it or send it back as pending". So the
+      contract shown to the LLM has been lying about the implemented behaviour since
+      p0374, which is a sharper version of the same complaint this phase makes about
+      the ledger. Restoring the call restores the described behaviour; nothing had to
+      be re-derived.
+
+  - category: Scope
+    chose: "The ledger's AUTHORITY is untouched; only its HONESTY is restored"
+    reason: |
+      p0393 settled authority: no vote on a green verdict, a qualifying vote on red
+      where it separates "gave up early" from "genuinely stuck" (p0363). Nothing here
+      changes ShouldReengage, the keystone, or any read of the ledger. The merge acts
+      only on what an incoming update_progress call may do to what the ledger already
+      recorded. Worth stating because the two are easy to conflate and the last
+      attempt in this area silently reverted p0363.
+
+  - category: Architecture
+    chose: "Transitions ride the run TRAIL as their own event, projected only as a raw row"
+    over: "A typed side-table projection, or extending the run row's ledger snapshot"
+    reason: |
+      The run row's ProgressLedgerJson is a SNAPSHOT that every mid-run flush
+      overwrites, so it structurally cannot hold history — that is why p0374's
+      promised traceability snapshot was never a snapshot's job in the first place.
+      The trail already is the surface a watcher reads, it is append-only, and
+      RunEventApplier's default branch persists any unhandled event as a raw
+      RunEvents row — so LedgerTransitionsRecorded needs no migration, no applier
+      case and no new endpoint, and arrives on GET /api/runs/{id}/trail beside the
+      ledger it explains. A typed side-table (the RunDecision precedent) stays
+      available if transitions ever need their own filtered query; building it now
+      would be a schema change bought before anyone asked a question that needs it.
+
+  - category: Implementation
+    chose: "A refused rewrite is stated back to the MODEL in the tool's own reply"
+    over: "The p0368 shape, where the refusal was a server-side log line only"
+    reason: |
+      This is the phase's "no-silent-rewrite" step and it is the part p0368 lacked.
+      From the model's seat a silent keep is indistinguishable from a silent rewrite:
+      it reads the returned checklist as its own and drifts. The reply now names how
+      many completed steps were re-attached or kept done, and says the one way to
+      reopen deliberately — which also makes the guard self-teaching for a pin whose
+      master text is older than this change. The warning logs stay for the operator.
+
+  - category: Implementation
+    chose: "The master pass is read through a Func<int> the handler owns"
+    over: "Letting the tool host count its own calls as the pass number"
+    reason: |
+      "Pass" means the master's re-engagement pass — the loop lives in
+      AgenticMasterHandler.ReengageWhileProductiveAsync and nowhere else. A host-side
+      call counter would have been a different number wearing the same name, and the
+      one question a transition record has to answer is "which pass did this happen
+      in", not "how many times was the tool called". Pass 0 is the first loop and the
+      p0255/p0263 nudges; re-engagement passes are 1-based.
+
+  - category: TradeOff
+    chose: "A dropped PENDING entry is recorded as a transition too"
+    reason: |
+      It is not a refusal — unfinished work stays the model's to restructure, which
+      is p0359's rule and stays true. But a step that disappears with no record is
+      exactly the unexplained gap this phase exists to close, so the drop is written
+      down and allowed. Symmetrically, re-sending an unchanged checklist records
+      NOTHING and publishes no event: a record of what happened, not of what was
+      re-stated, and a trail flooded with no-ops is a trail nobody reads.
+
+  - category: Tooling
+    chose: "coding-agent-master splits the ledger rule in two and bumps to 1.21.0"
+    reason: |
+      The skill had one bullet saying the checklist is the model's to "add, reword,
+      reorder, or remove" — true of pending work, false of completed work under this
+      phase — and a migration-playbook line instructing the exact move the guard now
+      refuses ("flip the affected batch entries back from done to pending"). Both are
+      corrected: pending work is yours, completed work is a record, and `reopen` is
+      named as the one way back. The per-master version bump is what CI enforces, and
+      the embedded catalog pin will need to move past the release that carries it
+      before a deployed run sees the new wording — until then the tool's own reply is
+      what teaches the model, which is why that reply names the token.

--- a/.agentsmith/decisions/p0393b.yaml
+++ b/.agentsmith/decisions/p0393b.yaml
@@ -1,0 +1,66 @@
+# yaml-language-server: $schema=../decision.schema.json
+phase: p0393b
+
+decisions:
+  - category: Scope
+    chose: "The subject is a ticket-triggered run, not spec-dialog — the spec's premise is wrong and is recorded rather than worked around"
+    over: "Rebuilding the scenario against spec-dialog as the spec instructs"
+    reason: |
+      The spec asserts spec-dialog "still checkpoints". It does not, and it cannot.
+      DialogueAskGate.IsCheckpointEligible requires ContextKeys.TicketId and its own
+      comment names spec-dialog as a full-hot-wait surface; DialogueCheckpointWriter
+      refuses to write without a ticket; RunCheckpointedEvent carries the ticket id;
+      RunResumer relaunches through the capacity queue keyed on (project, ticket).
+      Underneath that is a design reason, not an oversight: a spec-dialog turn runs
+      IN PROCESS from a live chat thread, SpecDialogTurnRunner owns its sandboxes and
+      a SpecDialogReplySlot the checkpoint serializer explicitly excludes, and a
+      resume launched into the Redis job queue could neither rebuild the slot nor
+      reach the thread. Its operator is present by construction — the hot wait is the
+      right shape there, and the durable answer already survives as the session
+      transcript, which the next turn reads. Making spec-dialog park durably would
+      have been a new feature built on a false premise, in a phase whose steps are
+      test-only.
+
+  - category: Architecture
+    chose: "The harness supplies the park point by binding the production AskContextBuilder to the preset's LoadContext slot"
+    over: "Adding an ask step to a shipped preset so the harness has one to park on"
+    reason: |
+      The larger finding is that the durable-dialogue spine has NO production carrier
+      today: AskCommandHandler, ApprovalHandler and NegotiateExpectationHandler are
+      the only callers of IDialogueAskGate, and p0393 deleted Approval from the code
+      preset while p0393a removed NegotiateExpectation — Ask was never in one. So the
+      checkpoint/resume machinery, the durable inbox and DialogueResumeSweeper are
+      live, registered, unit-tested and unreachable from every preset agent-smith
+      ships. Restoring reachability is a behaviour change with deployment
+      consequences (it would park real runs for days on a master question) and it
+      collides with p0391, which deliberately chose the TICKET park for the code
+      presets; it is not this phase's call. The harness therefore supplies the asking
+      STEP the way it already supplies the LLM script — one keyed-builder swap — and
+      every other part of the path stays the production registration: ask gate,
+      checkpoint writer, checkpoint store, durable transport + inbox, sweeper,
+      resumer, capacity queue, pump, ResumeRunLauncher, and the executor's
+      resume-at-cursor. What was unproven end to end is now proven end to end; what
+      is dormant is named here instead of being made to look alive.
+
+  - category: Implementation
+    chose: "mad-discussion as the carrying preset, parking at LoadContext"
+    over: "The `code` preset the deleted test used"
+    reason: |
+      The three-act scenario needs a ticket run whose ask sits AFTER CheckoutSource
+      (so the checkpoint's re-provisioning prefix is exercised rather than trivially
+      empty) and whose resumed tail can complete without scripting a full derivation
+      +master+verify+PR sequence. mad-discussion is a ticket-triggered discussion
+      preset with exactly that shape: act 1 needs no LLM call at all, and the resumed
+      tail needs one. Running `code` would have made the test's centre of gravity the
+      p0393a phase sequence rather than the checkpoint spine it exists to prove.
+
+  - category: Tooling
+    chose: "Three tests, renamed off the SpecDialog_ prefix the spec proposed"
+    reason: |
+      Keeping the spec's names would have made the file assert something the code
+      cannot do and would have read, to the next agent, as proof that spec-dialog
+      parks durably. The scenarios are the ones the spec asked for — the three-act
+      restart, the inbox surviving the restart, and the sweeper resuming exactly once
+      — under names that say what the subject actually is. The third scenario also
+      gained a second scan: a consumed checkpoint must never enqueue a second resume,
+      which is the property the sweeper's ResumedAt marking exists for.

--- a/src/backend/AgentSmith.Application/Services/Handlers/AgenticMasterHandler.cs
+++ b/src/backend/AgentSmith.Application/Services/Handlers/AgenticMasterHandler.cs
@@ -135,16 +135,27 @@ public sealed class AgenticMasterHandler(
         // leaves both its checklist AND its edits behind. Coding masters only —
         // scan/spec-dialog surfaces have no update_progress tool.
         var checkpointInterval = context.AgentConfig.CheckpointPushMinIntervalSeconds;
-        Func<Contracts.Progress.ProgressLedger, Task>? onReplaced =
+        // p0374a: the master pass a ledger update arrived in. Pass 0 is the first
+        // loop; ReengageWhileProductiveAsync advances it per re-engagement pass.
+        // The counter lives here because the loop does; the tool host only reads it.
+        var masterPass = 0;
+        Func<Contracts.Progress.ProgressLedger, IReadOnlyList<Contracts.Progress.LedgerTransition>, Task>? onReplaced =
             flusher is null && checkpointInterval <= 0
                 ? null
-                : async ledger =>
+                : async (ledger, transitions) =>
                 {
-                    if (flusher is not null) await flusher.FlushAsync(ledger);
+                    if (flusher is not null)
+                    {
+                        await flusher.FlushAsync(ledger);
+                        // p0374a: what CHANGED goes on the trail — the snapshot above is
+                        // overwritten by the next flush and cannot hold the history.
+                        await flusher.RecordTransitionsAsync(transitions);
+                    }
                     await checkpointer.CheckpointAsync(
                         context.Pipeline, checkpointInterval, cancellationToken);
                 };
-        var progress = new ProgressLedgerToolHost(seedEntries, onReplaced, logger);
+        var progress = new ProgressLedgerToolHost(
+            seedEntries, onReplaced, logger, currentPass: () => masterPass);
         context.Pipeline.Set(ContextKeys.ProgressLedger, progress.GetLedger());
         if (!progress.GetLedger().IsEmpty && flusher is not null)
             await flusher.FlushAsync(progress.GetLedger());
@@ -492,7 +503,7 @@ public sealed class AgenticMasterHandler(
         (loopResult, changes, verification) = await ReengageWhileProductiveAsync(
             context, request, userPrompt, pipelineName, progress, fs, log,
             costTracker, TrackMasterResponse, ticketClarifications, loopResult, changes, verification,
-            cancellationToken);
+            setPass: p => masterPass = p, cancellationToken);
         if (ticketClarifications?.Captured is { } reengageQuestion)
         {
             context.Pipeline.Set(ContextKeys.CodeChanges, changes);
@@ -755,11 +766,15 @@ public sealed class AgenticMasterHandler(
             Action<ChatResponse> trackMasterResponse,
             TicketClarificationToolHost? ticketClarifications,
             AgenticLoopResult loopResult, IReadOnlyList<CodeChange> changes,
-            MasterVerification? verification, CancellationToken cancellationToken)
+            MasterVerification? verification, Action<int> setPass,
+            CancellationToken cancellationToken)
     {
         var ratifiedCriteria = RatifiedCriteria(context.Pipeline);
         for (var pass = 0; pass < ReengageHardSafetyCap; pass++)
         {
+            // p0374a: pass 0 is the first loop, so a re-engagement pass is 1-based —
+            // every ledger transition recorded from here carries the pass it happened in.
+            setPass(pass + 1);
             if (!ShouldReengage(
                     pipelineName, progress.GetLedger(), verification,
                     costTracker.IsBudgetExhausted, ratifiedCriteria, changes))

--- a/src/backend/AgentSmith.Application/Services/RunStorySnapshotBuilder.cs
+++ b/src/backend/AgentSmith.Application/Services/RunStorySnapshotBuilder.cs
@@ -28,6 +28,34 @@ public static class RunStorySnapshotBuilder
     }
 
     /// <summary>
+    /// p0374a: the transitions of ONE accepted update_progress call, as the wire
+    /// JSON the trail carries. Nothing changed → null, and no event is published:
+    /// re-sending an unchanged checklist is not history.
+    /// </summary>
+    public static string? BuildTransitionsJson(IReadOnlyList<LedgerTransition>? transitions)
+    {
+        if (transitions is null || transitions.Count == 0) return null;
+        var items = transitions
+            .Select(t => new LedgerTransitionView(
+                t.EntryId, t.Activity, StatusOrNull(t.From), StatusOrNull(t.To), CauseOf(t.Cause), t.Pass))
+            .ToList();
+        return RunStoryJson.Serialize(items);
+    }
+
+    private static string? StatusOrNull(ProgressStatus? status) =>
+        status is null ? null : StatusOf(status.Value);
+
+    private static string CauseOf(LedgerTransitionCause cause) => cause switch
+    {
+        LedgerTransitionCause.Added => LedgerTransitionCauses.Added,
+        LedgerTransitionCause.ExplicitReopen => LedgerTransitionCauses.ExplicitReopen,
+        LedgerTransitionCause.RegressionRefused => LedgerTransitionCauses.RegressionRefused,
+        LedgerTransitionCause.OmissionRefused => LedgerTransitionCauses.OmissionRefused,
+        LedgerTransitionCause.Dropped => LedgerTransitionCauses.Dropped,
+        _ => LedgerTransitionCauses.ModelUpdate,
+    };
+
+    /// <summary>
     /// Pairs the ratified criteria with the master's ordered dispositions the
     /// same way <see cref="RunOutcomeKeystone"/> does. A criterion the master
     /// reported nothing for is "unproven" — visible, never silently dropped.

--- a/src/backend/AgentSmith.Application/Services/Tools/ProgressLedgerFlusher.cs
+++ b/src/backend/AgentSmith.Application/Services/Tools/ProgressLedgerFlusher.cs
@@ -32,4 +32,25 @@ public sealed class ProgressLedgerFlusher(IEventPublisher events, string runId, 
                 "Mid-run ledger flush failed for {RunId} — the next flush / run-end snapshot repairs it", runId);
         }
     }
+
+    /// <summary>
+    /// p0374a: publishes what CHANGED in this update onto the trail. The snapshot
+    /// above is overwritten by the next flush, so it is the only place the run's
+    /// ledger history can live. Same swallow-and-continue contract as the flush.
+    /// </summary>
+    public async Task RecordTransitionsAsync(IReadOnlyList<LedgerTransition> transitions)
+    {
+        var json = RunStorySnapshotBuilder.BuildTransitionsJson(transitions);
+        if (json is null) return;
+        try
+        {
+            await events.PublishAsync(
+                new LedgerTransitionsRecordedEvent(runId, json, DateTimeOffset.UtcNow));
+        }
+        catch (Exception ex)
+        {
+            logger.LogDebug(ex,
+                "Ledger transition record failed for {RunId} — the ledger snapshot still flushes", runId);
+        }
+    }
 }

--- a/src/backend/AgentSmith.Application/Services/Tools/ProgressLedgerToolHost.cs
+++ b/src/backend/AgentSmith.Application/Services/Tools/ProgressLedgerToolHost.cs
@@ -22,6 +22,15 @@ namespace AgentSmith.Application.Services.Tools;
 /// the keystone cross-checks whatever the FINAL list claims against the diff.
 /// The handler seeds it from the ratified plan and reads <see cref="GetLedger"/>
 /// back into PipelineContext (the source of truth), mirroring LogDecisionToolHost.
+/// <para>
+/// p0374a restores the merge p0374 unwired and pays the price p0374 promised and
+/// never shipped: every accepted update emits its <see cref="LedgerTransition"/>s
+/// (entry, from-state, to-state, cause, master pass) and a refused rewrite is
+/// NAMED in the tool's own reply instead of being silently kept. p0374's
+/// rationale — the model must be able to correct its own record — is exactly what
+/// the reopen token already covers, so the guard costs the model nothing it is
+/// entitled to.
+/// </para>
 /// </summary>
 public sealed class ProgressLedgerToolHost : IToolHost
 {
@@ -29,20 +38,31 @@ public sealed class ProgressLedgerToolHost : IToolHost
     // p0356: awaited after every ACCEPTED replace — the mid-run durability
     // hook (ProgressLedgerFlusher publishes the ledger onto the event stream).
     // Awaited, not fire-and-forget, so a flush never outlives the tool call.
-    private readonly Func<ProgressLedger, Task>? _onReplaced;
+    // p0374a: it also carries what CHANGED, which the overwritten snapshot cannot.
+    private readonly Func<ProgressLedger, IReadOnlyList<LedgerTransition>, Task>? _onReplaced;
+    // p0374a: the master's current re-engagement pass, read at update time — the
+    // handler owns the loop counter, the host only stamps it onto the record.
+    private readonly Func<int>? _currentPass;
+    private readonly List<LedgerTransition> _transitions = [];
     private readonly ILogger _logger;
 
     public ProgressLedgerToolHost(
         IEnumerable<ProgressLedgerEntry>? seed = null,
-        Func<ProgressLedger, Task>? onReplaced = null,
-        ILogger? logger = null)
+        Func<ProgressLedger, IReadOnlyList<LedgerTransition>, Task>? onReplaced = null,
+        ILogger? logger = null,
+        Func<int>? currentPass = null)
     {
         _entries = seed?.ToList() ?? new List<ProgressLedgerEntry>();
         _onReplaced = onReplaced;
         _logger = logger ?? NullLogger.Instance;
+        _currentPass = currentPass;
     }
 
     public ProgressLedger GetLedger() => new(_entries.AsReadOnly());
+
+    /// <summary>p0374a: every transition this host recorded, in order — the run's
+    /// ledger history as opposed to its current state.</summary>
+    public IReadOnlyList<LedgerTransition> GetTransitions() => _transitions.AsReadOnly();
 
     public IEnumerable<AIFunction> GetTools(SkillExecutionPhase? phase, string? investigatorMode)
     {
@@ -87,19 +107,45 @@ public sealed class ProgressLedgerToolHost : IToolHost
         if (mapped.Count(e => e.Status == ProgressStatus.InProgress) > 1)
             return "Error: at most one item may be in_progress at a time.";
 
-        // p0374 (test): the progress ledger is the master's OWN working plan — fully
-        // model-owned. It may reword, drop, reorder AND uncheck (done→pending) freely.
-        // p0368 forced yesterday's done-state back onto the plan, which fought the
-        // master's legitimate self-correction (it marks a step done, realises it isn't,
-        // and cannot reopen it to do the work). "The LLM doesn't care about its own
-        // chatter from yesterday": the plan is hers; traceability is OUR concern and
-        // belongs in a separate history snapshot, not as a constraint on the plan.
-        // The empty-pass re-engage gate (p0365) still bounds the loop, and the keystone
-        // still fails a done-claim with no real diff — so an open ledger stays honest.
-        _ = reopened; // status still validated above; no forced merge
-        _entries = mapped;
-        if (_onReplaced is not null) await _onReplaced(GetLedger());
-        return ProgressLedgerRenderer.Render(GetLedger());
+        // p0368/p0374a: MERGE, don't replace — a DONE step survives a rewrite that drops
+        // or regresses it, unless the model sends the explicit reopen token. Pending work
+        // follows the incoming list, so the model's own plan stays its own.
+        var merge = LedgerMergePolicy.Merge(
+            GetLedger(), new ProgressLedger(mapped), reopened, _currentPass?.Invoke() ?? 0);
+        WarnOnRescuedWork(merge);
+        _entries = merge.Merged.Entries.ToList();
+        _transitions.AddRange(merge.Transitions);
+        if (_onReplaced is not null) await _onReplaced(GetLedger(), merge.Transitions);
+        // p0374a: a refusal the model cannot see is a silent rewrite from where it
+        // stands — it would read the returned checklist as its own and drift. The
+        // reply names what was refused and how to reopen deliberately.
+        return ProgressLedgerRenderer.Render(GetLedger()) + RefusalNotice(merge);
+    }
+
+    // p0374a: the refusal, stated to the model in the tool's own reply.
+    private static string RefusalNotice(LedgerMergeResult merge)
+    {
+        if (!merge.RefusedAnything) return string.Empty;
+        var parts = new List<string>(2);
+        if (merge.ReattachedDone > 0)
+            parts.Add($"{merge.ReattachedDone} completed step(s) you omitted were re-attached");
+        if (merge.RejectedRegressions > 0)
+            parts.Add($"{merge.RejectedRegressions} completed step(s) you sent back to pending were kept done");
+        return "\n\nNote: " + string.Join("; ", parts)
+            + ". Completed work only leaves done via the explicit 'reopen' status — "
+            + "use it when a finished step genuinely has to be redone.";
+    }
+
+    private void WarnOnRescuedWork(LedgerMergeResult merge)
+    {
+        if (merge.ReattachedDone > 0)
+            _logger.LogWarning(
+                "update_progress tried to DISCARD {Count} completed step(s) by omission — "
+                + "re-attached (a done step stays done).", merge.ReattachedDone);
+        if (merge.RejectedRegressions > 0)
+            _logger.LogWarning(
+                "update_progress tried to REVERT {Count} completed step(s) to pending without a "
+                + "'reopen' signal — kept done.", merge.RejectedRegressions);
     }
 
     private static bool TryMapStatus(string? raw, out ProgressStatus status, out bool isReopen)

--- a/src/backend/AgentSmith.Contracts/Events/EventType.cs
+++ b/src/backend/AgentSmith.Contracts/Events/EventType.cs
@@ -78,4 +78,10 @@ public enum EventType
     // published by ScopeRepos at step ~4 — persisted onto the run row so the
     // dashboard can render spent/cap from early in the run.
     RunBudgetResolved = 75,
+    // p0374a: the per-entry transitions of one accepted update_progress call —
+    // entry, from-state, to-state, cause, master pass. The ledger snapshot on the
+    // run row is overwritten by every flush, so the SNAPSHOT cannot carry history;
+    // the trail can, and a record of what happened staying a record is the one job
+    // p0393 left the ledger.
+    LedgerTransitionsRecorded = 76,
 }

--- a/src/backend/AgentSmith.Contracts/Events/LedgerTransitionsRecordedEvent.cs
+++ b/src/backend/AgentSmith.Contracts/Events/LedgerTransitionsRecordedEvent.cs
@@ -1,0 +1,18 @@
+namespace AgentSmith.Contracts.Events;
+
+/// <summary>
+/// p0374a: the per-entry transitions of ONE accepted update_progress call —
+/// entry, from-state, to-state, cause, master pass. Trail-only: the applier
+/// persists the raw event row and touches no projection, because the run row's
+/// ledger column is a SNAPSHOT that every flush overwrites and therefore cannot
+/// hold history. The trail can, and it is the surface a watcher already reads.
+/// Travels the event stream for the same reason the story snapshot does — a
+/// spawned orchestrator has no other DB channel (p0330).
+/// <para><see cref="TransitionsJson"/> is the camelCase wire JSON
+/// (<c>RunStoryJson</c>) of an array of <c>LedgerTransitionView</c>.</para>
+/// </summary>
+public sealed record LedgerTransitionsRecordedEvent(
+    string RunId,
+    string TransitionsJson,
+    DateTimeOffset Timestamp)
+    : RunEvent(RunId, EventType.LedgerTransitionsRecorded, Timestamp);

--- a/src/backend/AgentSmith.Contracts/Progress/LedgerMergePolicy.cs
+++ b/src/backend/AgentSmith.Contracts/Progress/LedgerMergePolicy.cs
@@ -26,35 +26,97 @@ public static class LedgerMergePolicy
     /// <param name="explicitReopens">Ids the model deliberately reopened this call
     /// (an explicit, logged signal) — the only way a retained DONE step is allowed
     /// to regress to pending.</param>
+    /// <param name="pass">p0374a: the master pass this update arrived in; stamped
+    /// onto every emitted <see cref="LedgerTransition"/>.</param>
     public static LedgerMergeResult Merge(
-        ProgressLedger retained, ProgressLedger incoming, IReadOnlySet<string> explicitReopens)
+        ProgressLedger retained, ProgressLedger incoming, IReadOnlySet<string> explicitReopens,
+        int pass = 0)
     {
         var retainedDone = retained.Entries.Where(e => e.Status == ProgressStatus.Done).ToList();
         var byId = BuildIndex(retainedDone, e => e.Id);
         var byFallback = BuildIndex(retainedDone.Where(HasFallback), FallbackKey);
         var consumed = new HashSet<string>(StringComparer.Ordinal);
+        // p0374a: the whole retained ledger by id, so a non-done entry's own move
+        // (pending -> in_progress -> done) and its removal are traceable too.
+        var retainedById = BuildIndex(retained.Entries, e => e.Id);
+        var survivingIds = new HashSet<string>(StringComparer.Ordinal);
 
         var merged = new List<ProgressLedgerEntry>(incoming.Entries.Count + retainedDone.Count);
+        var transitions = new List<LedgerTransition>();
         int reattached = 0, rejected = 0, reverted = 0;
 
         foreach (var inc in incoming.Entries)
         {
+            survivingIds.Add(inc.Id);
             var match = FindRetainedDone(inc, byId, byFallback, consumed);
-            if (match is null) { merged.Add(inc); continue; }
+            if (match is null)
+            {
+                merged.Add(inc);
+                transitions.AddRange(PlainMove(retainedById, inc, pass));
+                continue;
+            }
 
             consumed.Add(match.Id);
-            if (inc.Status == ProgressStatus.Done) merged.Add(inc);
-            else if (explicitReopens.Contains(inc.Id)) { merged.Add(inc); reverted++; }
-            else { merged.Add(inc with { Status = ProgressStatus.Done }); rejected++; }
+            survivingIds.Add(match.Id);
+            if (inc.Status == ProgressStatus.Done)
+            {
+                merged.Add(inc);
+            }
+            else if (explicitReopens.Contains(inc.Id))
+            {
+                merged.Add(inc);
+                reverted++;
+                transitions.Add(new LedgerTransition(
+                    inc.Id, inc.Activity, ProgressStatus.Done, inc.Status,
+                    LedgerTransitionCause.ExplicitReopen, pass));
+            }
+            else
+            {
+                merged.Add(inc with { Status = ProgressStatus.Done });
+                rejected++;
+                transitions.Add(new LedgerTransition(
+                    inc.Id, inc.Activity, ProgressStatus.Done, ProgressStatus.Done,
+                    LedgerTransitionCause.RegressionRefused, pass));
+            }
         }
 
         foreach (var done in retainedDone.Where(d => !consumed.Contains(d.Id)))
         {
             merged.Add(done);
+            survivingIds.Add(done.Id);
             reattached++;
+            transitions.Add(new LedgerTransition(
+                done.Id, done.Activity, ProgressStatus.Done, ProgressStatus.Done,
+                LedgerTransitionCause.OmissionRefused, pass));
         }
 
-        return new LedgerMergeResult(new ProgressLedger(merged), reattached, rejected, reverted);
+        // A pending entry the rewrite dropped is legitimately gone — recorded so the
+        // trail shows the plan shrinking rather than the step vanishing unexplained.
+        foreach (var gone in retained.Entries.Where(e => !survivingIds.Contains(e.Id)))
+            transitions.Add(new LedgerTransition(
+                gone.Id, gone.Activity, gone.Status, null, LedgerTransitionCause.Dropped, pass));
+
+        return new LedgerMergeResult(
+            new ProgressLedger(merged), reattached, rejected, reverted, transitions);
+    }
+
+    // An incoming entry that matched no retained DONE: either brand new, or the
+    // model's own move on work it still owns. An unchanged entry emits nothing —
+    // the record is of CHANGE, and re-sending the full list is not a change.
+    private static IEnumerable<LedgerTransition> PlainMove(
+        IReadOnlyDictionary<string, ProgressLedgerEntry> retainedById,
+        ProgressLedgerEntry inc, int pass)
+    {
+        if (!retainedById.TryGetValue(inc.Id, out var before))
+        {
+            yield return new LedgerTransition(
+                inc.Id, inc.Activity, null, inc.Status, LedgerTransitionCause.Added, pass);
+            yield break;
+        }
+        if (before.Status != inc.Status)
+            yield return new LedgerTransition(
+                inc.Id, inc.Activity, before.Status, inc.Status,
+                LedgerTransitionCause.ModelUpdate, pass);
     }
 
     private static ProgressLedgerEntry? FindRetainedDone(
@@ -91,6 +153,14 @@ public static class LedgerMergePolicy
 
 /// <summary>p0368: outcome of a ledger merge — the preserved ledger plus the
 /// visibility counters the tool host logs (a rewrite that tried to discard or
-/// revert completed work is surfaced to the operator).</summary>
+/// revert completed work is surfaced to the operator).
+/// <para>p0374a: and the per-entry transitions, so the counters are no longer the
+/// only trace of what the rewrite tried to do.</para></summary>
 public sealed record LedgerMergeResult(
-    ProgressLedger Merged, int ReattachedDone, int RejectedRegressions, int ExplicitReverts);
+    ProgressLedger Merged, int ReattachedDone, int RejectedRegressions, int ExplicitReverts,
+    IReadOnlyList<LedgerTransition> Transitions)
+{
+    /// <summary>True when the incoming rewrite tried to take completed work back
+    /// without the reopen token — by omission or by a plain status regression.</summary>
+    public bool RefusedAnything => ReattachedDone > 0 || RejectedRegressions > 0;
+}

--- a/src/backend/AgentSmith.Contracts/Progress/LedgerTransition.cs
+++ b/src/backend/AgentSmith.Contracts/Progress/LedgerTransition.cs
@@ -1,0 +1,46 @@
+namespace AgentSmith.Contracts.Progress;
+
+/// <summary>
+/// p0374a: one recorded change to a ledger entry — what moved, from which state
+/// to which, why, and in which master pass. This is the traceability p0374
+/// promised when it dropped the merge and never shipped: the ledger's remaining
+/// job (p0393) is to tell a watcher what the machine did and when, and a
+/// checklist that silently rewrites its own history cannot do it.
+/// <para>
+/// <see cref="From"/> is null when the entry is new to the ledger;
+/// <see cref="To"/> is null when the entry left it. A REFUSED rewrite records
+/// From == To == <see cref="ProgressStatus.Done"/> — the attempt happened, the
+/// state did not change, and the cause says which attempt it was.
+/// </para>
+/// </summary>
+public sealed record LedgerTransition(
+    string EntryId,
+    string Activity,
+    ProgressStatus? From,
+    ProgressStatus? To,
+    LedgerTransitionCause Cause,
+    int Pass);
+
+/// <summary>p0374a: why a ledger entry moved — the cause every transition carries.</summary>
+public enum LedgerTransitionCause
+{
+    /// <summary>The incoming checklist carries an entry the ledger did not.</summary>
+    Added,
+
+    /// <summary>The model moved the entry and the move stands (pending work is its own).</summary>
+    ModelUpdate,
+
+    /// <summary>A done entry left done because the model sent the explicit reopen token.</summary>
+    ExplicitReopen,
+
+    /// <summary>A rewrite sent a done entry back to pending WITHOUT the reopen token.
+    /// Refused: the entry stays done.</summary>
+    RegressionRefused,
+
+    /// <summary>A rewrite dropped a done entry. Refused: the entry is re-attached.</summary>
+    OmissionRefused,
+
+    /// <summary>A rewrite dropped a pending entry. Allowed: unfinished work is the
+    /// model's to restructure.</summary>
+    Dropped,
+}

--- a/src/backend/AgentSmith.Contracts/Runs/RunStoryContracts.cs
+++ b/src/backend/AgentSmith.Contracts/Runs/RunStoryContracts.cs
@@ -43,6 +43,33 @@ public sealed record ProgressLedgerItemView(
     string? Note = null);
 
 /// <summary>
+/// p0374a: one ledger TRANSITION as it rides the run trail — the record the
+/// overwritten ledger snapshot cannot keep. <see cref="From"/> is null when the
+/// entry was added, <see cref="To"/> null when it was dropped; a refused rewrite
+/// carries From == To == "done" and a cause naming the refusal. Status vocabulary
+/// matches <see cref="ProgressLedgerItemView"/>: "pending" | "in_progress" | "done".
+/// Cause vocabulary: see <see cref="LedgerTransitionCauses"/>.
+/// </summary>
+public sealed record LedgerTransitionView(
+    string EntryId,
+    string Activity,
+    string? From,
+    string? To,
+    string Cause,
+    int Pass);
+
+/// <summary>p0374a: the wire vocabulary of <see cref="LedgerTransitionView.Cause"/>.</summary>
+public static class LedgerTransitionCauses
+{
+    public const string Added = "added";
+    public const string ModelUpdate = "model_update";
+    public const string ExplicitReopen = "explicit_reopen";
+    public const string RegressionRefused = "regression_refused";
+    public const string OmissionRefused = "omission_refused";
+    public const string Dropped = "dropped";
+}
+
+/// <summary>
 /// p0344b: the run's acceptance contract as served on the run detail — the
 /// ratified criteria (p0328) paired with the master's per-criterion dispositions
 /// (p0340), snapshotted at run end. Criterion status vocabulary: "met" | "unmet"

--- a/src/backend/AgentSmith.Infrastructure/Services/Events/EventEnvelopeSerializer.cs
+++ b/src/backend/AgentSmith.Infrastructure/Services/Events/EventEnvelopeSerializer.cs
@@ -125,6 +125,7 @@ public static class EventEnvelopeSerializer
         EventType.ExpectationRatified => typeof(ExpectationRatifiedEvent), // p0328
         EventType.RunStoryRecorded => typeof(RunStoryRecordedEvent), // p0344b
         EventType.RunBudgetResolved => typeof(RunBudgetResolvedEvent), // p0357
+        EventType.LedgerTransitionsRecorded => typeof(LedgerTransitionsRecordedEvent), // p0374a
         _ => null
     };
 }

--- a/src/dashboard/src/components/jobs/ActivityRow.tsx
+++ b/src/dashboard/src/components/jobs/ActivityRow.tsx
@@ -433,6 +433,41 @@ function projectEvent(event: RunEvent): RowView {
         severity: "info",
       };
     }
+    case EventType.LedgerTransitionsRecorded: {
+      // p0374a: what one update_progress call actually changed. The Story row
+      // above shows the ledger's current SHAPE, which every flush overwrites;
+      // this is the history that shape came from. A refused rewrite is a warning:
+      // the model tried to take completed work back without the reopen token.
+      const e = event as Extract<RunEvent, { type: EventType.LedgerTransitionsRecorded }>;
+      const t = parseTransitions(e.transitionsJson);
+      const refused = t.filter(
+        (x) => x.cause === "regression_refused" || x.cause === "omission_refused",
+      ).length;
+      return {
+        icon: refused > 0 ? "⤺" : "☑",
+        label: "Ledger",
+        detail:
+          t.length === 0
+            ? "no change"
+            : `${t.length} transition${t.length === 1 ? "" : "s"} (pass ${t[0].pass})`,
+        reason:
+          refused > 0
+            ? `${refused} refused — completed work only reopens via the 'reopen' status`
+            : null,
+        severity: refused > 0 ? "warn" : "info",
+      };
+    }
+  }
+}
+
+/** p0374a: the trail carries transitions as JSON; a corrupt payload renders as
+ * "no change" rather than taking the row down. */
+function parseTransitions(json: string): { cause: string; pass: number }[] {
+  try {
+    const parsed: unknown = JSON.parse(json);
+    return Array.isArray(parsed) ? (parsed as { cause: string; pass: number }[]) : [];
+  } catch {
+    return [];
   }
 }
 

--- a/src/dashboard/src/components/jobs/FilterRail.tsx
+++ b/src/dashboard/src/components/jobs/FilterRail.tsx
@@ -40,6 +40,7 @@ const LABELS: Record<EventType, string> = {
   [EventType.ExpectationRatified]: "ExpectationRatified", // p0328
   [EventType.RunStoryRecorded]: "RunStoryRecorded", // p0344b
   [EventType.RunBudgetResolved]: "RunBudgetResolved", // p0357
+  [EventType.LedgerTransitionsRecorded]: "LedgerTransitionsRecorded", // p0374a
 };
 
 interface FilterRailProps {

--- a/src/dashboard/src/types/hub-events.ts
+++ b/src/dashboard/src/types/hub-events.ts
@@ -37,6 +37,7 @@ export enum EventType {
   ExpectationRatified = 73,
   RunStoryRecorded = 74,
   RunBudgetResolved = 75,
+  LedgerTransitionsRecorded = 76,
 }
 
 interface RunEventBase {
@@ -431,6 +432,18 @@ export interface RunBudgetResolvedEvent extends RunEventBase {
   capTokens: number;
 }
 
+/**
+ * p0374a: the per-entry transitions of one accepted update_progress call —
+ * entry, from-state, to-state, cause, master pass. Trail-only: the run row's
+ * ledger snapshot is overwritten by every flush and cannot hold history, so
+ * this event IS the run's ledger history. transitionsJson is an array of
+ * { entryId, activity, from, to, cause, pass }.
+ */
+export interface LedgerTransitionsRecordedEvent extends RunEventBase {
+  type: EventType.LedgerTransitionsRecorded;
+  transitionsJson: string;
+}
+
 export type RunEvent =
   | RunStartedEvent
   | RunFinishedEvent
@@ -465,7 +478,8 @@ export type RunEvent =
   | RunCheckpointedEvent
   | ExpectationRatifiedEvent
   | RunStoryRecordedEvent
-  | RunBudgetResolvedEvent;
+  | RunBudgetResolvedEvent
+  | LedgerTransitionsRecordedEvent;
 
 /** p0327: the pending question of a status="waiting_for_input" run, joined
  *  from its checkpoint row at query time (REST detail only). */

--- a/tests/AgentSmith.PipelineHarness/Composition/DurableDialogueHarness.cs
+++ b/tests/AgentSmith.PipelineHarness/Composition/DurableDialogueHarness.cs
@@ -1,4 +1,6 @@
 using AgentSmith.Application.Services;
+using AgentSmith.Application.Services.Builders;
+using AgentSmith.Contracts.Commands;
 using AgentSmith.Contracts.Dialogue;
 using AgentSmith.Contracts.Models;
 using AgentSmith.Domain.Models;
@@ -20,15 +22,37 @@ namespace AgentSmith.PipelineHarness.Composition;
 /// production durable-inbox transport, a synchronous event→DB projection and a
 /// recorded job queue. Also builds the REAL CapacityQueuePump wired to a
 /// ResumeRunLauncher so a matched checkpoint launches exactly like production.
+/// <para>
+/// p0393b: the park POINT is supplied here. Since p0393 deleted Approval and
+/// p0393a removed NegotiateExpectation, no shipped preset declares a step-level
+/// ask any more, so the real <c>AskCommandHandler</c> (still registered, still
+/// the only production caller of IDialogueAskGate) has no carrier. The harness
+/// gives it one by binding the production <see cref="AskContextBuilder"/> to the
+/// <c>LoadContext</c> slot of the preset under test: the asking STEP is fixture-
+/// supplied exactly as the LLM script is, and everything the checkpoint/resume
+/// spine is made of — ask gate, checkpoint writer, checkpoint store, durable
+/// inbox, sweeper, resumer, pump, launcher, resume-at-cursor — stays production.
+/// </para>
 /// </summary>
 public static class DurableDialogueHarness
 {
+    /// <summary>The preset step whose slot carries the ask. It sits after
+    /// CheckoutSource in every preset that has both, so the checkpoint's
+    /// re-provisioning prefix is exercised rather than trivially empty.</summary>
+    public const string ParkStep = CommandNames.LoadContext;
+
     public static RealCompositionHarness Build(
         string fixtureName, string dbPath, RecordingJobQueue jobQueue) =>
         RealCompositionHarness.Build(
             FixturePaths.For(fixtureName), SandboxBackend.Stub, session: null,
             SkillsBackend.Fixture, services =>
             {
+                // p0393b: the fixture-supplied park point (see the type remarks).
+                // CommandContextFactory indexes the keyed builders by name, so the
+                // original registration is removed rather than shadowed.
+                services.Remove(services.Single(d =>
+                    d.ImplementationInstance is KeyedContextBuilder k && k.CommandName == ParkStep));
+                services.AddSingleton(new KeyedContextBuilder(ParkStep, new AskContextBuilder()));
                 // Shared SQLite FILE: the durable state that survives the "restart".
                 services.RemoveAll<DbContextOptions<AgentSmithDbContext>>();
                 services.RemoveAll<DbContextOptions>();

--- a/tests/AgentSmith.PipelineHarness/Fixtures/agentsmith-dialogue.yml
+++ b/tests/AgentSmith.PipelineHarness/Fixtures/agentsmith-dialogue.yml
@@ -53,6 +53,14 @@ projects:
     agent: openai-default
     tracker: github-fixture
     repos: [spec-dialog-fixture]
+  # p0393b: the durable-dialogue subject — a ticket-triggered discussion run,
+  # which is the shape the checkpoint/resume spine actually requires (a ticket
+  # identity to re-launch on). See DurableDialogueTests for why it is not
+  # spec-dialog.
+  fixture-durable-dialogue:
+    agent: openai-default
+    tracker: github-fixture
+    repos: [csharp-fixture]
 
 secrets:
   azdo_token: ${AGENTSMITH_TEST_AZDO_TOKEN}

--- a/tests/AgentSmith.PipelineHarness/Presets/DurableDialogueTests.cs
+++ b/tests/AgentSmith.PipelineHarness/Presets/DurableDialogueTests.cs
@@ -1,4 +1,5 @@
 using AgentSmith.Contracts.Dialogue;
+using AgentSmith.Contracts.Commands;
 using AgentSmith.Contracts.Models;
 using AgentSmith.Contracts.Services;
 using AgentSmith.Domain.Models;
@@ -14,28 +15,168 @@ using Microsoft.Extensions.DependencyInjection;
 namespace AgentSmith.PipelineHarness.Presets;
 
 /// <summary>
-/// p0327: the durable-dialogue proof, LLM-free through the REAL composition.
-/// A fix-bug run with an interactive approval crosses the (zero-width fixture)
-/// hot window, checkpoints, and parks as waiting_for_input; the orchestrator
-/// "restarts" (first harness disposed, a second built over the same SQLite
-/// file); the operator's answer lands in the durable inbox; the sweeper turns
-/// it into a capacity-queue resume entry; the REAL pump launches it; and the
-/// resumed request completes the run — ONE run record, correct result.
-/// p0328 note: fix-bug now negotiates the expectation BEFORE planning, so the
-/// FIRST interactive park is the ratification ask (approved verbatim here);
-/// the approval this test was built around is the SECOND park — the sequential
-/// checkpoint upsert (one row per run, re-parked) is proven en route.
+/// p0327/p0393b: the durable-dialogue proof, LLM-free through the REAL
+/// composition. A ticket run's ask crosses the (zero-width fixture) hot window,
+/// checkpoints, and parks as waiting_for_input; the orchestrator "restarts"
+/// (first harness disposed, a second built over the same SQLite file); the
+/// operator's answer lands in the durable inbox; the sweeper turns it into a
+/// capacity-queue resume entry; the REAL pump launches it; and the resumed
+/// request completes the run — ONE run record, correct result.
+///
+/// <para>
+/// p0393b — why the subject is a ticket-triggered discussion run and NOT
+/// spec-dialog, which the phase spec named:
+/// </para>
+/// <list type="bullet">
+/// <item>Durable dialogue is ticket-keyed by construction. DialogueAskGate's
+/// eligibility check requires ContextKeys.TicketId, DialogueCheckpointWriter
+/// refuses to write without one, RunCheckpointedEvent carries the ticket id, and
+/// RunResumer relaunches through the capacity queue keyed on (project, ticket).</item>
+/// <item>A spec-dialog turn has no ticket. It runs IN PROCESS from a live chat
+/// thread (SpecDialogTurnRunner owns its sandboxes and a SpecDialogReplySlot that
+/// is explicitly excluded from the checkpoint), so a resume launched into the job
+/// queue could neither reconstitute the slot nor reach the thread. Its operator is
+/// present by construction — that is why the ask gate names spec-dialog as a
+/// full-hot-wait surface, not a parking one.</item>
+/// <item>Since p0393 deleted Approval and p0393a removed NegotiateExpectation, no
+/// shipped preset declares a step-level ask at all — the spine has no production
+/// carrier today. The harness supplies the park point (DurableDialogueHarness
+/// binds the production AskContextBuilder to the preset's LoadContext slot), the
+/// same way it supplies the LLM script; every other part of the spine is the real
+/// registration. That gap is recorded in decisions/p0393b.yaml.</item>
+/// </list>
 /// </summary>
 [Trait("Category", "PipelineHarness")]
 public sealed class DurableDialogueTests
 {
     private const string Fixture = "agentsmith-dialogue.yml";
-    private const string Project = "fixture-fix-bug";
+    private const string Project = "fixture-durable-dialogue";
+    private const string Pipeline = "mad-discussion";
     private const string TicketNumber = "7";
+    private const string QuestionId = "durable-dialogue-q1";
+
+    [Fact]
+    public async Task TicketRun_CheckpointMidAsk_RestartAnswerResume_OneRunRecord()
+    {
+        var dbPath = NewDbPath();
+        var jobQueue = new RecordingJobQueue();
+        try
+        {
+            // ---- Act 1: the run parks at the ask ----
+            var runId = await ParkAsync(dbPath, jobQueue);
+            var checkpoint = SingleCheckpoint(dbPath);
+
+            // ---- Act 2: "restart" — a fresh composition over the same DB ----
+            await using var second = DurableDialogueHarness.Build(Fixture, dbPath, jobQueue);
+
+            // ---- Act 3: the operator answers AFTER the restart — durable inbox first ----
+            second.ChatClient.EnqueueText("Discussion synthesised.");
+            await AnswerAsync(second, checkpoint, "keep the current design");
+            (await Sweeper(second).ScanOnceAsync(CancellationToken.None)).Should().Be(1);
+            await DurableDialogueHarness.BuildPump(second, Fixture, jobQueue)
+                .TickAsync(CancellationToken.None);
+
+            var resumeRequest = jobQueue.DequeueViaJsonRoundTrip();
+            resumeRequest.RunId.Should().Be(runId, "the resume reuses the reserved run row");
+            resumeRequest.Context.Should().ContainKey(ContextKeys.ResumeCheckpoint);
+
+            // ---- Act 4: the resumed worker re-enters at the cursor ----
+            var resumed = await DurableDialogueHarness.ExecuteAsync(second, Fixture, resumeRequest);
+
+            resumed.IsSuccess.Should().BeTrue($"the resumed run must complete: {resumed.Message}");
+            second.StubSandboxFactory!.Spawned.Should().NotBeEmpty(
+                "resume re-provisions fresh sandboxes — the checkpointed run held none");
+            AssertOneCompletedRun(dbPath, runId);
+        }
+        finally
+        {
+            Cleanup(dbPath);
+        }
+    }
+
+    [Fact]
+    public async Task AnswerArrivesAfterRestart_DurableInboxDeliversIt()
+    {
+        var dbPath = NewDbPath();
+        var jobQueue = new RecordingJobQueue();
+        try
+        {
+            await ParkAsync(dbPath, jobQueue);
+            var checkpoint = SingleCheckpoint(dbPath);
+
+            // The composition that PARKED is gone; a different one takes the answer.
+            await using var second = DurableDialogueHarness.Build(Fixture, dbPath, jobQueue);
+            await AnswerAsync(second, checkpoint, "the answer the operator typed hours later");
+
+            // And a THIRD composition reads it back: the answer outlived both the
+            // process that asked and the process that received it, so it is the
+            // durable inbox holding it, not any in-memory hot wait.
+            await using var third = DurableDialogueHarness.Build(Fixture, dbPath, jobQueue);
+            var delivered = await third.Services.GetRequiredService<IDialogueAnswerInbox>()
+                .GetAsync(checkpoint.DialogueJobId, checkpoint.QuestionId, CancellationToken.None);
+
+            delivered.Should().NotBeNull("the durable inbox must survive the restart");
+            delivered!.Answer.Should().Be("the answer the operator typed hours later");
+        }
+        finally
+        {
+            Cleanup(dbPath);
+        }
+    }
+
+    [Fact]
+    public async Task ResumeSweeper_ParkedRunWithAnswer_ResumesExactlyOnce()
+    {
+        var dbPath = NewDbPath();
+        var jobQueue = new RecordingJobQueue();
+        try
+        {
+            await ParkAsync(dbPath, jobQueue);
+            var checkpoint = SingleCheckpoint(dbPath);
+
+            await using var second = DurableDialogueHarness.Build(Fixture, dbPath, jobQueue);
+            await AnswerAsync(second, checkpoint, "approve");
+
+            var sweeper = Sweeper(second);
+            (await sweeper.ScanOnceAsync(CancellationToken.None)).Should().Be(1,
+                "the answered checkpoint enqueues exactly one resume");
+            (await sweeper.ScanOnceAsync(CancellationToken.None)).Should().Be(0,
+                "a consumed checkpoint must never enqueue a second resume");
+
+            using var ctx = Db(dbPath);
+            ctx.RunCheckpoints.Single().ResumedAt.Should().NotBeNull(
+                "the checkpoint is marked consumed by the scan that enqueued it");
+            ctx.QueuedTickets.Should().ContainSingle(
+                "the capacity queue carries exactly one resume entry");
+        }
+        finally
+        {
+            Cleanup(dbPath);
+        }
+    }
+
+    // ---- acts ----
+
+    // Act 1 for every scenario: a ticket run reaches the ask, the (zero-width)
+    // hot window elapses, the run checkpoints and parks. Returns the run id.
+    private static async Task<string> ParkAsync(string dbPath, RecordingJobQueue jobQueue)
+    {
+        string runId;
+        await using (var first = DurableDialogueHarness.Build(Fixture, dbPath, jobQueue))
+        {
+            await DurableDialogueHarness.MigrateAsync(first);
+            var result = await DurableDialogueHarness.ExecuteAsync(first, Fixture, Request());
+            result.IsSuccess.Should().BeTrue("parking is a clean halt, not a failure");
+            runId = SingleRun(dbPath).Id;
+        }
+
+        AssertParked(dbPath);
+        return runId;
+    }
 
     // ---- assertions ----
 
-    private static void AssertParked(string dbPath, string expectQuestion)
+    private static void AssertParked(string dbPath)
     {
         using var ctx = Db(dbPath);
         var run = ctx.Runs.Single();
@@ -43,9 +184,11 @@ public sealed class DurableDialogueTests
         run.FinishedAt.Should().BeNull("waiting is an active state — the run is NOT over");
         var checkpoint = ctx.RunCheckpoints.Single();
         checkpoint.ResumedAt.Should().BeNull();
-        checkpoint.QuestionJson.Should().Contain(expectQuestion);
-        checkpoint.RemainingCommandsJson.Should().Contain("CheckoutSourceCommand",
+        checkpoint.QuestionId.Should().Be(QuestionId);
+        checkpoint.RemainingCommandsJson.Should().Contain(CommandNames.CheckoutSource,
             "the resume re-provisions the working tree first — sandboxes are cattle");
+        checkpoint.RemainingCommandsJson.Should().Contain(DurableDialogueHarness.ParkStep,
+            "the cursor re-enters the asking step so it consumes the answer");
     }
 
     private static void AssertOneCompletedRun(string dbPath, string runId)
@@ -59,32 +202,55 @@ public sealed class DurableDialogueTests
         ctx.QueuedTickets.Should().BeEmpty("the launched resume entry is consumed");
     }
 
-    // ---- plumbing shared with ExpectationNegotiationTests (p0328) ----
+    // ---- plumbing ----
 
-    internal static Task AnswerAsync(
+    private static DialogueResumeSweeper Sweeper(RealCompositionHarness harness) =>
+        harness.Services.GetRequiredService<DialogueResumeSweeper>();
+
+    private static Task AnswerAsync(
         RealCompositionHarness harness, RunCheckpoint checkpoint, string answer) =>
         harness.Services.GetRequiredService<IDialogueTransport>().PublishAnswerAsync(
             checkpoint.DialogueJobId,
             new DialogAnswer(checkpoint.QuestionId, answer, null, DateTimeOffset.UtcNow, "@operator"),
             CancellationToken.None);
 
-    internal static RunCheckpoint SingleCheckpoint(string dbPath)
+    private static RunCheckpoint SingleCheckpoint(string dbPath)
     {
         using var ctx = Db(dbPath);
         return ctx.RunCheckpoints.Single();
     }
 
-    internal static Run SingleRun(string dbPath)
+    private static Run SingleRun(string dbPath)
     {
         using var ctx = Db(dbPath);
         return ctx.Runs.Single();
     }
 
-    // Headless=false so the asks actually ask — the checkpointable shape.
-    internal static PipelineRequest Request(string? runId) => new(
-        Project, "fix-bug", TicketId: new TicketId(TicketNumber), Headless: false, RunId: runId);
+    // Headless=false so the ask actually asks — the checkpointable shape. The
+    // question's timeout is days-scale against the fixture's zero-width hot
+    // window, which is exactly the "outlives the process" case.
+    private static PipelineRequest Request() => new(
+        Project, Pipeline, TicketId: new TicketId(TicketNumber), Headless: false,
+        Context: new Dictionary<string, object>
+        {
+            [ContextKeys.DialogueQuestion] = new DialogQuestion(
+                QuestionId, QuestionType.FreeText,
+                "Which direction should the discussion take?",
+                Context: null, Choices: null, DefaultAnswer: "proceed",
+                Timeout: TimeSpan.FromDays(3)),
+        });
 
-    internal static AgentSmithDbContext Db(string dbPath) => new(
+    private static string NewDbPath() =>
+        Path.Combine(Path.GetTempPath(), $"agentsmith-harness-{Guid.NewGuid():N}.db");
+
+    private static void Cleanup(string dbPath)
+    {
+        SqliteConnection.ClearAllPools();
+        foreach (var f in new[] { dbPath, dbPath + "-wal", dbPath + "-shm" })
+            if (File.Exists(f)) try { File.Delete(f); } catch (IOException) { /* best-effort */ }
+    }
+
+    private static AgentSmithDbContext Db(string dbPath) => new(
         new DbContextOptionsBuilder<AgentSmithDbContext>()
             .UseSqlite($"Data Source={dbPath}").Options);
 }

--- a/tests/AgentSmith.Tests/Hubs/TrailReaderTests.cs
+++ b/tests/AgentSmith.Tests/Hubs/TrailReaderTests.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using AgentSmith.Contracts.Events;
+using AgentSmith.Contracts.Runs;
 using AgentSmith.Infrastructure.Persistence;
 using AgentSmith.Infrastructure.Persistence.Contracts;
 using AgentSmith.Infrastructure.Services.Events;
@@ -105,6 +106,38 @@ public sealed class TrailReaderTests : IDisposable
         // All 4 DB rows (not the single Redis entry) come back, ordered by Seq.
         result.Select(e => e.Type).Should().ContainInOrder(
             EventType.RunStarted, EventType.StepStarted, EventType.StepStarted, EventType.RunFinished);
+    }
+
+    [Fact]
+    public async Task Trail_LedgerTransitions_AreReadable()
+    {
+        // p0374a: the ledger snapshot on the run row is overwritten by every flush, so
+        // history lives on the trail. Prove it round-trips: projected as a raw row by
+        // the generic applier path, read back as the TYPED event with its transitions
+        // intact — entry, from-state, to-state, cause and pass.
+        StubEmptyRedis();
+        var transitions = new List<LedgerTransitionView>
+        {
+            new("3", "migrate the call sites", "done", "done", LedgerTransitionCauses.RegressionRefused, 2),
+            new("4", "update the docs", null, "pending", LedgerTransitionCauses.Added, 2),
+        };
+        SeedDbTrail(
+            new RunStartedEvent(_runId, "ticket", "code", new[] { "server" }, DateTimeOffset.UtcNow),
+            new LedgerTransitionsRecordedEvent(
+                _runId, RunStoryJson.Serialize(transitions), DateTimeOffset.UtcNow));
+
+        var sut = new TrailReader(_redis.Object, _scopes);
+        var result = await sut.ReadDbTrailTypedAsync(_runId);
+
+        var recorded = result.OfType<LedgerTransitionsRecordedEvent>().Should().ContainSingle().Subject;
+        var read = RunStoryJson.TryDeserialize<List<LedgerTransitionView>>(recorded.TransitionsJson);
+        read.Should().HaveCount(2);
+        read![0].Cause.Should().Be(LedgerTransitionCauses.RegressionRefused);
+        read[0].From.Should().Be("done");
+        read[0].To.Should().Be("done");
+        read[0].Pass.Should().Be(2);
+        read[1].From.Should().BeNull("an added entry has no prior state");
+        read[1].Cause.Should().Be(LedgerTransitionCauses.Added);
     }
 
     [Fact]

--- a/tests/AgentSmith.Tests/Services/LedgerMergePolicyTests.cs
+++ b/tests/AgentSmith.Tests/Services/LedgerMergePolicyTests.cs
@@ -125,4 +125,80 @@ public sealed class LedgerMergePolicyTests
         result.Merged.Entries.Count(e => e.Status == ProgressStatus.Done).Should().Be(2);
         result.ReattachedDone.Should().Be(0);
     }
+
+    // ---- p0374a: the four named cases of "done stays done", and the record ----
+
+    [Fact]
+    public void Merge_IncomingWithoutDoneEntry_KeepsTheStoredDone()
+    {
+        var result = LedgerMergePolicy.Merge(
+            Ledger(Done("1"), Pending("2")), Ledger(Pending("2")), NoReopens);
+
+        result.Merged.Entries.Single(e => e.Id == "1").Status.Should().Be(ProgressStatus.Done);
+        result.RefusedAnything.Should().BeTrue();
+        result.Transitions.Should().ContainSingle(t =>
+            t.EntryId == "1" && t.Cause == LedgerTransitionCause.OmissionRefused);
+    }
+
+    [Fact]
+    public void Merge_IncomingDowngradesDoneWithoutToken_IsRefusedAndRecorded()
+    {
+        var result = LedgerMergePolicy.Merge(
+            Ledger(Done("1")), Ledger(Pending("1")), NoReopens, pass: 4);
+
+        result.Merged.Entries.Single().Status.Should().Be(ProgressStatus.Done);
+        var transition = result.Transitions.Should().ContainSingle().Subject;
+        transition.Cause.Should().Be(LedgerTransitionCause.RegressionRefused);
+        transition.From.Should().Be(ProgressStatus.Done);
+        transition.To.Should().Be(ProgressStatus.Done, "the attempt happened; the state did not move");
+        transition.Pass.Should().Be(4);
+    }
+
+    [Fact]
+    public void Merge_IncomingCarriesReopenToken_ReopensTheEntry()
+    {
+        var result = LedgerMergePolicy.Merge(
+            Ledger(Done("1")), Ledger(Pending("1")), new HashSet<string> { "1" });
+
+        result.Merged.Entries.Single().Status.Should().Be(ProgressStatus.Pending);
+        result.RefusedAnything.Should().BeFalse("an explicit reopen is not a refused rewrite");
+        result.Transitions.Should().ContainSingle(t =>
+            t.EntryId == "1" && t.Cause == LedgerTransitionCause.ExplicitReopen
+            && t.From == ProgressStatus.Done && t.To == ProgressStatus.Pending);
+    }
+
+    [Fact]
+    public void Merge_NewEntries_AreAppended()
+    {
+        var result = LedgerMergePolicy.Merge(
+            Ledger(Done("1")), Ledger(Done("1"), Pending("2"), Pending("3")), NoReopens);
+
+        result.Merged.Entries.Select(e => e.Id).Should().BeEquivalentTo("1", "2", "3");
+        result.RefusedAnything.Should().BeFalse();
+        result.Transitions.Select(t => (t.EntryId, t.Cause)).Should().BeEquivalentTo(new[]
+        {
+            ("2", LedgerTransitionCause.Added),
+            ("3", LedgerTransitionCause.Added),
+        });
+    }
+
+    [Fact]
+    public void Merge_DroppedPendingEntry_IsAllowedAndRecorded()
+    {
+        var result = LedgerMergePolicy.Merge(
+            Ledger(Pending("1"), Pending("2")), Ledger(Pending("1")), NoReopens);
+
+        result.Merged.Entries.Select(e => e.Id).Should().BeEquivalentTo("1");
+        result.Transitions.Should().ContainSingle(t =>
+            t.EntryId == "2" && t.Cause == LedgerTransitionCause.Dropped
+            && t.From == ProgressStatus.Pending && t.To == null);
+    }
+
+    [Fact]
+    public void Merge_UnchangedResend_RecordsNothing()
+    {
+        var ledger = Ledger(Done("1"), Pending("2"));
+
+        LedgerMergePolicy.Merge(ledger, ledger, NoReopens).Transitions.Should().BeEmpty();
+    }
 }

--- a/tests/AgentSmith.Tests/Services/PriorRunLedgerSeederTests.cs
+++ b/tests/AgentSmith.Tests/Services/PriorRunLedgerSeederTests.cs
@@ -84,10 +84,10 @@ public sealed class PriorRunLedgerSeederTests
     [Fact]
     public async Task Seed_SeededEntries_RoundTripIntoToolHost()
     {
-        // The resume seed round-trips into the tool host. p0374 made the ledger fully
-        // model-owned — a resumed model restructures its plan freely, so an update
-        // that omits a prior step drops it (the working plan is the master's; resume
-        // traceability lives in the run history, not as a constraint here).
+        // The resume seed round-trips into the tool host, and the merge (p0368,
+        // restored by p0374a) protects it: work the PRIOR run finished is exactly the
+        // work a resumed run must not re-tread, so an update omitting step 1 does not
+        // drop it. Pending work stays the resumed model's to restructure.
         var seed = PriorRunLedgerSeeder.Seed(
             Prior(TimeSpan.FromHours(1), Item("1", "done"), Item("2", "pending")), Now);
         var host = new ProgressLedgerToolHost(seed);
@@ -98,6 +98,6 @@ public sealed class PriorRunLedgerSeederTests
         });
 
         result.Should().NotContain("Error");
-        host.GetLedger().Entries.Select(e => e.Id).Should().BeEquivalentTo("2");
+        host.GetLedger().Entries.Select(e => e.Id).Should().BeEquivalentTo("2", "1");
     }
 }

--- a/tests/AgentSmith.Tests/Services/ProgressLedgerFlusherTests.cs
+++ b/tests/AgentSmith.Tests/Services/ProgressLedgerFlusherTests.cs
@@ -69,7 +69,7 @@ public sealed class ProgressLedgerFlusherTests
     public async Task UpdateProgress_AcceptedReplace_AwaitsFlushCallback()
     {
         ProgressLedger? flushed = null;
-        var host = new ProgressLedgerToolHost(onReplaced: l => { flushed = l; return Task.CompletedTask; });
+        var host = new ProgressLedgerToolHost(onReplaced: (l, _) => { flushed = l; return Task.CompletedTask; });
 
         await host.UpdateProgress(new[] { new ProgressUpdateItem("1", "a", "in_progress") });
 
@@ -81,7 +81,7 @@ public sealed class ProgressLedgerFlusherTests
     public async Task UpdateProgress_RejectedReplace_DoesNotFlush()
     {
         var flushes = 0;
-        var host = new ProgressLedgerToolHost(onReplaced: _ => { flushes++; return Task.CompletedTask; });
+        var host = new ProgressLedgerToolHost(onReplaced: (_, _) => { flushes++; return Task.CompletedTask; });
 
         await host.UpdateProgress(new[]
         {

--- a/tests/AgentSmith.Tests/Services/ProgressLedgerTests.cs
+++ b/tests/AgentSmith.Tests/Services/ProgressLedgerTests.cs
@@ -16,9 +16,12 @@ namespace AgentSmith.Tests.Services;
 // p0341: the durable progress ledger. These pin the invariants that make a
 // full-state-replace safe as MEMORY: at-most-one in_progress, a size cap, an
 // EXPLICIT target for the honesty diagnostic (no fuzzy matching), and that the
-// ledger never touches p0340's keystone. p0359: the replace is fully model-owned —
-// restructuring (including dropping steps) is legal, because the plan may deviate
-// mid-run and the keystone cross-checks whatever the FINAL list claims.
+// ledger never touches p0340's keystone. p0359: the replace is model-owned for
+// PENDING work — restructuring (including dropping steps) is legal, because the plan
+// may deviate mid-run and the keystone cross-checks whatever the FINAL list claims.
+// p0368/p0374a: completed work is the exception. A done step leaves done only via the
+// explicit reopen token, the refusal of any other route is stated back to the model,
+// and every accepted change is recorded as a transition carrying its cause and pass.
 public sealed class ProgressLedgerTests
 {
     private static ProgressUpdateItem Item(string id, string status, string? target = null, string? note = null)
@@ -134,27 +137,29 @@ public sealed class ProgressLedgerTests
     }
 
     [Fact]
-    public async Task ProgressLedger_DoneUnchecked_AcceptedAsPending()
+    public async Task ProgressLedger_DoneRegressedWithoutReopen_KeptDone_AndRefusalIsVisible()
     {
-        // p0374: the ledger is the master's own working plan — unchecking a step
-        // (done→pending) is legitimate self-correction and is accepted as-is. p0368
-        // forced it back to done, which fought the master (it marks a step done,
-        // realises it isn't, and must be able to reopen it to do the work).
+        // p0368, restored by p0374a: a plain done→pending regression is NOT the
+        // self-correction p0374 removed the merge for — the reopen token above is,
+        // and it already covered that case. p0374a adds the half p0374 promised: the
+        // refusal is stated in the tool's own reply, so the model cannot read the
+        // returned checklist as its own and drift.
         var host = new ProgressLedgerToolHost();
         await host.UpdateProgress(new[] { Item("1", "done"), Item("2", "done") });
 
-        await host.UpdateProgress(new[] { Item("1", "pending"), Item("2", "done") });
+        var result = await host.UpdateProgress(new[] { Item("1", "pending"), Item("2", "done") });
 
-        host.GetLedger().Entries.Single(e => e.Id == "1").Status.Should().Be(ProgressStatus.Pending);
+        host.GetLedger().Entries.Single(e => e.Id == "1").Status.Should().Be(ProgressStatus.Done);
+        result.Should().Contain("kept done", "a refused rewrite must be visible, not a silent keep");
+        result.Should().Contain("reopen", "the reply names the one way to reopen a step");
     }
 
     [Fact]
-    public async Task ProgressLedger_RewriteOmittingDoneItem_DropsItFreely()
+    public async Task ProgressLedger_RewriteOmittingDoneItem_ReattachesItAndSaysSo()
     {
-        // p0374: the ledger is fully model-owned — a rewrite may drop items, done or
-        // not. "The LLM doesn't care about its chatter from yesterday": traceability is
-        // OUR concern (a separate history snapshot), not a constraint that re-attaches
-        // dropped work onto the master's plan.
+        // p0368, restored by p0374a: dropping completed work by omission is the
+        // failure mode that made a run re-tread finished steps. Pending work stays
+        // freely droppable (see ProgressLedger_RestructureDroppingSteps above).
         var host = new ProgressLedgerToolHost(
             seed: new[]
             {
@@ -162,26 +167,74 @@ public sealed class ProgressLedgerTests
                 new ProgressLedgerEntry("2", "more finished work", ProgressStatus.Done),
             });
 
-        await host.UpdateProgress(new[] { Item("9", "in_progress") });
+        var result = await host.UpdateProgress(new[] { Item("9", "in_progress") });
 
-        host.GetLedger().Entries.Select(e => e.Id).Should().BeEquivalentTo(new[] { "9" },
-            "a rewrite fully replaces the plan — dropped items do not survive");
+        host.GetLedger().Entries.Select(e => e.Id).Should().BeEquivalentTo(new[] { "9", "1", "2" },
+            "completed work survives a rewrite that omits it");
+        result.Should().Contain("re-attached");
     }
 
     [Fact]
-    public async Task ProgressLedger_RewriteToAllPending_ReplacesFully()
+    public async Task ProgressLedger_DoneCount_NeverDecreasesAcrossRewrites()
     {
-        // p0374: a rewrite fully replaces the plan; the done-count may drop. The loop is
-        // no longer protected by forcing done-state — the empty-pass re-engage gate
-        // (p0365) bounds it and the keystone (a done-claim needs a real diff) keeps it
-        // honest.
+        // p0368, restored by p0374a: the done-count is monotone unless the model
+        // reopens explicitly. Without this the re-engagement loop could be driven
+        // forever by a checklist that keeps un-finishing its own finished work.
         var host = new ProgressLedgerToolHost();
         await host.UpdateProgress(new[] { Item("1", "done"), Item("2", "done"), Item("3", "pending") });
 
         await host.UpdateProgress(new[] { Item("a", "pending"), Item("b", "pending") });
 
-        host.GetLedger().Entries.Select(e => e.Id).Should().BeEquivalentTo(new[] { "a", "b" });
-        DoneCount(host).Should().Be(0);
+        host.GetLedger().Entries.Select(e => e.Id).Should().BeEquivalentTo(new[] { "a", "b", "1", "2" });
+        DoneCount(host).Should().Be(2);
+    }
+
+    [Fact]
+    public async Task ProgressLedger_EveryTransition_CarriesItsCauseAndPass()
+    {
+        // p0374a step "traceability": the record p0374 promised in exchange for the
+        // merge and never shipped. The stored ledger is a SNAPSHOT every flush
+        // overwrites, so the history has to be its own record.
+        var pass = 0;
+        var host = new ProgressLedgerToolHost(
+            seed: new[] { new ProgressLedgerEntry("1", "seeded", ProgressStatus.Pending) },
+            currentPass: () => pass);
+
+        await host.UpdateProgress(new[] { Item("1", "done"), Item("2", "pending") });
+        pass = 3;
+        await host.UpdateProgress(new[] { Item("1", "pending") });
+
+        var transitions = host.GetTransitions();
+        transitions.Should().AllSatisfy(t => t.EntryId.Should().NotBeNullOrWhiteSpace());
+
+        var firstPass = transitions.Where(t => t.Pass == 0).ToList();
+        firstPass.Should().Contain(t =>
+            t.EntryId == "1" && t.From == ProgressStatus.Pending && t.To == ProgressStatus.Done
+            && t.Cause == LedgerTransitionCause.ModelUpdate);
+        firstPass.Should().Contain(t =>
+            t.EntryId == "2" && t.From == null && t.To == ProgressStatus.Pending
+            && t.Cause == LedgerTransitionCause.Added);
+
+        var secondPass = transitions.Where(t => t.Pass == 3).ToList();
+        secondPass.Should().Contain(t =>
+            t.EntryId == "1" && t.Cause == LedgerTransitionCause.RegressionRefused
+            && t.From == ProgressStatus.Done && t.To == ProgressStatus.Done);
+        secondPass.Should().Contain(t =>
+            t.EntryId == "2" && t.To == null && t.Cause == LedgerTransitionCause.Dropped);
+    }
+
+    [Fact]
+    public async Task ProgressLedger_UnchangedResend_RecordsNoTransition()
+    {
+        // A record of what HAPPENED. Re-sending the same checklist is not history,
+        // and a trail flooded with no-ops is a trail nobody reads.
+        var host = new ProgressLedgerToolHost();
+        await host.UpdateProgress(new[] { Item("1", "in_progress") });
+        var afterFirst = host.GetTransitions().Count;
+
+        await host.UpdateProgress(new[] { Item("1", "in_progress") });
+
+        host.GetTransitions().Should().HaveCount(afterFirst);
     }
 
     [Fact]


### PR DESCRIPTION
Two phases held until p0393a landed, because both touch surfaces it was rewriting.

## p0374a — done stays done

p0368 built `LedgerMergePolicy`: an incoming `update_progress` MERGES with the stored ledger, and a done entry returns to open only through the explicit reopen token. p0374 unwired it on the rationale that the model must be able to correct its own record — **which is exactly what the reopen token already covered** — and promised a traceability snapshot in exchange that never shipped. The system lost the guard and did not gain the replacement.

This is **not** a re-argument about the ledger's AUTHORITY. p0393 settled that: no vote on a green verdict, a qualifying vote on red where it separates "gave up early" from "genuinely stuck" (p0363's case). Nothing here touches `ShouldReengage` or the keystone. This is about the ledger not **lying** — a record of what happened staying a record, which is the one job p0393 left it. A checklist that silently rewrites its own history cannot do that job.

**What changed**

- **The merge is re-wired.** Worth recording: `LedgerMergePolicy` was never deleted, only *orphaned*. The class, its seven unit tests, and the tool host's doc-comment describing the merge all stayed in the tree — p0374 removed only the call site. So the `update_progress` tool description shown to the LLM has been promising *"a step already marked done STAYS done even if you omit it or send it back as pending"* for a behaviour that was not implemented. Restoring the call restores the described contract; nothing had to be re-derived.
- **A refused rewrite is now visible** — the half p0368 lacked. From the model's seat a silent keep is indistinguishable from a silent rewrite: it reads the returned checklist as its own and drifts. The tool's reply now names how many completed steps were re-attached or kept done, and names `reopen` as the one way back. That also makes the guard self-teaching for a pin whose master text predates this change.
- **Traceability ships.** Every accepted update emits per-entry `LedgerTransition`s — entry, from-state, to-state, cause, master pass — onto the run trail as its own event. The run row's `ProgressLedgerJson` is a snapshot every mid-run flush overwrites, so it structurally cannot hold history; the trail is append-only and already the surface a watcher reads. Trail-only, so **no migration and no applier case** (the applier's default branch persists the raw row). A dropped *pending* entry is recorded too — allowed, but never unexplained. An unchanged re-send records nothing and publishes nothing.
- **The pass number** is read through a `Func<int>` the handler owns, because "pass" means the master's re-engagement pass and that loop lives in `AgenticMasterHandler`. A host-side call counter would have been a different number wearing the same name.

Skills side (separate PR, `agent-smith-skills#…`): `coding-agent-master` 1.20.0 → 1.21.0. Its ledger bullet said the checklist is the model's to "add, reword, reorder, or remove" — true of pending work, false of completed work — and its migration playbook told the model to *"flip the affected batch entries back from `done` to `pending`"*, the exact move the guard refuses. Both corrected.

## p0393b — the durable-dialogue spine gets its proof back

p0393 deleted the coding path's dialogue checkpoints and `DurableDialogueTests` lost its **subject** with them. Since then `DialogueResumeSweeper` and the durable inbox have had unit coverage and no end-to-end proof. The three-act shape is rebuilt through the real composition: park → restart over the same SQLite file → answer → resume, **one run record**, plus the inbox surviving the restart and the sweeper resuming exactly once.

**Where the spec disagreed with the code, and what I did about it**

The spec said to move the coverage to `spec-dialog` because it "still checkpoints". It does not, and it cannot:

- `DialogueAskGate.IsCheckpointEligible` requires `ContextKeys.TicketId` and its own comment names spec-dialog as a full-hot-wait surface; `DialogueCheckpointWriter` refuses to write without a ticket; `RunCheckpointedEvent` carries the ticket id; `RunResumer` relaunches through the capacity queue keyed on `(project, ticket)`.
- Underneath that is a design reason, not an oversight. A spec-dialog turn runs **in process** from a live chat thread; `SpecDialogTurnRunner` owns its sandboxes and a `SpecDialogReplySlot` the checkpoint serializer explicitly excludes. A resume launched into the Redis job queue could neither rebuild the slot nor reach the thread. Its operator is present by construction, and the durable answer already survives as the session transcript the next turn reads.

So the subject is a ticket-triggered discussion run, and the contradiction is recorded in `decisions/p0393b.yaml` rather than resolved quietly.

**The larger finding**, which I did not act on: the spine has **no production carrier at all**. `AskCommandHandler`, `ApprovalHandler` and `NegotiateExpectationHandler` are the only callers of `IDialogueAskGate`; p0393 deleted Approval from the code preset, p0393a removed NegotiateExpectation, and `Ask` was never in one. The checkpoint/resume machinery, the durable inbox and the sweeper are live, registered, unit-tested and unreachable from every shipped preset. Making it reachable again is a behaviour change with deployment consequences (it would park real runs for days on a master question) and it collides with p0391, which deliberately chose the *ticket* park for the code presets — not this phase's call. The harness therefore supplies the asking **step** the way it already supplies the LLM script (one keyed-builder swap onto the preset's `LoadContext` slot); ask gate, checkpoint writer, checkpoint store, durable transport + inbox, sweeper, resumer, capacity queue, pump, `ResumeRunLauncher` and the executor's resume-at-cursor are all the production registration. What was unproven end to end is now proven end to end; what is dormant is named instead of made to look alive.

## Tests

Baseline measured at the branch point (`origin/main` @ 396c45cb): **3473 + 82 + 93 = 3648**, green.
After: **3482 + 85 + 93 = 3660**, green. Delta +12 — three harness scenarios, six merge-policy cases, two transition-record cases, one trail-readability case.

Dashboard: `pnpm test` 555/555 green; `gen:hub-events --check` reports no drift (the new event type is mirrored into `hub-events.ts` + `FilterRail`).

`bash scripts/validate-skills.sh` green on the skills branch.

Not touched, per instruction: `.agentsmith/contexts/default/context.yaml`, and neither phase spec was moved out of `planned/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)