### PR TITLE
fix: a question in a repair pass is still asked (p0449)

### DIFF
--- a/.agentsmith/decisions/p0449.yaml
+++ b/.agentsmith/decisions/p0449.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=../decision.schema.json
+phase: p0449
+
+decisions:
+  - category: Implementation
+    chose: "Add MasterOpenQuestions to the repair block, in block order"
+    over: "Posting the question from the verdict step, or parking on the bag flag"
+    reason: |
+      The repair is a repetition of part of the phase block. The step that posts a question
+      is already in that block and already does exactly this job; repeating it is the
+      change with no new mechanism. The alternatives would have added a second way to post
+      a question, which is how the two drift.
+  - category: Process
+    chose: "Assert the count against RepairBlock.Count instead of a literal"
+    reason: |
+      The old test carried HaveCount(3) — a second copy of the list, which had to be
+      edited the moment the list changed. It now tracks the block it is about.
+  - category: Process
+    chose: "Treat this as the first cell of the position-times-shape cross"
+    reason: |
+      p0391 tested "the master asks" at ONE position. p0438 broke it at another. Five of
+      today's defects have that shape: a behaviour proven at one seam and unguarded at the
+      rest. The harness that would have caught this already exists; the cases do not.

--- a/.agentsmith/phases/done/p0449-a-question-in-a-repair-pass-is-still-asked.yaml
+++ b/.agentsmith/phases/done/p0449-a-question-in-a-repair-pass-is-still-asked.yaml
@@ -1,0 +1,43 @@
+# yaml-language-server: $schema=../../phase-spec.schema.json
+phase: p0449
+goal: "A repair pass that asks reaches the operator, exactly as a first pass does."
+
+applies_to: "backend"
+
+requires:
+  - p0438
+
+decisions:
+  - key: |
+      THE DOOR p0391 OPENED WAS BRICKED UP AGAIN, ONE POSITION LATER. p0391 proved the
+      master's way out works: it asks, the question reaches the ticket, the run parks —
+      two harness tests, on fix-bug and add-feature, in the FIRST pass. p0438 then built
+      the repair block out of three of the phase block's six steps and left the question
+      step out, so the same behaviour at the same seam one pass later had no way through.
+  - key: |
+      LIVE RUN 459d. The first pass left two criteria outstanding, the repair ran, its step
+      reported "awaiting_user_input: master asked for clarification mid-run", and the next
+      step was Commit. The question stayed in the bag, OpenQuestionsAwaitingAnswer was
+      never set, RunCheckpoints held zero rows, and the run failed on the very criteria it
+      had asked about. Nobody ever saw the question.
+  - key: |
+      IT PUNISHES THE BEHAVIOUR THE GATE EXISTS TO PRODUCE. Asking rather than guessing is
+      what the whole clarification path is for. It must not be worth less on the second
+      pass than on the first.
+  - key: |
+      THE COUNT IN THE OLD TEST WAS A SECOND COPY OF THE LIST. RepairSteps_CarryThePhase
+      asserted HaveCount(3) — a literal that had to be edited the moment the block changed.
+      It now tracks RepairBlock.Count, so the next member is a one-line change and not a
+      two-line one.
+
+steps:
+  - id: the-repair-can-be-answered
+    action: "Repeat the question step in the repair block, in the order the phase runs it."
+
+tests:
+  - "ARepairThatAsks_StillReachesTheOperator"
+  - "TheRepairRepeatsTheBlocksOwnOrder"
+  - "EveryRepairedStep_IsAStepThePhaseActuallyRuns"
+
+done:
+  - "A question raised during a repair pass reaches the ticket and parks the run."

--- a/src/backend/AgentSmith.Application/Services/Specs/PhaseVerdict.cs
+++ b/src/backend/AgentSmith.Application/Services/Specs/PhaseVerdict.cs
@@ -82,13 +82,23 @@ public static class PhaseVerdict
     ];
 
     /// <summary>
-    /// The part of the phase block a repair repeats: work, put on the branch, judged again.
-    /// Every name here is a member of the block itself — a repair that repeated a step the
-    /// phase never runs would be inventing a pipeline, and RepairBlockRuleTests says so.
+    /// The part of the phase block a repair repeats: work, anything it needs to ask, put on
+    /// the branch, judged again. Every name here is a member of the block itself — a repair
+    /// that repeated a step the phase never runs would be inventing a pipeline, and the
+    /// suite says so.
+    /// <para>
+    /// p0449: the question step used to be missing. On live run 459d the repair reported
+    /// "awaiting_user_input: master asked for clarification mid-run" and the next step was
+    /// Commit — the question stayed in the bag, the parking flag was never set, no
+    /// checkpoint was written, and the run failed on the criteria it had asked about.
+    /// Asking rather than guessing must not be worth less on the second pass than on the
+    /// first.
+    /// </para>
     /// </summary>
     public static IReadOnlyList<string> RepairBlock { get; } =
     [
         CommandNames.AgenticMaster,
+        CommandNames.MasterOpenQuestions,
         CommandNames.CommitPhaseWork,
         CommandNames.VerifyPhase,
     ];

--- a/tests/AgentSmith.Tests/Specs/PhaseRepairTests.cs
+++ b/tests/AgentSmith.Tests/Specs/PhaseRepairTests.cs
@@ -111,7 +111,9 @@ public sealed class PhaseRepairTests
     public void RepairSteps_CarryThePhaseTheyRepair()
         => PhaseVerdict.RepairSteps("p19106a").Should()
             .OnlyContain(c => c.PhaseId == "p19106a")
-            .And.HaveCount(3);
+            // The count tracks the block: a literal here would have to be edited every
+            // time the block changes, and p0449 is exactly that moment.
+            .And.HaveCount(PhaseVerdict.RepairBlock.Count);
 
     /// <summary>
     /// A run outside a phase sequence has no phase to belong to, and inventing one would put
@@ -129,4 +131,34 @@ public sealed class PhaseRepairTests
     [Fact]
     public void EveryRepairedStep_IsAStepThePhaseActuallyRuns()
         => PhaseVerdict.RepairBlock.Should().BeSubsetOf(PipelinePresets.CodePhaseBlock);
+
+    /// <summary>
+    /// p0449: a repair pass can ask, so a repair pass must be able to be answered.
+    /// <para>
+    /// Live run 459d: the first pass left two criteria outstanding, the repair ran, and its
+    /// step reported "awaiting_user_input: master asked for clarification mid-run". The
+    /// next step was Commit. The repair repeated work, branch and verdict, and skipped the
+    /// one step through which a question reaches the operator — so the question stayed in
+    /// the bag, the parking flag was never set, no checkpoint was written, and the run went
+    /// on to fail on the very criteria it had asked about.
+    /// </para>
+    /// <para>
+    /// Asking rather than guessing is the behaviour the whole gate exists to produce. It
+    /// must not be worth less on the second pass than on the first.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void ARepairThatAsks_StillReachesTheOperator()
+        => PhaseVerdict.RepairBlock.Should().Contain(CommandNames.MasterOpenQuestions,
+            "a question the repair captured and nobody posts is a question nobody asked");
+
+    /// <summary>
+    /// The repeated steps stay in the order the phase runs them: the question is posted
+    /// after the work that raised it and before the branch is judged.
+    /// </summary>
+    [Fact]
+    public void TheRepairRepeatsTheBlocksOwnOrder()
+        => PhaseVerdict.RepairBlock.Should().ContainInOrder(
+            CommandNames.AgenticMaster, CommandNames.MasterOpenQuestions,
+            CommandNames.CommitPhaseWork, CommandNames.VerifyPhase);
 }


### PR DESCRIPTION
**The door p0391 opened was bricked up again, one position later.**

p0391 proved the master's way out works: it asks, the question reaches the ticket, the run parks — two harness tests, on `fix-bug` and `add-feature`, in the **first** pass. p0438 then built the repair block out of three of the phase block's six steps and left the question step out, so the same behaviour at the same seam one pass later had no way through.

Live run `459d`:

```
23  Build and test        2 criterion(s) outstanding; one repair pass follows
24  Run master skill      awaiting_user_input: master asked for clarification mid-run
25  Commit the phase's work     ← the question is never posted
26  Build and test        FAILED — the criteria it had asked about
```

The question stayed in the bag, `OpenQuestionsAwaitingAnswer` was never set, `RunCheckpoints` held zero rows, and nobody ever saw it. It also destroyed the evidence for a separate question the operator asked afterwards — what did it want to know? Unanswerable.

It punishes the behaviour the gate exists to produce. Asking rather than guessing must not be worth less on the second pass than on the first.

The old `RepairSteps` test carried `HaveCount(3)` — a second copy of the list, which had to be edited the moment the list changed. It now tracks `RepairBlock.Count`.

**Honest limit:** this is correct on inspection and **not yet proven**. The harness case that would prove it is the subject of p0450 and does not yet drive the pipeline into a repair — so it is deliberately not shipped as a green claim.

3881 backend tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)