### PR TITLE
fix: a diagnostic page is read at the width of the pages around it

### DIFF
--- a/src/dashboard/src/app/config/[[...slug]]/page.tsx
+++ b/src/dashboard/src/app/config/[[...slug]]/page.tsx
@@ -66,7 +66,7 @@ export default function ConfigPage({ params }: PageProps) {
 // parity page scope, so this phase changed where they live and nothing they show.
 function DiagnosticPage({ children }: { children: React.ReactNode }) {
   return (
-    <div className="mock-shell mock-system" data-testid="diagnostic-page">
+    <div className="mock-shell mock-system mock-diagnostic" data-testid="diagnostic-page">
       <main className="main">{children}</main>
     </div>
   );

--- a/src/dashboard/src/app/config/__tests__/page.test.tsx
+++ b/src/dashboard/src/app/config/__tests__/page.test.tsx
@@ -43,6 +43,9 @@ describe("Configuration route", () => {
     expect(await screen.findByTestId("installation-view")).toBeInTheDocument();
     // The same parity page scope they rendered inside under /system.
     expect(screen.getByTestId("diagnostic-page").className).toContain("mock-system");
+    // A diagnostic page is read at the width of the other /config pages: its cards put
+    // the value hard right, so the subsystem streams' 1500px strands it off screen.
+    expect(screen.getByTestId("diagnostic-page").className).toContain("mock-diagnostic");
 
     renderConfig(["connection-check"]);
     expect(await screen.findByTestId("connections-view")).toBeInTheDocument();

--- a/src/dashboard/src/styles/mock-parity.css
+++ b/src/dashboard/src/styles/mock-parity.css
@@ -688,6 +688,10 @@
    need (.stateline, .errline, .tail-line, .lrow log rows) and are marked.
    ========================================================================= */
 .mock-system .main { padding: 24px 34px 60px; max-width: 1500px; }
+/* A diagnostic page under /config is read like the other /config pages, not like a
+   subsystem's event stream: its cards put the label left and the value hard right, so
+   1500px leaves a screen's width between "Provider" and "sqlite". */
+.mock-system.mock-diagnostic .main { max-width: 1000px; }
 @media (max-width: 640px) { .mock-system .main { padding: 18px 16px 40px; } }
 .mock-system .m-head { display: flex; align-items: flex-end; gap: 16px; margin-bottom: 16px; flex-wrap: wrap; }
 .mock-system .m-head .mt { flex: 1; }


### PR DESCRIPTION
The installation page carried `.mock-system`, whose 1500px column exists for the subsystem event streams.

Its cards put the label on the left and the value hard right (`.ec-right { margin-left: auto }`), so on a wide display "Provider" and `sqlite` sat most of a screen apart and the value ran off the edge entirely — the operator reported it from a screenshot where the Database tiles look empty.

It now reads at the 1000px the other `/config` pages use, scoped to a new `.mock-diagnostic` class so the subsystem streams keep the width they need. One assertion added on the route test.

Dashboard: 919 tests, 173 files, green. Phase gate passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)