### PR TITLE
docs: deployment artifacts catch up with config-in-DB, one code pipeline, 0.129.0 pins

### DIFF
--- a/config/agentsmith.example.yml
+++ b/config/agentsmith.example.yml
@@ -2,6 +2,15 @@
 #
 # Agent Smith — Example Configuration (p0139 catalog-first schema)
 #
+# ── p0349: what the SERVER reads from this file ─────────────────────────
+# At BOOT the server reads ONLY `persistence:` + `secrets:` (the bootstrap
+# slice). Everything else in this document is the IMPORT/EXPORT format for
+#   agentsmith config import <yaml>    # seed an empty DB (guarded; --force)
+#   agentsmith config export           # DB -> YAML, for backup/DR
+# and is edited in the Config Studio (dashboard). The one-shot CLI pipelines
+# still read the full file directly.
+# ────────────────────────────────────────────────────────────────────────
+#
 # Top-level catalogs (`agents:`, `repos:`, `trackers:`, `pipeline_triggers:`)
 # are defined once. Each project under `projects:` references catalog entries
 # by name and adds its own trigger blocks. This replaces the pre-p0139 form
@@ -21,7 +30,7 @@
 # still load and win field-by-field when present.
 deployment:
   registry: holgerleichsenring
-  version: 0.48.0
+  version: 0.129.0
 
 # --- Per-language toolchain images (p0245) ---
 # Override the built-in language→image table per language, for one project, without
@@ -249,10 +258,9 @@ trackers:
     # p0318/p0391: where a run parks when it needs an answer from you (a too-thin
     # ticket, or a question the master raises mid-run). It must sit OUTSIDE
     # trigger_statuses — you moving the ticket back into one IS the re-trigger.
-    # REQUIRED for any project that runs a pipeline able to park (fix-bug,
-    # fix-no-test, add-feature, phase-execution); the loader refuses to start
-    # without it, because a park with nowhere to go leaves the ticket claimable
-    # and the run repeats forever.
+    # REQUIRED for any project that runs a pipeline able to park (code,
+    # spec-dialog); the loader refuses to start without it, because a park with
+    # nowhere to go leaves the ticket claimable and the run repeats forever.
     needs_clarification_status: "Question"
 
   acme-ado:
@@ -270,7 +278,7 @@ trackers:
     failed_status: "Resolved"
     needs_clarification_status: "Question"   # p0318/p0391 — see acme-github above
     pipeline_from_label:
-      bug: fix-bug
+      bug: code
       security: security-scan
 
   acme-jira:
@@ -295,10 +303,13 @@ trackers:
 # ────────────────────────────────────────────────────────────────────────
 # Applied when a project's trigger block omits `pipeline_from_label`.
 # A populated project-level map wins over this global default.
+# p0393: ONE `code` pipeline ships all code changes (the former fix-bug /
+# fix-no-test / add-feature / phase-execution names still load as aliases of it,
+# but new configuration should say `code`).
 pipeline_triggers:
   agent-smith:init: init-project
-  bug: fix-bug
-  feature: add-feature
+  bug: code
+  feature: code
   security-review: security-scan
   api-security-review: api-security-scan
 
@@ -312,7 +323,7 @@ projects:
     agent: claude-default
     tracker: acme-github
     repos: [acme-app]
-    pipeline: fix-bug
+    pipeline: code
     coding_principles_path: .agentsmith/coding-principles.md
     # Per-pipeline overrides. Each entry: name + optional agent / skills_path /
     # coding_principles_path / confidence_threshold. confidence_threshold
@@ -347,7 +358,7 @@ projects:
     agent: claude-default
     tracker: acme-ado
     repos: [acme-platform]
-    pipeline: fix-bug
+    pipeline: code
     polling:
       enabled: true
       interval_seconds: 60
@@ -362,7 +373,7 @@ projects:
     agent: claude-default
     tracker: acme-jira
     repos: [acme-rules-shared, acme-rules-billing]
-    pipeline: fix-bug
+    pipeline: code
     jira_trigger:
       project_resolution:
         # p0140a: Jira tag dispatch — a ticket carrying the label "acme-rules"
@@ -396,10 +407,14 @@ tool_runner:
     nuclei: projectdiscovery/nuclei:latest
     spectral: stoplight/spectral:6
 
-# Skill catalog source. See docs/skills/source-modes.md.
+# Skill catalog source. The server ships with the catalog EMBEDDED in the
+# image (pinned v4.0.0) — normally you need no skills block at all. Set
+# source/version only to OVERRIDE the embedded catalog: an airgap mirror pin,
+# or catalog development against a local checkout (source: path). See
+# docs/skills/source-modes.md.
 skills:
   source: default
-  version: v2.2.0
+  version: v4.0.0
   # cache_dir defaults to $XDG_CACHE_HOME/agentsmith/skills, then ~/.cache/agentsmith/skills.
   # cache_dir: /var/lib/agentsmith/skills
 
@@ -430,7 +445,7 @@ pipeline_cost_cap:
   #   api-security-scan:
   #     usd: 10
   #     tokens: 1000000
-  #   fix-bug:
+  #   code:
   #     usd: 2
   #     tokens: 200000
 

--- a/deploy/docker-compose.example.yml
+++ b/deploy/docker-compose.example.yml
@@ -5,7 +5,7 @@
 # Run from repo root after copying + editing:
 #   docker compose -f deploy/docker-compose.yml up -d                        # server + redis
 #   docker compose -f deploy/docker-compose.yml run --rm agentsmith run --headless "fix #1 in my-project"
-#   docker compose -f deploy/docker-compose.yml run --rm agentsmith security-scan --repo /app/repo --output console
+#   docker compose -f deploy/docker-compose.yml run --rm agentsmith security-scan --agent claude-default --source-path /app/repo --output console
 #
 # Build everything locally (from repo root):
 #   docker compose -f deploy/docker-compose.yml build                              # CLI + server (the default set)
@@ -14,11 +14,11 @@
 #   # ...or all profiles in one shot:
 #   docker compose -f deploy/docker-compose.yml --profile build-only --profile dashboard build
 #
-#   The bare `build` (no profile) builds the `agentsmith` (CLI) and `server`
-#   services only. Note:
-#     - `migrate` has no build of its own — it re-uses the agentsmith-cli image
-#       (init-container pattern, runs `database migrate`). Building `agentsmith`
-#       covers it.
+#   The bare `build` (no profile) builds the `agentsmith` (CLI), `migrate` and
+#   `server` services. Note:
+#     - `migrate` builds the SAME agentsmith-cli image as `agentsmith`
+#       (init-container pattern, runs `database migrate`); its own build block
+#       exists so `up --build` rebuilds it too.
 #     - `sandbox-agent` is profile-gated (`build-only`) because it is spawned
 #       per-run by the server, not started by compose — the bare `build` skips
 #       it on purpose. Build it explicitly before the first pipeline runs.
@@ -32,15 +32,23 @@
 # Two things to set before this template runs:
 #   1. The bind-mount target for /app/config below — replace the placeholder
 #      with the absolute path to the directory containing your agentsmith.yml.
-#   2. AGENTSMITH_VERSION / AGENT_VERSION in your .env (or shell) — pin to a
-#      released agent-smith tag (default below is the current release).
+#      p0349: for the SERVER this file is the BOOTSTRAP slice only — it reads
+#      just `persistence:` + `secrets:` from it. Real configuration (agents,
+#      trackers, repos, projects, triggers, settings) lives in the DB: edit it
+#      in the Config Studio (dashboard profile below), or seed an empty DB once:
+#        docker compose -f deploy/docker-compose.yml run --rm agentsmith config import /app/config/agentsmith.yml
+#      (The one-shot CLI pipelines keep reading the full file directly.)
+#   2. AGENTSMITH_VERSION in your .env (or shell) — ONE knob pins every image
+#      tag below to a released agent-smith version (default is the current
+#      release). AGENT_VERSION remains as a sandbox-agent-only override and
+#      falls back to AGENTSMITH_VERSION.
 
 services:
   agentsmith:
     build:
       context: ..
       dockerfile: src/backend/AgentSmith.Cli/Dockerfile
-    image: agentsmith-cli:${AGENTSMITH_VERSION:-0.50.0}
+    image: agentsmith-cli:${AGENTSMITH_VERSION:-0.129.0}
     restart: "no"
     env_file:
       - ../.env
@@ -48,6 +56,7 @@ services:
       - /path/to/your/agentsmith/config:/app/config   # REPLACE — directory containing your agentsmith.yml
       - ${SSH_KEY_PATH:-~/.ssh}:/home/agentsmith/.ssh:ro
       - /var/run/docker.sock:/var/run/docker.sock    # for Nuclei/Spectral tool containers
+      - agentsmith-db:/var/lib/agentsmith            # so `config import/export` and `database migrate` hit the server's DB
 
   # Carrier image consumed by the server's DockerSandboxFactory as an
   # init-container — never run as a long-lived service. Profile-gated so
@@ -63,13 +72,17 @@ services:
     build:
       context: ..
       dockerfile: src/backend/AgentSmith.Sandbox.Agent/Dockerfile
-    image: agent-smith-sandbox-agent:${AGENT_VERSION:-0.50.0}
+    image: agent-smith-sandbox-agent:${AGENT_VERSION:-${AGENTSMITH_VERSION:-0.129.0}}
     profiles: [build-only]
 
   redis:
     image: redis:7-alpine
     restart: unless-stopped
-    command: ["--maxmemory", "256mb", "--maxmemory-policy", "allkeys-lru", "--save", ""]
+    # AOF persistence: Redis carries live run state (queues, ledger, config
+    # epoch) — without it a redis restart wipes in-flight coordination.
+    command: ["--maxmemory", "256mb", "--maxmemory-policy", "allkeys-lru", "--save", "", "--appendonly", "yes"]
+    volumes:
+      - agentsmith-redis-data:/data
     ports:
       - "6379:6379"
     healthcheck:
@@ -86,8 +99,15 @@ services:
   # For an external DB (Postgres/SQLServer), point persistence.connection_string
   # in agentsmith.yml at it — this same job migrates it.
   migrate:
-    image: agentsmith-cli:${AGENTSMITH_VERSION:-0.50.0}
+    # Mirrors the agentsmith (CLI) build: without its own build block,
+    # `up --build` would run a stale pinned image against a newer schema.
+    build:
+      context: ..
+      dockerfile: src/backend/AgentSmith.Cli/Dockerfile
+    image: agentsmith-cli:${AGENTSMITH_VERSION:-0.129.0}
     restart: "no"
+    env_file:
+      - ../.env
     command: ["database", "migrate", "--config", "/app/config/agentsmith.yml"]
     volumes:
       - /path/to/your/agentsmith/config:/app/config   # REPLACE — same path as the agentsmith service above
@@ -97,6 +117,7 @@ services:
     build:
       context: ..
       dockerfile: src/backend/AgentSmith.Server/Dockerfile
+    image: agentsmith-server:${AGENTSMITH_VERSION:-0.129.0}
     restart: unless-stopped
     user: root  # docker socket access for SPAWNER_TYPE=docker (local dev)
     extra_hosts:
@@ -112,7 +133,7 @@ services:
       - REDIS_URL=redis:6379
       - SPAWNER_TYPE=${SPAWNER_TYPE:-docker}
       - ASPNETCORE_ENVIRONMENT=${ASPNETCORE_ENVIRONMENT:-Production}
-      - AGENTSMITH_IMAGE=${AGENTSMITH_IMAGE:-agentsmith-cli:${AGENTSMITH_VERSION:-0.50.0}}
+      - AGENTSMITH_IMAGE=${AGENTSMITH_IMAGE:-agentsmith-cli:${AGENTSMITH_VERSION:-0.129.0}}
       - IMAGE_PULL_POLICY=${IMAGE_PULL_POLICY:-IfNotPresent}
     ports:
       - "${SERVER_PORT:-8081}:8081"
@@ -127,13 +148,14 @@ services:
       retries: 3
       start_period: 15s
 
-  # Operator opt-in dashboard (p0169-pre).
+  # Operator opt-in dashboard (p0169-pre). Since p0349 it hosts the Config
+  # Studio — the primary surface for editing the configuration in the DB.
   # Run with: docker compose --profile dashboard up
   dashboard:
     build:
       context: ..
       dockerfile: src/dashboard/Dockerfile
-    image: agentsmith-dashboard:${AGENTSMITH_VERSION:-0.60.1}
+    image: agentsmith-dashboard:${AGENTSMITH_VERSION:-0.129.0}
     profiles: [dashboard]
     restart: unless-stopped
     environment:
@@ -157,7 +179,7 @@ services:
       start_period: 15s
 
   ollama:
-    image: ollama/ollama
+    image: ollama/ollama:0.12.0   # pinned — bump deliberately, `latest` drifts
     profiles: [local-models]
     volumes:
       - ollama-data:/root/.ollama
@@ -171,4 +193,6 @@ services:
 
 volumes:
   ollama-data:
-  agentsmith-db:   # p0246g: SQLite system-of-record, shared by the migrate job + the server
+  agentsmith-redis-data:   # Redis AOF data (see the redis service)
+  agentsmith-db:   # p0246g/p0349: SQLite system-of-record — run history AND the
+                   # operator's configuration — shared by migrate + server + CLI

--- a/deploy/k8s/10-deployment-dashboard.yaml
+++ b/deploy/k8s/10-deployment-dashboard.yaml
@@ -25,13 +25,13 @@ spec:
       # runAsNonRoot + runAsUser: 1000 below.
       containers:
         - name: dashboard
-          # Built from src/dashboard/Dockerfile. NOTE: next.config.ts bakes the
-          # backend URL in at BUILD time from the AGENTSMITH_BACKEND_URL build
-          # arg — build the image with
+          # Published from src/dashboard/Dockerfile. NOTE: next.config.ts bakes
+          # the backend URL in at BUILD time from the AGENTSMITH_BACKEND_URL
+          # build arg — when building your own image, pass
           #   --build-arg AGENTSMITH_BACKEND_URL=http://agentsmith-server
           # so the in-cluster Service is the rewrite target. The runtime env
           # below covers SSR/runtime reads of the same value.
-          image: agentsmith-dashboard:latest
+          image: holgerleichsenring/agentsmith-dashboard:0.129.0
           imagePullPolicy: IfNotPresent  # prod: Always
           ports:
             - name: http

--- a/deploy/k8s/12-pvc-persistence.yaml
+++ b/deploy/k8s/12-pvc-persistence.yaml
@@ -1,0 +1,30 @@
+# Agent Smith - Persistence PVC
+#
+# Backs /var/lib/agentsmith in the server pod: the SQLite system-of-record that
+# — since p0349 — ALSO holds the operator's entire configuration (agents,
+# trackers, repos, projects, triggers, settings entered in the Config Studio or
+# seeded via `agentsmith config import`). This volume MUST survive pod
+# restarts; an emptyDir here would wipe run history AND the configuration on
+# every reschedule.
+#
+# Numbering: kubectl applies the whole directory in one pass — the pod simply
+# stays Pending until this claim binds, so apply order does not matter.
+#
+# Not needed when persistence.connection_string points at an external
+# Postgres/SQL Server — then the DB lives outside the cluster and the server's
+# persistence mount only has to exist (see 8-deployment-server.yaml).
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: agentsmith-persistence
+  namespace: agentsmith
+  labels:
+    app.kubernetes.io/name: agentsmith
+    app.kubernetes.io/component: persistence
+spec:
+  accessModes:
+    - ReadWriteOnce            # SQLite is single-writer; replicas: 1
+  resources:
+    requests:
+      storage: 1Gi
+  # storageClassName: standard  # uncomment to pin a class; default class otherwise

--- a/deploy/k8s/3-configmap.yaml
+++ b/deploy/k8s/3-configmap.yaml
@@ -1,3 +1,19 @@
+# Agent Smith - Bootstrap ConfigMap (p0349 config-in-DB era)
+#
+# This file carries ONLY the bootstrap slice the server reads at boot:
+#   persistence:  which database to connect to (cannot live in the DB it describes)
+#   secrets:      the name -> ${ENV_VAR} map for secret resolution
+#
+# Everything else — agents, trackers, repos, connections, projects, triggers,
+# skills, settings — lives in the DATABASE. Configure it in the Config Studio
+# (the dashboard UI) or seed it once from a YAML file:
+#
+#   agentsmith config import <yaml>      # guarded: empty store, or --force
+#
+# There is NO auto-seed: a fresh (empty) DB boots UNCONFIGURED — pipelines and
+# pollers stay idle while the Config Studio is reachable to enter configuration.
+# Edit this ConfigMap by hand; it is small on purpose. A full agentsmith.yml
+# pasted in here would be silently ignored beyond the two sections above.
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -8,143 +24,22 @@ metadata:
     app.kubernetes.io/component: config
 data:
   agentsmith.yml: |
-    # This ConfigMap is generated from config/agentsmith.yml.
-    # Do not edit manually. Regenerate with:
-    #
-    #   ./deploy/k8s/regenerate-configmap.sh
-    #
+    # Bootstrap slice — the server reads ONLY persistence: + secrets: from this
+    # file. All other configuration lives in the DB (Config Studio / config import).
 
-    projects:
-      # --- Example 1: GitLab + Claude ---
-      my-gitlab-project:
-        source:
-          type: GitLab
-          url: https://gitlab.com/yourorg/your-repo
-          auth: token
-        tickets:
-          type: GitLab
-          url: https://gitlab.com/yourorg/your-repo
-          auth: token
-        agent:
-          type: Claude
-          model: claude-sonnet-4-20250514
-          retry:
-            max_retries: 5
-            initial_delay_ms: 2000
-            backoff_multiplier: 2.0
-            max_delay_ms: 60000
-          cache:
-            is_enabled: true
-            strategy: automatic
-          compaction:
-            is_enabled: true
-            threshold_iterations: 8
-            max_context_tokens: 80000
-            keep_recent_iterations: 3
-            summary_model: claude-haiku-4-5-20251001
-          models:
-            scout:
-              model: claude-haiku-4-5-20251001
-              max_tokens: 4096
-            primary:
-              model: claude-sonnet-4-20250514
-              max_tokens: 8192
-            planning:
-              model: claude-sonnet-4-20250514
-              max_tokens: 4096
-            summarization:
-              model: claude-haiku-4-5-20251001
-              max_tokens: 2048
-          pricing:
-            models:
-              claude-sonnet-4-20250514:
-                input_per_million: 3.0
-                output_per_million: 15.0
-                cache_read_per_million: 0.30
-              claude-haiku-4-5-20251001:
-                input_per_million: 0.80
-                output_per_million: 4.0
-                cache_read_per_million: 0.08
-        pipeline: fix-bug
-        coding_principles_path: .agentsmith/coding-principles.md
-        gitlab_trigger:
-          trigger_statuses: ["opened"]
-          done_status: "closed"
-          # p0318/p0391: where a run parks when it needs an answer from you.
-          # Required for a project running a park-capable pipeline (fix-bug here)
-          # and must sit OUTSIDE trigger_statuses.
-          needs_clarification_status: "waiting-for-answer"
-          pipeline_from_label:
-            bug: fix-bug
-            feature: add-feature
-            security: security-scan
-          default_pipeline: fix-bug
-          comment_keyword: "@agent-smith"
+    persistence:
+      provider: sqlite
+      connection_string: "Data Source=/var/lib/agentsmith/agentsmith.db"
+      # For a shared/HA deployment point at an external DB instead; the
+      # ${db_password} placeholder resolves via the secrets map below.
+      # provider: postgresql
+      # connection_string: "Host=postgres;Database=agentsmith;Username=agentsmith;Password=${db_password}"
+      # provider: sqlserver
+      # connection_string: "Server=mssql,1433;Database=agentsmith;User Id=agentsmith;Password=${db_password};Encrypt=True;TrustServerCertificate=True"
 
-      # --- Example 2: Azure DevOps + Azure OpenAI ---
-      my-azuredevops-project:
-        source:
-          type: AzureRepos
-          url: https://dev.azure.com/yourorg/your-project/_git/your-repo
-          auth: token
-        tickets:
-          type: AzureDevOps
-          organization: yourorg
-          project: your-project
-          auth: token
-        agent:
-          type: azure-openai
-          endpoint: https://your-instance.openai.azure.com
-          api_version: 2025-01-01-preview
-          retry:
-            max_retries: 5
-            initial_delay_ms: 2000
-            backoff_multiplier: 2.0
-            max_delay_ms: 60000
-          models:
-            scout:
-              model: gpt-4.1-mini
-              deployment: gpt-4o-mini-deployment
-              max_tokens: 4096
-            primary:
-              model: gpt-4.1
-              deployment: gpt4-1-deployment
-              max_tokens: 8192
-            planning:
-              model: gpt-4.1
-              deployment: gpt4-1-deployment
-              max_tokens: 4096
-            summarization:
-              model: gpt-4.1-mini
-              deployment: gpt-4o-mini-deployment
-              max_tokens: 2048
-          pricing:
-            models:
-              gpt-4.1:
-                input_per_million: 2.0
-                output_per_million: 8.0
-                cache_read_per_million: 0.50
-              gpt-4.1-mini:
-                input_per_million: 0.40
-                output_per_million: 1.60
-                cache_read_per_million: 0.10
-        pipeline: fix-bug
-        coding_principles_path: .agentsmith/coding-principles.md
-        azuredevops_trigger:
-          trigger_statuses: ["New", "Active"]
-          done_status: "Resolved"
-          needs_clarification_status: "Question"   # p0318/p0391 — see Example 1
-          pipeline_from_label:
-            bug: fix-bug
-            security-review: security-scan
-          default_pipeline: fix-bug
-          comment_keyword: "@agent-smith"
-
-    # p0325: skills ship embedded in the server image — no source/version pin
-    # needed. cache_dir points the materialized catalog at the mounted volume.
-    skills:
-      cache_dir: /var/lib/agentsmith/skills
-
+    # Secret NAME map: config placeholders (${github_token} etc.) resolve to
+    # these environment variables. The VALUES come from the agentsmith-secrets
+    # Secret (4-secret-template.yaml) — never write a real value here.
     secrets:
       anthropic_api_key: ${ANTHROPIC_API_KEY}
       azure_openai_api_key: ${AZURE_OPENAI_API_KEY}
@@ -156,3 +51,5 @@ data:
       azure_devops_token: ${AZURE_DEVOPS_TOKEN}
       jira_token: ${JIRA_TOKEN}
       jira_email: ${JIRA_EMAIL}
+      jira_webhook_secret: ${JIRA_WEBHOOK_SECRET}
+      db_password: ${DB_PASSWORD}

--- a/deploy/k8s/4-secret-template.yaml
+++ b/deploy/k8s/4-secret-template.yaml
@@ -45,3 +45,6 @@ stringData:
 
   # --- Infrastructure ---
   redis-url: "redis://redis:6379"  # Redis connection string inside the cluster
+  db-password: ""                # Persistence credential — referenced as ${db_password}
+                                 # in the bootstrap persistence.connection_string
+                                 # (3-configmap.yaml). Leave empty for the sqlite default.

--- a/deploy/k8s/8-deployment-server.yaml
+++ b/deploy/k8s/8-deployment-server.yaml
@@ -31,7 +31,7 @@ spec:
       # string, or run your own idempotent-SQL pipeline instead.
       initContainers:
         - name: migrate
-          image: agentsmith-cli:latest
+          image: holgerleichsenring/agent-smith-cli:0.129.0
           imagePullPolicy: IfNotPresent
           # p0348: call the DLL directly. The image ENTRYPOINT is a gosu
           # privilege-drop shim (docker-entrypoint.sh); under this pod's hardened
@@ -39,6 +39,14 @@ spec:
           # privileges, and there is no `agentsmith` executable on PATH — the k8s
           # `command:` overrides the ENTRYPOINT, so the shim never runs anyway.
           command: ["dotnet", "AgentSmith.Cli.dll", "database", "migrate", "--config", "/app/config/agentsmith.yml"]
+          # For an external DB whose connection string uses ${db_password},
+          # uncomment so the placeholder resolves during migration:
+          # env:
+          #   - name: DB_PASSWORD
+          #     valueFrom:
+          #       secretKeyRef:
+          #         name: agentsmith-secrets
+          #         key: db-password
           volumeMounts:
             - name: config
               mountPath: /app/config
@@ -47,7 +55,7 @@ spec:
               mountPath: /var/lib/agentsmith
       containers:
         - name: server
-          image: agentsmith-server:latest
+          image: holgerleichsenring/agent-smith-server:0.129.0
           imagePullPolicy: IfNotPresent  # prod: Always
           ports:
             - name: http
@@ -78,7 +86,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: AGENTSMITH_IMAGE
-              value: "agentsmith-cli:latest"
+              value: "holgerleichsenring/agent-smith-cli:0.129.0"
             - name: IMAGE_PULL_POLICY
               value: "IfNotPresent"      # prod: Always
             - name: K8S_SECRET_NAME
@@ -100,6 +108,13 @@ spec:
               value: "512Mi"
             - name: JobSpawner__Resources__MemoryLimit
               value: "2Gi"
+            # For an external DB whose connection string uses ${db_password},
+            # uncomment (mirrors the migrate init container above):
+            # - name: DB_PASSWORD
+            #   valueFrom:
+            #     secretKeyRef:
+            #       name: agentsmith-secrets
+            #       key: db-password
           volumeMounts:
             - name: config
               mountPath: /app/config
@@ -142,11 +157,14 @@ spec:
         - name: skills-cache
           emptyDir:
             sizeLimit: 64Mi
-        # p0246g: holds the SQLite system-of-record (the init container migrates
-        # it, the server reads it). emptyDir is fine for a test cluster; for run
-        # history that survives a pod restart use a PersistentVolumeClaim here, or
-        # point persistence.connection_string at an external Postgres/SQLServer.
+        # p0246g/p0349: holds the SQLite system-of-record (the init container
+        # migrates it, the server reads it). Since p0349 this DB is ALSO where
+        # the operator's CONFIGURATION lives (everything entered in the Config
+        # Studio or seeded via `agentsmith config import`) — an emptyDir here
+        # would wipe that configuration and all run history on EVERY pod
+        # restart. Do not downgrade this to emptyDir. Alternative: point
+        # persistence.connection_string at an external Postgres/SQLServer.
         - name: persistence
-          emptyDir:
-            sizeLimit: 256Mi
+          persistentVolumeClaim:
+            claimName: agentsmith-persistence   # 12-pvc-persistence.yaml
       restartPolicy: Always

--- a/deploy/k8s/9-ingress.yaml
+++ b/deploy/k8s/9-ingress.yaml
@@ -60,7 +60,9 @@ spec:
                 name: agentsmith-server
                 port:
                   name: http
-          # Everything else is the dashboard UI (Next.js).
+          # Everything else is the dashboard UI (Next.js) — including the
+          # Config Studio, the primary configuration surface since p0349 moved
+          # configuration into the DB.
           - path: /
             pathType: Prefix
             backend:

--- a/deploy/k8s/examples/airgap-deployment.yaml
+++ b/deploy/k8s/examples/airgap-deployment.yaml
@@ -1,28 +1,43 @@
 # Example: agent-smith server in an air-gapped environment, pulling a skills
 # catalog OTHER than the one embedded in the image.
 #
-# p0325: skills ship embedded in the server image, so a plain air-gapped
-# install needs NO skills config and no mirror at all — the embedded catalog
-# materializes offline. Use this example only when you must run a different
-# catalog version than the image carries: the server then pulls from an
-# internal mirror. The default GitHub release URL is overridden via
+# p0325: skills ship embedded in the server image (catalog v4.0.0), so a plain
+# air-gapped install needs NO skills config and no mirror at all — the embedded
+# catalog materializes offline. Use this example only when you must run a
+# different catalog version than the image carries: the server then pulls from
+# an internal mirror. The default GitHub release URL is overridden via
 # AGENTSMITH_SKILLS_REPOSITORY_URL — the same release semantics
 # (vX.Y.Z release path layout) just point at a different host.
+#
+# p0349: the skills BLOCK is configuration, and configuration lives in the DB —
+# the bootstrap file below carries only persistence + secrets. Set the skills
+# override in the Config Studio, or seed it once from the skills-override.yml
+# shipped in this ConfigMap:
+#
+#   agentsmith config import /app/config/skills-override.yml
+#
+# (guarded: empty store, or --force; run it from the CLI image with the same
+# config mount + persistence volume as the server).
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: agentsmith-config-airgap
   namespace: agentsmith
 data:
+  # Bootstrap slice — the ONLY part the server reads at boot (p0349).
   agentsmith.yml: |
-    skills:
-      source: default          # still uses the version-pinned default flow
-      version: v1.0.0          # pinned release on the internal mirror
-      cache_dir: /var/lib/agentsmith/skills
-      sha256: ""               # optional; recommended in airgap to detect mirror tampering
-    projects: {}
+    persistence:
+      provider: sqlite
+      connection_string: "Data Source=/var/lib/agentsmith/agentsmith.db"
     secrets:
       anthropic_api_key: ${ANTHROPIC_API_KEY}
+  # One-time import file for the mirror override (see head comment).
+  skills-override.yml: |
+    skills:
+      source: default          # still uses the version-pinned default flow
+      version: v4.0.0          # pinned release on the internal mirror
+      cache_dir: /var/lib/agentsmith/skills
+      sha256: ""               # optional; recommended in airgap to detect mirror tampering
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -40,9 +55,30 @@ spec:
         app: agentsmith-server
     spec:
       serviceAccountName: agentsmith
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+      # Apply relational-persistence migrations BEFORE the server starts (see
+      # 8-deployment-server.yaml for the full rationale). In airgap, mirror the
+      # CLI image into the internal registry alongside the server image.
+      initContainers:
+        - name: migrate
+          image: holgerleichsenring/agent-smith-cli:0.129.0
+          imagePullPolicy: IfNotPresent
+          # p0348: call the DLL directly — the image ENTRYPOINT is a gosu shim
+          # that cannot drop privileges under this hardened securityContext.
+          command: ["dotnet", "AgentSmith.Cli.dll", "database", "migrate", "--config", "/app/config/agentsmith.yml"]
+          volumeMounts:
+            - name: config
+              mountPath: /app/config
+              readOnly: true
+            - name: persistence
+              mountPath: /var/lib/agentsmith
       containers:
         - name: server
-          image: holgerleichsenring/agent-smith-server:latest
+          image: holgerleichsenring/agent-smith-server:0.129.0
           ports:
             - containerPort: 8081
           env:
@@ -56,6 +92,11 @@ spec:
               readOnly: true
             - name: skills-cache
               mountPath: /var/lib/agentsmith/skills
+            - name: persistence
+              mountPath: /var/lib/agentsmith
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
       volumes:
         - name: config
           configMap:
@@ -63,3 +104,9 @@ spec:
         - name: skills-cache
           emptyDir:
             sizeLimit: 64Mi
+        # p0349: the DB on this volume holds the operator's CONFIGURATION (plus
+        # run history) — an emptyDir would wipe it on every pod restart. Reuses
+        # the claim from ../12-pvc-persistence.yaml.
+        - name: persistence
+          persistentVolumeClaim:
+            claimName: agentsmith-persistence

--- a/deploy/k8s/examples/path-mode-deployment.yaml
+++ b/deploy/k8s/examples/path-mode-deployment.yaml
@@ -3,6 +3,16 @@
 # Use case: GitOps environments where the catalog is provisioned out-of-band
 # (e.g. ArgoCD pre-sync hook populates a PVC, or an InitContainer copies from a
 # bundled image). The server itself does no download — it just trusts the mount.
+#
+# p0349: the skills BLOCK is configuration, and configuration lives in the DB —
+# the bootstrap file below carries only persistence + secrets. Set skills to
+# path mode in the Config Studio, or seed it once from the skills-override.yml
+# shipped in this ConfigMap:
+#
+#   agentsmith config import /app/config/skills-override.yml
+#
+# (guarded: empty store, or --force; run it from the CLI image with the same
+# config mount + persistence volume as the server).
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -22,13 +32,18 @@ metadata:
   name: agentsmith-config-pathmode
   namespace: agentsmith
 data:
+  # Bootstrap slice — the ONLY part the server reads at boot (p0349).
   agentsmith.yml: |
+    persistence:
+      provider: sqlite
+      connection_string: "Data Source=/var/lib/agentsmith/agentsmith.db"
+    secrets:
+      anthropic_api_key: ${ANTHROPIC_API_KEY}
+  # One-time import file for path mode (see head comment).
+  skills-override.yml: |
     skills:
       source: path
       path: /var/lib/agentsmith/skills
-    projects: {}
-    secrets:
-      anthropic_api_key: ${ANTHROPIC_API_KEY}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -46,9 +61,29 @@ spec:
         app: agentsmith-server
     spec:
       serviceAccountName: agentsmith
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+      # Apply relational-persistence migrations BEFORE the server starts (see
+      # 8-deployment-server.yaml for the full rationale).
+      initContainers:
+        - name: migrate
+          image: holgerleichsenring/agent-smith-cli:0.129.0
+          imagePullPolicy: IfNotPresent
+          # p0348: call the DLL directly — the image ENTRYPOINT is a gosu shim
+          # that cannot drop privileges under this hardened securityContext.
+          command: ["dotnet", "AgentSmith.Cli.dll", "database", "migrate", "--config", "/app/config/agentsmith.yml"]
+          volumeMounts:
+            - name: config
+              mountPath: /app/config
+              readOnly: true
+            - name: persistence
+              mountPath: /var/lib/agentsmith
       containers:
         - name: server
-          image: holgerleichsenring/agent-smith-server:latest
+          image: holgerleichsenring/agent-smith-server:0.129.0
           ports:
             - containerPort: 8081
           env:
@@ -61,6 +96,11 @@ spec:
             - name: skills
               mountPath: /var/lib/agentsmith/skills
               readOnly: true
+            - name: persistence
+              mountPath: /var/lib/agentsmith
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
       volumes:
         - name: config
           configMap:
@@ -68,3 +108,9 @@ spec:
         - name: skills
           persistentVolumeClaim:
             claimName: agentsmith-skills-pvc
+        # p0349: the DB on this volume holds the operator's CONFIGURATION (plus
+        # run history) — an emptyDir would wipe it on every pod restart. Reuses
+        # the claim from ../12-pvc-persistence.yaml.
+        - name: persistence
+          persistentVolumeClaim:
+            claimName: agentsmith-persistence

--- a/deploy/k8s/regenerate-configmap.sh
+++ b/deploy/k8s/regenerate-configmap.sh
@@ -1,23 +1,26 @@
 #!/usr/bin/env bash
-# Regenerate the k8s ConfigMap from config/agentsmith.yml.
-# Run from the repository root:
+# RETIRED (p0349): this script used to regenerate the k8s ConfigMap from a full
+# config/agentsmith.yml. Since p0349 the ConfigMap carries ONLY the bootstrap
+# slice (persistence + secrets) — the server ignores everything else in the
+# mounted file, and copying a full config here would leak agents/trackers/
+# projects into a ConfigMap where they are dead weight (and possibly sensitive).
 #
-#   ./deploy/k8s/regenerate-configmap.sh
-#
+# The script deliberately does nothing rather than extract the slice in bash:
+# the bootstrap slice is a dozen hand-maintained lines in 3-configmap.yaml.
 set -euo pipefail
 
-REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
-CONFIG_FILE="${REPO_ROOT}/config/agentsmith.yml"
-OUTPUT_FILE="${REPO_ROOT}/deploy/k8s/3-configmap.yaml"
+cat >&2 <<'EOF'
+regenerate-configmap.sh is retired (p0349: configuration lives in the DB).
 
-if [ ! -f "$CONFIG_FILE" ]; then
-  echo "Error: $CONFIG_FILE not found." >&2
-  exit 1
-fi
-
-kubectl create configmap agentsmith-config \
-  --from-file=agentsmith.yml="$CONFIG_FILE" \
-  -n agentsmith \
-  --dry-run=client -o yaml > "$OUTPUT_FILE"
-
-echo "ConfigMap written to $OUTPUT_FILE"
+What to do instead:
+  * Bootstrap (persistence + secrets):
+      edit deploy/k8s/3-configmap.yaml BY HAND — it holds only the
+      `persistence:` and `secrets:` sections, the only parts the server
+      reads from the mounted file.
+  * Everything else (agents, trackers, repos, projects, triggers, settings):
+      configure in the Config Studio (dashboard), or seed an empty DB once:
+        agentsmith config import <your-agentsmith.yml>
+      Export the DB back to YAML for backup/DR:
+        agentsmith config export --output agentsmith.yml
+EOF
+exit 1


### PR DESCRIPTION
The tracked deployment artifacts were several eras behind the code. This brings them to the current state:

- **k8s ConfigMap** rewritten as the p0349 bootstrap slice (`persistence:` + `secrets:` — the only keys the server reads from file at boot); head comment explains Config Studio / `agentsmith config import`, no auto-seed.
- **Persistence emptyDir → PVC** (new `12-pvc-persistence.yaml`): since p0349 the DB holds the operator's configuration — an emptyDir wipes it on every pod restart.
- **Image pins**: `:latest` / 0.50.0 / 0.60.1 → org-prefixed 0.129.0 everywhere (verified live on Docker Hub); ollama pinned.
- **compose example**: one `AGENTSMITH_VERSION` knob, migrate gets `env_file` + build block, redis gets AOF + volume, header rewritten for the bootstrap-file/Config-Studio era, CLI example invocation fixed against the real CLI surface.
- **examples/** (airgap, path-mode): migrate init container, securityContext, bootstrap-slice configs, skills pin v4.0.0.
- **`regenerate-configmap.sh` retired** (would leak a full config into a ConfigMap the server ignores).
- **`config/agentsmith.example.yml`**: boot-surface banner, retired pipeline names → `code`, version pins.

Known pre-existing gap (not addressed here): the k8s server deployment injects only Slack/Redis env — `${ANTHROPIC_API_KEY}`-style secret refs are not wired as envFrom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)