### PR TITLE
fix: a phase commit is gated or says it was not (2026-09-09-8fce)

### DIFF
--- a/.agentsmith/phases/planned/2026-09-09-8fce-gate-no-silent-pass-through.yaml
+++ b/.agentsmith/phases/planned/2026-09-09-8fce-gate-no-silent-pass-through.yaml
@@ -1,0 +1,70 @@
+# yaml-language-server: $schema=../../phase-spec.schema.json
+phase: 2026-09-09-8fce
+goal: "A commit that names a phase is gated or says it was not: the marker reads several ids in one parenthesis, and a phase id in the subject with no marker is recorded and reported, not passed in silence."
+
+applies_to: "repo tooling (.claude/hooks/phase-gate.sh, its marker definition and its pass-through branches) plus a test file driving the gate over both"
+
+scope:
+  in: "The marker accepts a parenthesis carrying one id or several separated by commas or spaces, in either namespace; the ledger line names the first id of the marker, or the first id in the subject when no marker matched; a resolved message whose SUBJECT carries a phase id in the counter or date namespace but no marker the gate can read is recorded as not-gated and reported on stderr, instead of exiting zero in silence; tests drive the gate over the widened marker, over the subject-without-marker case, and over the messages that must stay silent."
+  out: "Blocking such a commit. The gate's contract is that a skip is never indistinguishable from a pass, not that every mention of a phase must be gated — a commit legitimately referencing an earlier phase ('revert the change from p0272') would otherwise be refused. Widening the counter-namespace shape used for the marker itself, which stays as it is. The three pass-throughs that already speak: a bare commit, an editor amend and a message built by a shell substitution. The `cd wt; git commit` resolver gap, which is fixed in the operator's own uncommitted work on commit-message.py and is not this phase's to commit."
+
+decisions:
+  - key: |
+      THE GAP WAS FOUND BY FALLING INTO IT. The commit carrying 72fd and 3d2a was written
+      "docs: … (2026-09-09-72fd, 2026-09-09-3d2a)". The marker is \((id)\), which requires the
+      closing parenthesis to follow the id, so two ids and a comma in one parenthesis matched
+      nothing. The gate concluded it was not a phase commit, ran no check, wrote no ledger line and
+      exited zero — a commit naming two phases went through unverified and looked exactly like a
+      clean pass. This is the fourth member of a family the script already documents: --amend
+      --no-edit, -F <file>, a shell-built message, and now a message the marker cannot parse.
+  - key: |
+      A LIST IS A MARKER; A MENTION IS NOT. Widening the marker to accept several ids in one
+      parenthesis costs nothing and matches how a commit that spans two phases is naturally
+      written. Widening it to any occurrence of an id would gate 'revert the change from p0272',
+      which is not a phase commit — so the mention case is not gated, it is REPORTED. Loud and
+      recorded, never silent, never blocked.
+  - key: |
+      THE WARNING USES A STRICTER ID SHAPE THAN THE MARKER, ON PURPOSE. The marker's counter shape
+      is p[0-9]+[a-z]? because forms like (p73a) exist and must keep gating. A warning built on
+      that shape would fire on 'p12' in ordinary prose, and a warning that cries wolf is a warning
+      people learn to scroll past. The detector therefore uses the shape CLAUDE.md actually
+      describes — four to six digits — so it speaks when a real phase id is in the subject and
+      stays quiet otherwise. Two definitions, each doing the job it is right for, with the
+      asymmetry written down where they are defined.
+  - key: |
+      THE SUBJECT, NOT THE WHOLE MESSAGE. A body routinely names other phases — a prerequisite, a
+      phase this one supersedes, the phase whose bug is being fixed. The marker's home is the
+      subject line, so that is where its absence is worth reporting. Scanning the body would make
+      the warning fire on most well-written phase commits.
+  - key: |
+      THE LEDGER LINE STILL NAMES A PHASE. record() reads the id out of the marker; with no marker
+      there was nothing to read and the line would say "unknown", which is the least useful thing
+      a ledger can say about the one case worth investigating. It falls back to the first id in the
+      subject, so the line names the phase whose commit was not gated.
+
+steps:
+  - id: the-marker-reads-a-list
+    action: "Split the id shape out of the marker and let the marker carry one id or several separated by commas or whitespace; record() takes the first id of the matched marker."
+  - id: a-named-phase-without-a-marker-speaks
+    action: "When the message resolves and no marker matches, and the subject carries a phase id in the strict counter or date shape, record not-gated with that id and report on stderr; every other unmarked message keeps exiting silently."
+  - id: both-are-tested
+    action: "A test file drives phase-gate.sh over a two-id marker, a space-separated marker, a subject naming a phase without a marker, and the messages that must stay silent, asserting the ledger line and stderr in each."
+
+tests:
+  - "Gate_MarkerCarryingTwoIdsSeparatedByAComma_IsGated"
+  - "Gate_MarkerCarryingTwoIdsSeparatedByASpace_IsGated"
+  - "Gate_MarkerCarryingTwoIds_RecordsTheFirstInTheLedger"
+  - "Gate_SubjectNamingAPhaseWithoutAMarker_IsRecordedAsNotGated"
+  - "Gate_SubjectNamingAPhaseWithoutAMarker_SaysSoOnStderr"
+  - "Gate_SubjectNamingAPhaseWithoutAMarker_NamesThePhaseInTheLedger"
+  - "Gate_BodyNamingAPhaseWithAMarkerlessSubject_StaysSilent"
+  - "Gate_AShortPLikeTokenInTheSubject_StaysSilent"
+  - "Gate_AMessageWithNoPhaseAnywhere_StaysSilent"
+  - "Gate_AMalformedDateMintedMarker_StaysSilent"
+
+done:
+  - "a commit whose message names two phases in one parenthesis is gated and leaves a passed or blocked ledger line"
+  - "a commit whose subject names a phase without a readable marker leaves a not-gated line naming that phase, and says so on stderr"
+  - "a commit with no phase in its subject still exits silently, including a malformed marker and a short p-like token"
+  - "the existing gate tests in test_commit_message.py still pass unchanged"
+  - "build green, full suite green"

--- a/.claude/hooks/phase-gate.sh
+++ b/.claude/hooks/phase-gate.sh
@@ -62,14 +62,27 @@ ledger="${PHASE_GATE_LOG:-$hooks_dir/../phase-gate.log}"
 # ledger and the gating decision below read this ONE definition — a marker recognised
 # by one and not the other would gate a commit it never records, or record one it
 # never gated.
-phase_marker='\((p[0-9]+[a-z]?|[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9a-f]{4})\)'
+phase_id='(p[0-9]+[a-z]?|[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9a-f]{4})'
+phase_marker="\\(${phase_id}([,[:space:]]+${phase_id})*\\)"
+
+# 2026-09-09-8fce: the marker takes a LIST, because a commit spanning two phases names both
+# and "(id, id)" matched nothing — the gate read it as an ordinary commit, ran no check and
+# wrote no line. A stricter id shape than the marker's serves the warning below: the marker
+# keeps p[0-9]+ so forms like (p73a) still gate, while a warning built on that shape would
+# fire on "p12" in prose, and a warning that cries wolf is one people scroll past.
+strict_phase_id='(p[0-9]{4,6}[a-z]?|[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9a-f]{4})'
 
 # One line per recognised phase commit: when, what the gate decided, the phase id,
 # the tree it gated and the commit the new one will sit on. That last field is what
 # ties a ledger line to a commit afterwards — it is the commit's parent.
 record() {
   local verdict=$1 tree=$2 detail=$3 phase parent
-  phase=$(printf '%s' "${message:-}" | grep -Eo "$phase_marker" | head -1 | tr -d '()')
+  phase=$(printf '%s' "${message:-}" | grep -Eo "$phase_marker" | head -1 \
+    | grep -Eo "$phase_id" | head -1)
+  # No marker: the one line worth investigating should still name its phase rather than
+  # say "unknown", so fall back to the first id in the subject.
+  [ -n "$phase" ] || phase=$(printf '%s' "${message:-}" | head -1 \
+    | grep -Eo "$strict_phase_id" | head -1)
   parent=$(git -C "$tree" rev-parse --short HEAD 2>/dev/null || echo none)
   printf '%s\t%s\t%s\t%s\t%s\t%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$verdict" \
     "${phase:-unknown}" "$tree" "$parent" "$detail" >>"$ledger" 2>/dev/null || true
@@ -95,9 +108,20 @@ if message=$(printf '%s' "$cmd" | python3 "$resolver" "${hook_cwd:-${CLAUDE_PROJ
     # command line, supplies the text. Finding no marker in `$(cat message.txt)`
     # proves nothing about the message the commit will carry, so say so instead of
     # passing in silence — silence here is what a clean pass looks like.
-    printf '%s' "$message" | grep -Eq '[$]\(|`' || exit 0
-    record not-gated "${hook_cwd:-.}" "message built by a shell substitution"
-    echo "[phase-gate] the commit message is built by the shell ($(printf '%s' "$message" | head -c 60)) — its text never reached the gate, so it was not gated; run the phase checks by hand if this is a phase commit" >&2
+    if printf '%s' "$message" | grep -Eq '[$]\(|`'; then
+      record not-gated "${hook_cwd:-.}" "message built by a shell substitution"
+      echo "[phase-gate] the commit message is built by the shell ($(printf '%s' "$message" | head -c 60)) — its text never reached the gate, so it was not gated; run the phase checks by hand if this is a phase commit" >&2
+      exit 0
+    fi
+    # 2026-09-09-8fce: a SUBJECT that names a phase but carries no marker the gate can read.
+    # That is a phase commit by intent and an ordinary commit by the gate's reading, and the
+    # silence between the two is what let a two-phase commit through unverified. The body is
+    # not scanned: a good phase commit names its prerequisites there.
+    if printf '%s' "$message" | head -1 | grep -Eq "(^|[^0-9A-Za-z-])${strict_phase_id}([^0-9A-Za-z-]|$)"; then
+      record not-gated "${hook_cwd:-.}" "phase named in the subject without a marker"
+      echo "[phase-gate] the subject names a phase but carries no marker the gate reads — write it as '(<id>)' or '(<id>, <id>)'; NOT gated, run the phase checks by hand" >&2
+      exit 0
+    fi
     exit 0
   fi
 else

--- a/.claude/hooks/test_phase_gate_marker.py
+++ b/.claude/hooks/test_phase_gate_marker.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Exercises what phase-gate.sh RECOGNISES as a phase commit (2026-09-09-8fce).
+
+Run it directly:  python3 .claude/hooks/test_phase_gate_marker.py
+
+The helpers come from test_commit_message.py, which owns the throwaway-repository
+and ledger fixtures. These cases live in their own file only so the marker work
+does not collide with uncommitted changes in that one; fold them in when it is
+free.
+
+A repository with no AgentSmith.sln and no skills validator makes the gate report
+"nothing to gate" — that line is the tell that it recognised the commit as a phase
+commit at all, without running a single .NET check.
+"""
+
+import importlib.util
+import pathlib
+import tempfile
+import traceback
+
+HOOKS_DIR = pathlib.Path(__file__).resolve().parent
+_spec = importlib.util.spec_from_file_location(
+    "gate_fixtures", HOOKS_DIR / "test_commit_message.py")
+_fixtures = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_fixtures)
+
+GATE_ENTERED = _fixtures.GATE_ENTERED
+_repository = _fixtures._repository
+_run_gate = _fixtures._run_gate
+_ledger = _fixtures._ledger
+
+TWO_IDS = "docs: two phases in one commit (2026-09-09-72fd, 2026-09-09-3d2a)"
+NO_MARKER = "docs: the set moves into phases for 2026-09-09-e1c8"
+
+
+def Gate_MarkerCarryingTwoIdsSeparatedByAComma_IsGated():
+    with _repository("seed") as repo:
+        completed = _run_gate(f'git commit -m "{TWO_IDS}"', repo)
+        assert completed.returncode == 0, completed
+        assert GATE_ENTERED in completed.stderr, completed.stderr
+
+
+def Gate_MarkerCarryingTwoIdsSeparatedByASpace_IsGated():
+    with _repository("seed") as repo:
+        completed = _run_gate('git commit -m "docs: both (p0508 2026-08-24-8a3f)"', repo)
+        assert completed.returncode == 0, completed
+        assert GATE_ENTERED in completed.stderr, completed.stderr
+
+
+def Gate_MarkerCarryingTwoIds_RecordsTheFirstInTheLedger():
+    with _repository("seed") as repo, tempfile.TemporaryDirectory() as elsewhere:
+        ledger = pathlib.Path(elsewhere) / "phase-gate.log"
+        _run_gate(f'git commit -m "{TWO_IDS}"', repo, ledger)
+        lines = _ledger(ledger)
+        assert [line[2] for line in lines] == ["2026-09-09-72fd"], lines
+
+
+def Gate_SubjectNamingAPhaseWithoutAMarker_IsRecordedAsNotGated():
+    with _repository("seed") as repo, tempfile.TemporaryDirectory() as elsewhere:
+        ledger = pathlib.Path(elsewhere) / "phase-gate.log"
+        _run_gate(f'git commit -m "{NO_MARKER}"', repo, ledger)
+        assert [line[1] for line in _ledger(ledger)] == ["not-gated"], _ledger(ledger)
+
+
+def Gate_SubjectNamingAPhaseWithoutAMarker_SaysSoOnStderr():
+    with _repository("seed") as repo:
+        completed = _run_gate(f'git commit -m "{NO_MARKER}"', repo)
+        assert completed.returncode == 0, completed
+        assert "no marker the gate reads" in completed.stderr, completed.stderr
+
+
+def Gate_SubjectNamingAPhaseWithoutAMarker_NamesThePhaseInTheLedger():
+    with _repository("seed") as repo, tempfile.TemporaryDirectory() as elsewhere:
+        ledger = pathlib.Path(elsewhere) / "phase-gate.log"
+        _run_gate(f'git commit -m "{NO_MARKER}"', repo, ledger)
+        assert [line[2] for line in _ledger(ledger)] == ["2026-09-09-e1c8"], _ledger(ledger)
+
+
+def Gate_BodyNamingAPhaseWithAMarkerlessSubject_StaysSilent():
+    with _repository("seed") as repo:
+        completed = _run_gate(
+            'git commit -m "chore: tidy the hooks" -m "follows p0508"', repo)
+        assert completed.returncode == 0, completed
+        assert completed.stderr == "", completed.stderr
+
+
+def Gate_AShortPLikeTokenInTheSubject_StaysSilent():
+    with _repository("seed") as repo:
+        completed = _run_gate('git commit -m "chore: bump p12 to the new default"', repo)
+        assert completed.returncode == 0, completed
+        assert completed.stderr == "", completed.stderr
+
+
+def Gate_AMessageWithNoPhaseAnywhere_StaysSilent():
+    with _repository("seed") as repo:
+        completed = _run_gate('git commit -m "chore: no phase here"', repo)
+        assert completed.returncode == 0, completed
+        assert completed.stderr == "", completed.stderr
+
+
+def Gate_AMalformedDateMintedMarker_StaysSilent():
+    with _repository("seed") as repo:
+        completed = _run_gate('git commit -m "chore: nightly (2026-13-99-zzzz)"', repo)
+        assert completed.returncode == 0, completed
+        assert completed.stderr == "", completed.stderr
+
+
+def main():
+    cases = [(name, case) for name, case in list(globals().items())
+             if callable(case) and name.startswith("Gate_")]
+    failed = []
+    for name, case in cases:
+        try:
+            case()
+            print(f"PASS {name}")
+        except Exception:
+            failed.append(name)
+            print(f"FAIL {name}")
+            traceback.print_exc()
+    print(f"\n{len(cases) - len(failed)}/{len(cases)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## The gap, found by falling into it

The gate's phase marker was `\((id)\)` — one id, closing parenthesis immediately after. A commit written

```
docs: the set's bookkeeping and the decision file names (2026-09-09-72fd, 2026-09-09-3d2a)
```

matched nothing. The gate concluded it was not a phase commit, ran no check, wrote no ledger line and exited zero. A commit naming two phases went through **unverified**, and the result was indistinguishable from a clean pass — that commit is in PR #611's history, and the only reason it was caught is that the ledger had no line for it.

This is the fourth member of a family `phase-gate.sh` already documents: `--amend --no-edit`, `-F <file>`, a shell-built message, and now a message whose marker the gate cannot parse.

## Two changes

**The marker takes a list.** One id or several, separated by commas or whitespace, in either namespace. `record()` names the first.

**A named phase without a marker speaks.** When the message resolves, no marker matches, and the *subject* carries a phase id, the gate records `not-gated` naming that phase and reports on stderr, instead of exiting in silence.

## Deliberately not blocking

The gate's contract is that a skip never looks like a pass — not that every mention of a phase must be gated. `revert: the change from p0272` is not a phase commit and must not be refused.

Two supporting choices, both written into the script where they are defined:

- **The warning uses a stricter id shape than the marker.** The marker keeps `p[0-9]+[a-z]?` so forms like `(p73a)` still gate; the warning uses the four-to-six-digit shape CLAUDE.md actually describes, so it does not fire on `p12` in ordinary prose. A warning that cries wolf is one people scroll past.
- **The subject only.** A good phase commit names its prerequisites in the body; scanning it would make the warning fire on most of them.

## Tests

| message | before | after |
|---|---|---|
| `(id, id)` | silent pass, no ledger line | gated, ledger names the first id |
| `(id id)` | silent pass | gated |
| subject names `2026-09-09-e1c8`, no marker | silent pass | `not-gated`, ledger names the phase, loud on stderr |
| body names `p0508`, subject does not | silent | silent |
| `bump p12 to the new default` | silent | silent |
| `(2026-13-99-zzzz)` | silent | silent |

10 new cases pass; the 26 existing cases in `test_commit_message.py` still pass.

The new cases live in their own file (`test_phase_gate_marker.py`) only so this commit does not sweep up uncommitted work in `test_commit_message.py` — which fixes a *fifth* gap in the same family, `cd wt; git commit`, where shlex glues the `;` to the path and hides the commit segment. Fold the cases into the one file when that work lands.

## Gate

`.claude/phase-gate.log`: `blocked … dotnet test`, then `passed 2026-09-09-8fce … dashboard,build,tests,dry-runs,harness-presets`. The block was real but not from this change — a spec file being written by a concurrent session in the same working tree was read mid-write. It parses; the retry is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)