### PR TITLE
docs: three specs for the target-repo artifact cut (c56e, 72fd, 3d2a)

### DIFF
--- a/.agentsmith/phases/planned/2026-09-08-c56e-record-run-directory-not-committed.yaml
+++ b/.agentsmith/phases/planned/2026-09-08-c56e-record-run-directory-not-committed.yaml
@@ -61,6 +61,16 @@ decisions:
       naming a file that will no longer exist, and so does PrReviewCommentRenderer, which today
       tells a reviewer to open `.agentsmith/runs/{runId}/result.md`.
   - key: |
+      A TICKET COMMENT IS NOT MARKDOWN, ON EITHER PROVIDER. result.md is Markdown — headings,
+      backticked paths, tables. Ticket comments in this system are not: they are authored in a
+      small HTML subset (<b>, <br/>, <code>, HTML-encoded text), which FailureTicketComment
+      already writes and JiraAdfRenderer.FromCommentText converts into real ADF, because Jira
+      rejects wiki markup and shows HTML as literal text. Azure DevOps renders the same way —
+      a pasted '##' stays a '##'. So the result reaches the ticket through a renderer into that
+      subset, not by moving the Markdown bytes; the Markdown original stays what the artifact
+      store holds and the dashboard shows. One body, two renderings, and the ticket gets the one
+      its provider can display.
+  - key: |
       ONLY THE PATHS THAT ACTUALLY RENDER A RESULT. PipelineErrorHandler terminalises a ticket
       from three entry points — HandleStepFailureAsync, HandleFatalFailureAsync and
       FinalizeFailedTicketAsync — and only the first is preceded by the finalizer tail that
@@ -86,6 +96,8 @@ steps:
     action: "WriteRunResultHandler stops writing result.md and the dependency-audit json into the repo, keeping every artifact-store write; the plan.md read-back is unchanged."
   - id: the-ticket-carries-the-result
     action: "Post the bounded, secret-scanned result body as the ticket comment from TicketLifecycle.FinalizeAsync and from PipelineErrorHandler's step-failure path, with a dashboard link for the tail; the two red paths that render no result keep their present message."
+  - id: the-comment-speaks-the-comment-dialect
+    action: "Render the result body into the HTML comment subset FailureTicketComment already uses, so Jira converts it to ADF and Azure DevOps displays it; the Markdown original is unchanged in the artifact store."
   - id: a-run-with-no-diff-still-opens-its-pr
     action: "Open the record-carrier PR without requiring a stageable commit, so a run whose only artifact was the run record does not silently end without a pull request."
   - id: no-pointer-at-a-file-that-is-gone
@@ -105,6 +117,7 @@ tests:
   - "Finalize_AGreenRun_PostsTheResultBodyAsTheComment"
   - "PipelineError_AStepFailure_PostsTheResultBodyAsTheComment"
   - "PipelineError_AFatalFailureWithNoRenderedResult_PostsTodaysMessage"
+  - "TicketComment_TheResultBody_IsRenderedInTheCommentSubsetNotMarkdown"
   - "TicketComment_ABodyOverTheProviderLimit_IsBoundedAndLinksTheDashboard"
   - "TicketComment_ABodyCarryingASecretPattern_IsRedactedNotPosted"
   - "PrReviewComment_TheFullReportPointer_NamesTheDashboardRun"
@@ -115,6 +128,7 @@ done:
   - "result.md and the dependency-audit json exist in the artifact store and nowhere in the target repo"
   - "the phase record, the context.yaml index line and the memory narrative are still committed"
   - "a green run and a step-failure run each leave the result body as a ticket comment, secret-scanned and within the provider's limit"
+  - "no ticket comment carries raw Markdown headings or fences on Jira or Azure DevOps"
   - "a run whose only artifact was the run record still opens a pull request"
   - "no artifact, comment or PR body names .agentsmith/runs/<id>/result.md"
   - "compile-wiki no longer exists as a command"

--- a/.agentsmith/phases/planned/2026-09-08-c56e-record-run-directory-not-committed.yaml
+++ b/.agentsmith/phases/planned/2026-09-08-c56e-record-run-directory-not-committed.yaml
@@ -1,0 +1,121 @@
+# yaml-language-server: $schema=../../phase-spec.schema.json
+phase: 2026-09-08-c56e
+goal: "No run commits a run directory: nothing under .agentsmith/runs/ is staged by any writer, result.md stops being written to the repo, and its body reaches the operator as a bounded ticket comment."
+
+applies_to: "backend (CommitAndPRHandler, RepoWorkPusher, PersistWorkBranchHandler, InitCommitHandler, WriteRunResultHandler, RunRecordPaths, TicketLifecycle, PipelineErrorHandler, PrReviewCommentRenderer, CompileKnowledgeHandler, AzureReposSourceProvider) + skills catalog (the coding master's run-record instruction)"
+
+requires:
+  - 2026-09-07-f420
+
+scope:
+  in: "Every writer that can put .agentsmith/runs/ into a commit stops doing so — CommitAndPRHandler's stage-all plus force-stage, RepoWorkPusher's checkpoints, PersistWorkBranchHandler's parked/failed push, InitCommitHandler; result.md and the dependency-audit json are no longer written into the repo at all, only into the artifact store; the rendered result body is posted as the ticket comment on every path that renders one, passed through the secret scanner first and bounded to the provider's comment limit with a dashboard link for the tail; the record-carrier PR keeps opening for a run with nothing else to commit; PrReviewCommentRenderer and the Azure Repos truncation marker stop naming a file that will not exist; compile-wiki is retired."
+  out: "Relocating the spec set out of .agentsmith/specs/ and turning the phase record from a write into a move. That is the successor phase — 'the derived set is the phase directory' — and it is BLOCKED on one question this phase does not answer: what carries the executed-phase index, the segment-to-phase carry map, the revision list and the handback state on the branch once set.yaml is gone, given SpecSetReader is index-first and TicketSpecSet is deliberately a pointer and not a copy. It must also require 2026-09-07-e9a2, which renames the done file. Also out: removing specs/ directories already merged into target trunks; the decisions/ findability axis, which is a cut on THIS repo. The context.yaml state.done line and the .agentsmith/memory/ narrative are KEPT and untouched — they are records, not run scratch."
+
+decisions:
+  - key: |
+      THE COMMITTED COPY HAS A DURABLE TWIN AND ONE READER, WHICH IS RETIRED. IRunArtifactStore
+      exists because "the on-disk write inside the sandbox / target repo is not reachable from
+      the server", and DbRunArtifactStore (p0246e) mirrors result_md / plan_md / analyze_md /
+      spec_md into the database so they survive a restart AND a Redis flush. The dashboard reads
+      the store. The one thing that reads the committed copies is CompileKnowledgeHandler, which
+      walks <repo>/.agentsmith/runs/*/{plan.md,result.md} to build a wiki; it is reachable only
+      as the compile-wiki CLI verb and sits in no pipeline preset. Leaving it registered would
+      ship a verb that is a permanent no-op, so it goes with the directory it reads — a silent
+      empty result is worse than a removed command.
+  - key: |
+      THE WRITE STAYS, THE COMMIT GOES. plan.md is not dead weight during the run: the master
+      writes it into the sandbox tree via {RunRecordDir} and WriteRunResultHandler reads it back
+      to fill the durable plan slot the Plan beat renders. Cutting the write would cut the beat.
+      Only the staging changes. result.md is different — nothing reads it back, so it stops
+      being written to the repo entirely and only the store write remains.
+  - key: |
+      FOUR WRITERS, NOT ONE, AND THE FORCE-STAGE IS LOAD-BEARING. The run record reaches a commit
+      through CommitAndPRHandler (StageAllAsync then ForceStageAsync of the WHOLE ".agentsmith"
+      path), RepoWorkPusher's mid-run checkpoints (which see the master's freshly written
+      plan.md/decisions.md as working changes), PersistWorkBranchHandler's parked/failed push and
+      InitCommitHandler. A filter on one of them leaves three holes. The force-stage is why a
+      repo that gitignores .agentsmith still gets a PR (p0234) and why the p0228 "nothing staged"
+      guard is rare — so the exclusion is an UNSTAGE after both staging calls, and the force-stage
+      is retargeted at the paths that remain records: phases/done/, contexts/, memory/.
+  - key: |
+      A RUN WITH NOTHING ELSE TO COMMIT MUST STILL OPEN ITS PR. Today the run record is what
+      guarantees a stageable diff; without it CommitAndPRHandler returns SkippedNoChanges and no
+      PR is opened, and the draft spec PR is never marked ready. A ticketed run writes a phase
+      record, so the common case still stages. The case that does not — a run with no phase spec
+      that changed nothing — keeps its record-carrier PR by opening it without requiring a
+      commit, because "at least one PR, no obscure splitting" is the rule this must not repeal.
+  - key: |
+      THE OUTBOUND COMMENT IS SCANNED, BECAUSE TODAY THE COMMIT GATE IS THE SCAN. result.md
+      leaves the sandbox through CommitAndPRHandler's staged-diff scan, which ABORTS the commit
+      on a secret-pattern match — one of only two ISecretPatternScanner call sites. The body
+      carries the dialogue trail, the per-skill breakdown and the execution trail, i.e. command
+      output tails and model text. Moving it to a ticket comment without a scan would replace a
+      gate that blocks with a channel that publishes. The comment is scanned before it is posted
+      and a match redacts rather than blocks, because a failed run must still say why it failed.
+  - key: |
+      THE COMMENT IS BOUNDED, AND THE MARKER THAT NAMES result.md CHANGES WITH IT. Azure Repos
+      caps a PR description at 4000 characters and truncates with "… (truncated — see result.md
+      for the full record)"; Jira caps a comment at 32767. A 39-step run's result exceeds both.
+      The comment carries a bounded head — verdict, what changed, the PR link, the cost line —
+      and a dashboard link for the rest, rather than a truncated wall. The Azure marker stops
+      naming a file that will no longer exist, and so does PrReviewCommentRenderer, which today
+      tells a reviewer to open `.agentsmith/runs/{runId}/result.md`.
+  - key: |
+      ONLY THE PATHS THAT ACTUALLY RENDER A RESULT. PipelineErrorHandler terminalises a ticket
+      from three entry points — HandleStepFailureAsync, HandleFatalFailureAsync and
+      FinalizeFailedTicketAsync — and only the first is preceded by the finalizer tail that
+      renders a result. A fatal exception before any step fails, and an operator cancel, have no
+      result to post. Those two keep today's message and say so explicitly, rather than a
+      criterion claiming a coverage the code cannot give.
+  - key: |
+      THE SPEC SET IS A SEPARATE CUT AND ONE OF ITS ANSWERS IS MISSING. Moving SpecSetKey.Root
+      to a phases directory is not a rename: SpecSetReader is index-first and returns null with
+      no set.yaml, so dropping the index makes every resumed run re-derive and re-execute
+      already-executed phases; SpecSetStaleFiles git-rms every .yaml/.md in the set directory
+      that is not in the current cut, which against a phases/active/ shared with an operator
+      would delete hand-written specs; the security scanner's exclusion prefix IS SpecSetKey.Root,
+      so moving it re-exposes every merged spec to the pattern scan p0390 hid them from; and the
+      phase record is written to EVERY repo while the set lives in exactly one. Each has an
+      answer; the index one does not yet, and a phase that cannot say what carries the executed
+      list is a phase that loses runs. It is named in scope.out and waits for that answer.
+
+steps:
+  - id: nothing-under-runs-is-staged
+    action: "Add the exclusion to the one place that already defines the path class, RunRecordPaths, and apply it at all four writers: unstage runs/ after CommitAndPRHandler's stage-all and force-stage, and skip it in RepoWorkPusher, PersistWorkBranchHandler and InitCommitHandler; retarget the force-stage at phases/, contexts/ and memory/."
+  - id: result-and-audit-leave-the-repo
+    action: "WriteRunResultHandler stops writing result.md and the dependency-audit json into the repo, keeping every artifact-store write; the plan.md read-back is unchanged."
+  - id: the-ticket-carries-the-result
+    action: "Post the bounded, secret-scanned result body as the ticket comment from TicketLifecycle.FinalizeAsync and from PipelineErrorHandler's step-failure path, with a dashboard link for the tail; the two red paths that render no result keep their present message."
+  - id: a-run-with-no-diff-still-opens-its-pr
+    action: "Open the record-carrier PR without requiring a stageable commit, so a run whose only artifact was the run record does not silently end without a pull request."
+  - id: no-pointer-at-a-file-that-is-gone
+    action: "PrReviewCommentRenderer names the dashboard run instead of result.md; the Azure Repos truncation marker does the same; compile-wiki and its handler, reader and builder are removed."
+  - id: the-catalog-calls-it-scratch
+    action: "The coding master's run-record instruction says the run directory is written for the run and never committed. Release and pin bump are operator follow-ups."
+
+tests:
+  - "RunRecordPaths_APathUnderRunsDir_IsExcludedFromStaging"
+  - "CommitAndPR_ARunRecordUnderRunsDir_IsNotInTheStagedDiff"
+  - "CommitAndPR_APhaseRecordAndContextYaml_AreStillForceStaged"
+  - "CommitAndPR_ARunWithNoStageableDiff_StillOpensTheRecordCarrierPr"
+  - "RepoWorkPusher_ACheckpointWithOnlyRunRecordChanges_CommitsNothing"
+  - "PersistWorkBranch_AParkedRunWithOnlyRunRecordChanges_PushesNothing"
+  - "WriteRunResult_ResultMarkdown_ReachesTheStoreAndNotTheRepo"
+  - "WriteRunResult_TheAgentPlanMarkdown_IsStillReadBackIntoThePlanSlot"
+  - "Finalize_AGreenRun_PostsTheResultBodyAsTheComment"
+  - "PipelineError_AStepFailure_PostsTheResultBodyAsTheComment"
+  - "PipelineError_AFatalFailureWithNoRenderedResult_PostsTodaysMessage"
+  - "TicketComment_ABodyOverTheProviderLimit_IsBoundedAndLinksTheDashboard"
+  - "TicketComment_ABodyCarryingASecretPattern_IsRedactedNotPosted"
+  - "PrReviewComment_TheFullReportPointer_NamesTheDashboardRun"
+  - "Harness_AGreenTicketRun_CommitsNoPathUnderRunsDir"
+
+done:
+  - "no commit produced by any of the four writers carries a path under .agentsmith/runs/"
+  - "result.md and the dependency-audit json exist in the artifact store and nowhere in the target repo"
+  - "the phase record, the context.yaml index line and the memory narrative are still committed"
+  - "a green run and a step-failure run each leave the result body as a ticket comment, secret-scanned and within the provider's limit"
+  - "a run whose only artifact was the run record still opens a pull request"
+  - "no artifact, comment or PR body names .agentsmith/runs/<id>/result.md"
+  - "compile-wiki no longer exists as a command"
+  - "build green, dashboard build and tests green, full suite green"

--- a/.agentsmith/phases/planned/2026-09-09-3d2a-decision-file-named-like-spec.yaml
+++ b/.agentsmith/phases/planned/2026-09-09-3d2a-decision-file-named-like-spec.yaml
@@ -1,0 +1,83 @@
+# yaml-language-server: $schema=../../phase-spec.schema.json
+phase: 2026-09-09-3d2a
+goal: "A decision file is named like its phase spec, so listing decisions/ reads as topics instead of 643 bare ids; the archive is renamed and a filename-only test keeps the directory paired with phases/."
+
+applies_to: "repo methodology only — .agentsmith/decisions/ file names, CLAUDE.md's decision section, decision.schema.json's filename wording, docs/how-it-works/built-by-the-method.md, and the plugin's five statements of the rule (bootstrap-project, create-phase, log-decision, update-project, README.md, templates/prompt.md). No product code changes in this phase."
+
+scope:
+  in: "The 641 decision files whose id is the prefix of exactly one phase stem are renamed with git mv to that stem; p0131c is resolved by hand against its two candidates and p-meta-update keeps its name; the `phase:` key inside every file is left exactly as it is and decision.schema.json's 'Must match the filename' wording is corrected to say the filename BEGINS with the id; CLAUDE.md, the docs page and the plugin's six files state one rule, resolving the plugin's existing self-contradiction; a filename-only test asserts every decision file's id prefix names a phase id that exists."
+  out: "The product side — making FileDecisionLogger write the new name. It cannot be built yet: PhaseDraft carries only PhaseId and no stem, the stem is minted at the END of the run by WritePhaseRecordHandler's own Slug(goal) capped at 60 while PhaseIdFactory.Slug caps at 50, and no production caller passes a sourceLabel at all, so DecisionFileLabel's phase branch is dead code today. A successor phase does it AFTER 2026-09-07-e9a2 bounds the product slug — until then 'the phase's stem' is two different sentences. Also out: the schema cut — the enum, the missing categories, and the 25 files that are not parseable YAML at all — which is its own follow-up phase over decision.schema.json and the archive's content."
+
+decisions:
+  - key: |
+      MY FIRST MEASUREMENT WAS WRONG AND THE CORRECT ONE IS BETTER. The draft claimed 635 of 643
+      files map to one phase, 8 to none, 0 ambiguous. That came from a regex carrying `(?:-pre)?`,
+      which reads p0162-pre-monorepo-restructure as the id "p0162-pre", and from `p\d{4,6}[a-z]?`,
+      which cannot express p0169j-a's second-level suffix. Both are artefacts of the reader, not
+      facts about the archive. Measured by prefix at a '-' boundary: 641 map to exactly ONE phase
+      stem, 1 maps to none (p-meta-update), and 1 is genuinely ambiguous — p0131c, which prefixes
+      both p0131c-legacy-triage-removal and p0131c-pre-discussion-triage-migration. That one is
+      resolved by reading the file, never by longest- or first-match, because a heuristic around a
+      missing fact is how the wrong decisions end up under the wrong phase.
+  - key: |
+      THE WIN IS A READABLE LISTING, NOT A GLOB. The draft's done criterion promised
+      `ls decisions/*-account-*`. That is substring matching, not area-first: it returns three
+      phases whose label merely contains the word, and area-first cannot be globbed at all while
+      the id prefix is variable-width. CLAUDE.md makes the same false claim for phases —
+      `ls phases/done/account-*` returns nothing, verified — and this phase corrects it there too.
+      What actually changes is that `ls decisions/` stops being 643 bare ids and starts reading as
+      topics, which is the complaint. A two-step lookup through the phase file already works today
+      and keeps working; this removes the step, it does not create the capability.
+  - key: |
+      THE FILE NAME MOVES, THE KEY DOES NOT. Only the name changes; `phase:` keeps the bare id
+      it carries, because CLAUDE.md already settles this — the id is the identity, the file name a
+      pointer. decision.schema.json says the key "Must match the filename", which would put 641
+      files in violation the moment they are renamed, so the wording is corrected to say the
+      filename BEGINS with the id. Twenty-six files already carry a stem in the key; they are left
+      alone, since both forms then satisfy the corrected rule.
+  - key: |
+      THE TEST READS NAMES, NEVER CONTENT, AND DOES NOT RATCHET. It asserts that a decision file's
+      id prefix names a phase id that exists — not that the two stems are equal. Stem equality
+      would make every future relabel go red in an architecture test project the relabeller never
+      touched, and 4e6a relabelled 224 files at once. Filename-only also keeps the test off the 25
+      files that are not parseable YAML: a value beginning with a bare backtick, which is a
+      reserved indicator, so neither PyYAML nor YamlDotNet will read them. Those are the schema
+      follow-up's first job, and this phase must not be blocked behind them.
+  - key: |
+      THE PRE-p0400 NAMES COME ALONG AS THEY ARE. Of the 641, about 430 belong to phases whose
+      labels are pre-4e6a sentences — p0189-context-yaml-parse-errors-and-stream-in-tree and the
+      like — so decisions/ inherits sentence-shaped names for two thirds of the archive. That is
+      accepted, not overlooked: 4e6a deliberately left the closed counter namespace alone, and
+      inventing new labels for old phases here would mint a second name for a phase that already
+      has one. The listing is still readable; it is just wordier where the phase name is.
+  - key: |
+      THE PLUGIN ALREADY CONTRADICTS ITSELF AND THAT IS FIXED HERE. bootstrap-project and
+      create-phase already document decisions/<phase-id>-<slug>.yaml — this phase's rule — while
+      log-decision, update-project ("The filename IS the phase ID — no slug"), README.md and
+      templates/prompt.md say the bare id. Six statements, two rules. Leaving that is how a
+      bootstrapped project gets whichever shape the last file read happened to say.
+
+steps:
+  - id: the-archive-is-renamed
+    action: "git mv the 641 unambiguous decision files to their phase's stem; resolve p0131c by reading both candidate phase files and moving it to the one its decisions belong to; leave p-meta-update."
+  - id: the-schema-wording-is-corrected
+    action: "decision.schema.json's phase description says the filename begins with the id, not that it equals it; no property or pattern changes."
+  - id: one-rule-in-six-places
+    action: "CLAUDE.md's decision section, docs/how-it-works/built-by-the-method.md and the plugin's log-decision, update-project, README.md and templates/prompt.md state the same naming rule bootstrap-project and create-phase already state; CLAUDE.md's `ls phases/done/account-*` example is corrected to one that works."
+  - id: the-pairing-is-proven-by-name
+    action: "A test walks decisions/, splits each name at the id boundary and asserts the id names a phase that exists in done/, active/ or planned/, listing p-meta-update as the one historical exception; it never opens a file."
+
+tests:
+  - "DecisionPairing_EveryDecisionFile_NamesAPhaseIdThatExists"
+  - "DecisionPairing_TheHistoricalException_IsListedNotFailed"
+  - "DecisionPairing_ARelabelledPhase_DoesNotFailTheTest"
+  - "DecisionPairing_AFileThatIsNotParseableYaml_IsStillPaired"
+  - "DecisionNaming_TheDirectoryListing_CarriesAPhaseLabelForEveryPairedFile"
+
+done:
+  - "listing .agentsmith/decisions/ shows a phase label on every file except p-meta-update"
+  - "no decision file's `phase:` key changed, and decision.schema.json no longer claims the key equals the filename"
+  - "p0131c's decisions sit under the phase they were written for, chosen by reading the file"
+  - "CLAUDE.md, the docs page and all six plugin statements say one naming rule"
+  - "the pairing test passes without opening a decision file, so the 25 unparseable ones do not block it"
+  - "build green, full suite green"

--- a/.agentsmith/phases/planned/2026-09-09-72fd-spec-set-bookkeeping-to-database.yaml
+++ b/.agentsmith/phases/planned/2026-09-09-72fd-spec-set-bookkeeping-to-database.yaml
@@ -1,0 +1,103 @@
+# yaml-language-server: $schema=../../phase-spec.schema.json
+phase: 2026-09-09-72fd
+goal: "The spec set's bookkeeping moves out of set.yaml into the TicketSpecSet row, so the branch carries the reviewable phase files and nothing else, and a resumed run reads its state from the database."
+
+applies_to: "backend (SpecSetIndex/SpecSetIndexDocument, SpecSetWriter, SpecSetReader, SpecSetStaleFiles, ISpecSetPointerStore and both implementations, TicketSpecSet + repository + migrations in two assemblies, SpecRevisionCause)"
+
+requires:
+  - 2026-09-08-c56e
+
+scope:
+  in: "All fourteen fields of the set index — the ordered phase stems, the executed list, revisions, the segment carry map, discarded and unaccounted segments, discarded contexts, the handback case with reason, readings and taken, source and pinned-whole — become state on the existing TicketSpecSet row; set.yaml stops being written; the reader takes the phase files from the branch and everything else from the row, falling back read-only to a legacy set.yaml so a branch in flight at deploy time resumes; the stale sweep takes the previous revision's stem list from the row instead of listing the directory; the force-stage names the files of the current cut instead of the whole directory; SpecRevisionCause keeps detecting a reviewer edit against the phase files only."
+  out: "Relocating the set out of .agentsmith/specs/ and turning the phase record into a move. That successor is BLOCKED on a namespace problem this phase does not touch: PhaseIdFactory.For mints p{digits-of-the-ticket}{a,b,c…}, so tickets 131, PROJ-131 and AB-0131 all mint p0131a/b/c, while phases/done/ accumulates across every ticket a repo ever ran. Executed-ness read from a shared done/ would therefore report phases executed that belong to another ticket — provably: this repo's done/ already holds p0131a through p0131d. The successor must first give a phase a collision-free id, the way CLAUDE.md already mints one for humans (date plus four random hex), and only then can a directory be an execution list. Also out: anything about .agentsmith/runs/, which is c56e, and the decisions naming, which is 3d2a."
+
+decisions:
+  - key: |
+      THE ROW HOLDS BOOKKEEPING; GIT HOLDS WHAT A REVIEWER EDITS. TicketSpecSet says it is
+      "deliberately NOT a copy… duplicating it here would create a second source of truth that
+      drifts the moment a reviewer edits the branch". That objection is about the phase yaml and
+      its companion, which a reviewer does edit. None of the index's other fields is that:
+      revisions, the carry map, discarded and unaccounted segments, discarded contexts, the
+      handback state, source, pinned-whole. Nobody hand-edits them, and the row ALREADY holds four
+      of exactly that kind — RevisionSha, RevisionNumber, LastHandbackCase, RepeatedHandbackCount.
+      The split is "does a human edit it".
+  - key: |
+      THE ORDERED STEM LIST AND THE EXECUTED LIST GO TO THE ROW TOO, AND STAY EXPLICIT. An earlier
+      draft of this work replaced the executed list with "a file in phases/done/". That is false in
+      this product: PhaseIdFactory mints ids positionally from the ticket's digits, so a shared
+      done/ answers for every ticket at once, and PhaseSequenceHandler would report "nothing left
+      to run" on a green run that did nothing. Order is equally load-bearing — the tail is spliced
+      in Phases order, ExecutedHead is a TakeWhile over it, and the derivation master's contract is
+      that phase N may assume 1..N-1 ran. A directory listing gives neither, so both stay explicit
+      list state on the row.
+  - key: |
+      THE SWEEP AND THE STAGE BOTH STOP TRUSTING THE DIRECTORY. SpecSetStaleFiles lists the set
+      directory and git-rms every .yaml/.md not in the current cut; SpecSetWriter force-stages
+      key.Directory wholesale. Both are safe only because specs/<provider>-<ticket>/ is a directory
+      nothing else writes — a property this phase keeps but must not depend on silently. The sweep
+      takes the previous revision's stem list from the row, and the stage names the files of the
+      current cut, so neither can reach a file the set did not write. That is also the precondition
+      the blocked successor needs before any shared directory is thinkable.
+  - key: |
+      A DEV RUN WITHOUT A DATABASE LOSES THE SET ON RESTART, AND SAYS SO. ISpecSetPointerStore
+      defaults to an in-memory dictionary and only relational persistence swaps in the DB one. Its
+      own justification — "the pointer is machine state only; losing it degrades a re-entry to
+      'foreign edit', which is the SAFE reading" — dies once the row carries revisions, accounting
+      and handback. The in-memory store keeps the same fields and the same dev semantics: a CLI or
+      harness run that restarts mid-ticket loses the set and re-derives. The CLI is a dev tool, so
+      that is stated rather than engineered around; a server run has the row.
+  - key: |
+      TWO MIGRATION ASSEMBLIES, FOUR PROVIDERS, AND SIX COLLECTIONS. The fields are not all scalars:
+      revisions, carried, discarded, unaccounted, discarded contexts and handback readings are
+      collections. They are stored as JSON columns on the one row rather than as six child tables,
+      because nothing queries into them — they are read whole, with the set, exactly as set.yaml was
+      — and six tables would buy joins nobody needs. Migrations land in both
+      AgentSmith.Infrastructure.Persistence and .SqlServer.
+  - key: |
+      THE LEGACY BRANCH IS READ, NEVER WRITTEN. A branch whose set.yaml predates this phase is read
+      through the existing index-first path, once, to seed the row; from then on the row is the
+      carrier and set.yaml is not rewritten. Without that a run in flight at deploy time would find
+      no set, re-derive, and re-execute finished phases.
+  - key: |
+      THE REVIEWER-EDIT DETECTOR NARROWS TO THE PHASE FILES. SpecRevisionCause asks for the last
+      commit touching the set directory to decide whether a human changed the spec. With set.yaml
+      gone the only files there are the phase yamls and companions, which is what the question was
+      always about — but the query must name those files rather than the directory, or the run's own
+      writes keep answering it.
+
+steps:
+  - id: the-row-carries-the-set
+    action: "Move the index document's fourteen fields onto TicketSpecSet as scalars plus JSON columns for the six collections, with a migration in both persistence assemblies; extend ISpecSetPointerStore and both implementations to read and write them."
+  - id: the-branch-stops-carrying-it
+    action: "SpecSetWriter stops writing set.yaml and writes the row instead; the reader composes the set from the phase files on the branch plus the row, and seeds the row once from a legacy set.yaml when the row is empty."
+  - id: the-sweep-and-the-stage-name-their-files
+    action: "SpecSetStaleFiles removes the previous revision's stems that the current cut dropped, taken from the row; SpecSetWriter force-stages the cut's files by name instead of the directory."
+  - id: the-edit-detector-asks-about-phase-files
+    action: "SpecRevisionCause queries the last commit touching the cut's phase files rather than the set directory, so the run's own writes do not read as a reviewer edit."
+
+tests:
+  - "SpecSetIndex_AllFourteenFields_RoundTripThroughTheRow"
+  - "SpecSetWriter_ARevision_WritesNoSetYaml"
+  - "SpecSetReader_AsetWrittenByThisPhase_IsComposedFromThePhaseFilesAndTheRow"
+  - "SpecSetReader_ABranchWithALegacySetYaml_SeedsTheRowOnceAndIsRead"
+  - "SpecSetReader_AlegacySetYaml_IsNeverRewritten"
+  - "SpecSet_PhaseOrder_SurvivesTheRoundTripAndDrivesTheTail"
+  - "SpecSet_ExecutedList_SurvivesARestartWithRelationalPersistence"
+  - "StaleSweep_APhaseDroppedByARecut_IsRemoved"
+  - "StaleSweep_AFileThePreviousRevisionNeverWrote_IsNotRemoved"
+  - "SpecSetWriter_TheForceStage_NamesTheCutsFilesNotTheDirectory"
+  - "SpecRevisionCause_TheRunsOwnPhaseFileWrite_IsNotAReviewerEdit"
+  - "SpecRevisionCause_AHumanEditOfAPhaseFile_IsAReviewerEdit"
+  - "Harness_AThreePhaseTicketRun_ExecutesAllThreeInOrder"
+  - "Harness_ARunStoppedAfterOnePhase_ResumesAndExecutesTheRemainingTwo"
+  - "Harness_ARunStoppedAfterOnePhase_DoesNotReExecuteTheFinishedPhase"
+
+done:
+  - "no run writes set.yaml, and a target repo's spec directory holds only phase yamls, companions and accounting.md"
+  - "a three-phase ticket run executes all three in the derived order"
+  - "a run stopped after one phase resumes and executes exactly the remaining two, never the finished one"
+  - "the set's revisions, accounting, handback state and phase order survive a server restart"
+  - "a branch whose set.yaml predates this phase resumes without re-executing a finished phase, and its set.yaml is not rewritten"
+  - "no file the set did not write is staged or removed by a spec commit"
+  - "a resumed multi-phase run is not reported as a reviewer edit"
+  - "build green, dashboard build and tests green, full suite green"


### PR DESCRIPTION
Specs only — no code changes. Three phases that cut what a run leaves in a target repo.

Today a ticket run commits, per repo of the scope: `.agentsmith/runs/<runId>/{plan,decisions,result}.md` plus dependency-audit json, `.agentsmith/specs/<provider>-<ticket>/{<phase>.yaml, <phase>.md, set.yaml, accounting.md}`, and `.agentsmith/phases/done/<phase>.yaml`. `result.md` restates numbers the database already holds, and on a green run nobody opens any of it.

## `2026-09-08-c56e` — the run directory is scratch

Nothing under `.agentsmith/runs/` is staged by **any** of the four writers (CommitAndPRHandler's stage-all *and* force-stage, RepoWorkPusher's checkpoints, PersistWorkBranchHandler, InitCommitHandler). `result.md` and the audit json stop being written to the repo; `IRunArtifactStore` + `DbRunArtifactStore` already hold the durable copy the dashboard reads. The result body becomes the ticket comment on the green and the step-failure path — secret-scanned, because today that body leaves the sandbox through the staged-diff scan that *aborts the commit*, and bounded to the provider's limit.

Rendered into the **HTML comment subset**, not Markdown: `FailureTicketComment` authors comments in `<b>`/`<br/>`/`<code>` and `JiraAdfRenderer` converts only that subset to ADF. Azure DevOps renders a pasted `##` literally too.

Also: `compile-wiki` is retired rather than left a silent no-op (it is the one thing that reads the committed run directories), the record-carrier PR is kept alive, and `PrReviewCommentRenderer` plus the Azure truncation marker stop naming a file that will not exist.

## `2026-09-09-72fd` — the set's bookkeeping to the database

All fourteen fields of `set.yaml` move onto the existing `TicketSpecSet` row; the branch keeps the reviewable phase files. `TicketSpecSet`'s "deliberately NOT a copy" rule is about content a reviewer edits — revisions, the carry map, discarded segments, handback state are not that, and the row already holds four of exactly that kind.

An earlier draft also relocated the set into `phases/active/` and derived executed-ness from `phases/done/`. **An adversarial review refused it, and the refusal held up:** `PhaseIdFactory.For` mints `p{ticket-digits}{a,b,c…}`, so tickets `131`, `PROJ-131` and `AB-0131` all mint `p0131a/b/c`, while `done/` accumulates across every ticket a repo ever ran. This repo's `done/` already holds `p0131a` through `p0131d` — such a run would read its own phases as executed, `UnexecutedTail` would be empty, and `PhaseSequenceHandler` would answer "nothing left to run" on a green run that changed nothing.

The relocation is named in `scope.out`, blocked on a prior cut: give a phase a collision-free id, the way CLAUDE.md already mints one for humans (date plus four random hex) instead of from the ticket's digits.

The ordered phase list and the executed list therefore stay explicit state on the row rather than being read off a directory — order is load-bearing, since the derivation contract is that phase N may assume 1..N-1 ran.

## `2026-09-09-3d2a` — a decision file named like its spec

`ls .agentsmith/decisions/` is 643 bare ids. The phase label carries an area-first axis since `2026-09-07-4e6a`; it never reaches `decisions/` because the file is named by the id alone. The archive is renamed so the listing reads as topics.

Repo methodology only. The product side is deferred to a successor after `2026-09-07-e9a2`: no production caller passes a `sourceLabel`, so `DecisionFileLabel`'s phase branch is dead code, and `PhaseDraft` carries no stem at logging time — the stem is minted at the *end* of a run by a different slugger (60 chars) than the one naming the set (50).

Measured by prefix at a `-` boundary: **641 unambiguous, 1 orphan (`p-meta-update`), 1 genuinely ambiguous (`p0131c`)** to be resolved by reading the file rather than by a longest-match heuristic. A first measurement that reported 635/8/0 was wrong — its regex carried `(?:-pre)?` and read `p0162-pre-monorepo-restructure` as id `p0162-pre`.

The test reads filenames only and never opens a file: 25 decision files are not parseable YAML (values beginning with a bare backtick, a reserved indicator). Those, and the schema drift — 27 category values against a six-value enum, 111 files off-enum, no test validating any of it — are a named follow-up.

## Gate

`.claude/phase-gate.log`: `passed 2026-09-08-c56e` and `passed 2026-09-09-72fd`, both `dashboard,build,tests,dry-runs,harness-presets`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)